### PR TITLE
feat: add reviewed Skill taxonomy Gold Set

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python

--- a/.github/workflows/validate-repository.yml
+++ b/.github/workflows/validate-repository.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@ flowchart LR
 
 - Team and kit membership: [`config/team-manifest.json`](./config/team-manifest.json)
 - Skill category and candidate risk signals: [`config/skill-taxonomy.json`](./config/skill-taxonomy.json)
+- Reviewed classification labels and fixed sample membership: [`config/skill-taxonomy-gold.json`](./config/skill-taxonomy-gold.json)
 - Canonical physical skill inventory: tracked `skills/*/SKILL.md` files interpreted by [`scripts/repository_model.py`](./scripts/repository_model.py)
 - Removed machine-local link tombstones: [`config/external-skill-sources.json`](./config/external-skill-sources.json); nullable source fields are not provenance
 - Generated catalog: [`catalog/`](./catalog/) is an output, never a source
@@ -65,7 +66,7 @@ README counts, badges, plugin manifests, and generated JSON must not override th
 | Canonical skill library | tracked physical `skills/<id>/SKILL.md` | `skills/` | Foundational; consumed by every pack and catalog |
 | Team composition | `config/team-manifest.json` | `agents/`, `starter-kits/` | Composed; one roster drives installer and validation |
 | Safe installation | `./install.sh … <kit-or-agent>` | `install.sh`, installer fixtures | Composed; one safety boundary protects every deployment |
-| Catalog discovery | taxonomy in; Markdown/JSON index out | taxonomy, builder, `catalog/` | Composed; one rule set serves human and machine discovery |
+| Catalog discovery | taxonomy + fixed reviewed labels in; Markdown/JSON index + agreement report out | taxonomy, Gold Set, builders, `catalog/` | Composed; one rule set serves human and machine discovery with a separate semantic regression contract |
 | Distribution Adapters | harness manifests and curated packages | `.codex/`, plugin manifests, `plugins/` | Boundary; isolates harness conventions from canonical content |
 | Verification evidence | `npm test`, `npm run validate:strict` | `scripts/`, `tests/`, CI | Foundational; prevents drift across public surfaces |
 | Public navigation | README routes and maintained Pages | README files, `docs/`, `cookbook/`, `assets/` | Boundary; keeps copied claims out of source authority |
@@ -78,6 +79,7 @@ The registry also records each primary path role: `authored-authority`, `authore
 - `team-manifest portability class → install.sh selection → workspace Skills + generated TOOLS.md` is the generic-install Seam; only `required` and `optional` cross it.
 - `team-manifest assignments → catalog builder → skill-index assignments + portability_class` is the human/machine classification Seam.
 - `skill-taxonomy → catalog builder → catalog/` is a generated discovery Seam.
+- `fixed Gold labels + generated skill index → taxonomy evaluator → reviewed-set agreement report` is a semantic-regression Seam. It measures label agreement, not runtime quality.
 - Root full-library harness manifests are legacy or manifest-only Adapters.
 - `plugins/agi-super-team-codex/` is an independently curated Codex Adapter; it remains manifest-only until a matching client receipt exists.
 - `CHARTER.md` and `COLLABORATION.md` are required shared generic-workspace inputs. Installed role packs use relative links to them.
@@ -104,6 +106,7 @@ Legacy root documents may remain as stable routing paths. They must not duplicat
 |---|---|---|
 | `config/team-manifest.json` | Installer, catalog usage, and validator must fail before writes | High-Depth authority Interface |
 | `config/skill-taxonomy.json` | Catalog build/check must fail | Authored classification authority |
+| `config/skill-taxonomy-gold.json` | Semantic evaluation must fail closed | Reviewed, fixed-membership evaluation authority |
 | `catalog/` | `npm run build:skills` recreates discovery outputs; `npm run build:skill-quality` recreates the quality report | Generated outputs, never authority |
 | One distribution Adapter | Only that harness surface is lost | Adapter boundary is local |
 | `CHARTER.md` or `COLLABORATION.md` | Installer preflight must fail with zero writes | Required shared installation Seam |
@@ -114,7 +117,7 @@ Legacy root documents may remain as stable routing paths. They must not duplicat
 | When changing | Update | Verify |
 |---|---|---|
 | Agent or kit membership | `config/team-manifest.json`, referenced Agent files | `npm run validate -- --warnings-as-errors` |
-| Skill metadata or taxonomy | Skill `SKILL.md`, taxonomy if needed | `npm run check:skills` and `npm run check:skill-quality` |
+| Skill metadata or taxonomy | Skill `SKILL.md`, taxonomy, and reviewed label only when its source changed | `npm run check:skills`, `npm run check:skill-quality`, and `npm run check:taxonomy-evaluation` |
 | Generic installer behavior | `install.sh` and installer fixtures | `npm run test:installer` |
 | Curated Codex package | `plugins/agi-super-team-codex/` and its index | Repository tests plus client receipt when available |
 | Site data or SEO | `docs/`, data builder, site contracts | `npm run test:repository` |
@@ -122,7 +125,7 @@ Legacy root documents may remain as stable routing paths. They must not duplicat
 
 ## Contract score boundary
 
-`npm run check:architecture` measures automated architecture-classification contracts: path ownership, authority separation, generated lineage, Adapter status, navigation, decision memory, and taxonomy debt ceilings. It does **not** measure semantic category accuracy, clean harness installs, fixture outcomes, or external beta evidence. Those remain separate scorecards.
+`npm run check:architecture` measures automated architecture-classification contracts: path ownership, authority separation, generated lineage, Adapter status, navigation, decision memory, and taxonomy debt ceilings. `npm run check:taxonomy-evaluation` separately measures agreement with the fixed reviewed Gold Set. Neither score proves Skill quality, safety, clean harness installs, fixture outcomes, or external beta evidence.
 
 ## Current deepening candidates
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ You can already browse a deterministic skill catalog, inspect every Agent instru
 | Repository inventory, counts, and references | `npm run validate -- --warnings-as-errors` | **Verified in this checkout** |
 | Generic installer preview, preflight, no-clobber, and staging | `npm test` | **Verified in this checkout** |
 | Generated catalog covers the canonical inventory | `npm run check:skills` | **Verified in this checkout** |
+| Primary-outcome classification agrees with the fixed reviewed set | [Gold Set method](./docs/skill-taxonomy-gold-set.md) + [generated report](./catalog/skill-taxonomy-evaluation.json) | **Reviewed-set gate passed in this checkout** |
 | Current-client harness installation and loading | Revision-matched harness receipt | **Validation pending** |
 | Task quality or business outcome | Public fixture, baseline, rubric, and artifacts | **Validation pending** |
 
@@ -146,6 +147,7 @@ python -m pip install --requirement requirements-dev.txt
 npm test
 npm run validate -- --warnings-as-errors
 npm run check:skills
+npm run check:taxonomy-evaluation
 npm run check:architecture
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -122,6 +122,7 @@ Star 只用于发现，不等于可信。矩阵记录 `DAILY`、`LIBRARY` 和 `Q
 | 仓库库存、数量和引用 | `npm run validate -- --warnings-as-errors` | **当前 checkout 已验证** |
 | 通用安装器的预览、预检、no-clobber 和暂存 | `npm test` | **当前 checkout 已验证** |
 | 自动生成目录覆盖权威库存 | `npm run check:skills` | **当前 checkout 已验证** |
+| 主成果分类与固定独立复核集一致 | [Gold Set 方法](./docs/skill-taxonomy-gold-set.md) + [生成报告](./catalog/skill-taxonomy-evaluation.json) | **当前 checkout 的复核集门禁已通过** |
 | 当前客户端中的工具安装与加载 | 与版本匹配的 harness receipt | **Validation pending** |
 | 任务质量或商业成果 | 公开 fixture、基线、评估规则和产物 | **Validation pending** |
 
@@ -146,6 +147,7 @@ python -m pip install --requirement requirements-dev.txt
 npm test
 npm run validate -- --warnings-as-errors
 npm run check:skills
+npm run check:taxonomy-evaluation
 npm run check:architecture
 ```
 

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -4,6 +4,8 @@
 
 Find a skill by the outcome you need. This index is generated from tracked, physical `SKILL.md` entrypoints; catalog inclusion proves structure, not behavior or cross-harness compatibility.
 
+**Classification evidence:** inspect the fixed [Gold Set methodology](../docs/skill-taxonomy-gold-set.md) and the machine-readable [reviewed-set agreement report](./skill-taxonomy-evaluation.json). The score measures agreement on reviewed primary-outcome labels; it is not a Skill quality or runtime-success score.
+
 ## 🚀 Suggested starting points
 
 For a first run, prefer a [starter kit](../starter-kits/) or the [Codex package](../.codex/INDEX.md). These are navigation aids, not claims of behavioral verification or a ranking of the full library.
@@ -14,7 +16,7 @@ For a first run, prefer a [starter kit](../starter-kits/) or the [Codex package]
 | 💻 Software Engineering | [`tdd-workflow`](../skills/tdd-workflow/) | Portable required assignment · structure checked | Drive implementation through a test-first loop. |
 | 📊 Data, Analytics & Research | [`deep-research`](../skills/deep-research/) | Harness-specific assignment · generic installer skips | Turn a question into an evidence-oriented research process. |
 | 📈 Marketing, SEO & Growth | [`seo-audit`](../skills/seo-audit/) | Portable required assignment · structure checked | Review search discoverability with explicit checks. |
-| ✍️ Content, Media & Publishing | [`writing-skills`](../skills/writing-skills/) | Portable required assignment · structure checked | Move from a bounded writing brief to a reviewable draft. |
+| 🤖 AI Agents & Orchestration | [`writing-skills`](../skills/writing-skills/) | Portable required assignment · structure checked | Create and maintain reusable agent Skill instructions with a reviewable workflow. |
 | 🛡️ Security, Privacy & Legal | [`security-audit`](../skills/security-audit/) | Portable required assignment · structure checked · review: system-change | Inspect code and configuration for security risk. |
 | 💹 Finance, Trading & Markets | [`backtest-expert`](../skills/backtest-expert/) | Portable required assignment · structure checked | Review backtests without implying live-trading safety. |
 | 🎨 Product, Design & UX | [`frontend-design-ultimate`](../skills/frontend-design-ultimate/) | Harness-specific assignment · generic installer skips | Create a concrete interface direction and implementation. |
@@ -26,20 +28,20 @@ This revision contains 794 canonical catalog entries. The number is generated he
 
 | Category | Use it for | Entries |
 |---|---|---:|
-| [🤖 AI Agents & Orchestration](#ai-agents-orchestration) | Coordinate agents, context, memory, models, prompts, and tool protocols. | 77 |
-| [💻 Software Engineering](#software-engineering) | Build, test, review, debug, and maintain applications and developer tooling. | 80 |
-| [☁️ Cloud, DevOps & Reliability](#cloud-devops-reliability) | Deploy, observe, troubleshoot, and operate cloud and local infrastructure. | 29 |
-| [📊 Data, Analytics & Research](#data-analytics-research) | Collect evidence, search sources, analyze data, and communicate findings. | 75 |
-| [🛡️ Security, Privacy & Legal](#security-privacy-legal) | Review security, privacy, compliance, permissions, contracts, and legal risk. | 34 |
-| [🎨 Product, Design & UX](#product-design-ux) | Shape product requirements, interfaces, design systems, and user experience. | 26 |
-| [📈 Marketing, SEO & Growth](#marketing-seo-growth) | Acquire audiences through positioning, campaigns, search, ads, and social growth. | 51 |
-| [✍️ Content, Media & Publishing](#content-media-publishing) | Create, edit, repurpose, and publish writing, images, audio, and video. | 78 |
-| [🤝 Sales, CRM & Customer Success](#sales-crm-customer-success) | Find, win, onboard, support, and retain customers with accountable workflows. | 36 |
-| [💹 Finance, Trading & Markets](#finance-trading-markets) | Analyze markets, backtest strategies, track portfolios, and review financial risk. | 64 |
-| [🧭 Business Operations & Strategy](#business-operations-strategy) | Plan work, make decisions, manage teams, and improve operating systems. | 72 |
+| [🤖 AI Agents & Orchestration](#ai-agents-orchestration) | Coordinate agents, context, memory, models, prompts, and tool protocols. | 78 |
+| [💻 Software Engineering](#software-engineering) | Build, test, review, debug, and maintain applications and developer tooling. | 81 |
+| [☁️ Cloud, DevOps & Reliability](#cloud-devops-reliability) | Deploy, observe, troubleshoot, and operate cloud and local infrastructure. | 32 |
+| [📊 Data, Analytics & Research](#data-analytics-research) | Collect evidence, search sources, analyze data, and communicate findings. | 78 |
+| [🛡️ Security, Privacy & Legal](#security-privacy-legal) | Review security, privacy, compliance, permissions, contracts, and legal risk. | 32 |
+| [🎨 Product, Design & UX](#product-design-ux) | Shape product requirements, interfaces, design systems, and user experience. | 20 |
+| [📈 Marketing, SEO & Growth](#marketing-seo-growth) | Acquire audiences through positioning, campaigns, search, ads, and social growth. | 47 |
+| [✍️ Content, Media & Publishing](#content-media-publishing) | Create, edit, repurpose, and publish writing, images, audio, and video. | 82 |
+| [🤝 Sales, CRM & Customer Success](#sales-crm-customer-success) | Find, win, onboard, support, and retain customers with accountable workflows. | 39 |
+| [💹 Finance, Trading & Markets](#finance-trading-markets) | Analyze markets, backtest strategies, track portfolios, and review financial risk. | 65 |
+| [🧭 Business Operations & Strategy](#business-operations-strategy) | Plan work, make decisions, manage teams, and improve operating systems. | 71 |
 | [⚙️ Apps & Workflow Automation](#apps-workflow-automation) | Connect everyday apps, browsers, messaging systems, and repeatable workflows. | 88 |
 | [🇨🇳 Chinese Platform Workflows](#chinese-platform-workflows) | Create, analyze, and publish for major Chinese-language platforms and channels. | 39 |
-| [🧰 Specialized Domains & Utilities](#general-utilities) | Domain-specific helpers and cross-functional tools that need a dedicated review path. | 45 |
+| [🧰 Specialized Domains & Utilities](#general-utilities) | Domain-specific helpers and cross-functional tools that need a dedicated review path. | 42 |
 
 <a id="ai-agents-orchestration"></a>
 ## 🤖 AI Agents & Orchestration
@@ -48,7 +50,6 @@ Coordinate agents, context, memory, models, prompts, and tool protocols.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
-| [`agent-browser`](../skills/agent-browser/) | A fast Rust-based headless browser automation CLI with Node.js fallback that enables AI agents to navigate, click, type, and snapshot pages via structured commands. | Catalog only |
 | [`agent-builder`](../skills/agent-builder/) | Build agent from spec: code, skill, config, launchd | Catalog only |
 | [`agent-capacity-modeler`](../skills/agent-capacity-modeler/) | 为每个Agent建立"技能-经验-价值观"三维动态模型，超越简单技能列表，实现真正的硅基人才画像。 | Catalog only |
 | [`agent-contacts`](../skills/agent-contacts/) | AI agent contacts — add, list, remove MCP contacts. Use when someone gives an agent URL, or when you need to view/remove contacts. | Catalog only |
@@ -66,6 +67,7 @@ Coordinate agents, context, memory, models, prompts, and tool protocols.
 | [`auto-memory`](../skills/auto-memory/) | Description needs review; inspect source. | Catalog only |
 | [`auto-respawn`](../skills/auto-respawn/) | Description needs review; inspect source. | Catalog only |
 | [`clawrouter`](../skills/clawrouter/) | Description needs review; inspect source. | Catalog only |
+| [`codex-cc-guide`](../skills/codex-cc-guide/) | 如何用 ACP sessions_spawn 调用 Claude Code / Codex 写代码 — 小code 团队编码任务指南 | Harness-specific assignment · generic installer skips · PE |
 | [`coding-agent-backup`](../skills/coding-agent-backup/) | Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3)… | Harness-specific assignment · generic installer skips · PE |
 | [`coding-agent-orchestrator`](../skills/coding-agent-orchestrator/) | coding-agent-orchestrator | Catalog only |
 | [`command-registry-integration`](../skills/command-registry-integration/) | Integrate new chat commands into OpenClaw's formal command registry | Catalog only |
@@ -77,15 +79,15 @@ Coordinate agents, context, memory, models, prompts, and tool protocols.
 | [`cross-instance-comm`](../skills/cross-instance-comm/) | Use when sending messages or tasks between multiple OpenClaw instances over Tailscale Gateway, such as asking another machine to execute work or sync context. | Catalog only |
 | [`dispatcher`](../skills/dispatcher/) | Route complex multi-step tasks, multi-skill orchestration, post-execution checklist | Catalog only |
 | [`dispatching-parallel-agents`](../skills/dispatching-parallel-agents/) | Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies | Harness-specific assignment · generic installer skips · CEO |
+| [`elite-github-skills-hub`](../skills/elite-github-skills-hub/) | Curated hub of the highest-value GitHub skills/repos for Claude Code, Cursor, Codex, Gemini CLI, and OpenClaw. Links to 20+ elite repos organized by tier. Use when discovering,… | Catalog only |
 | [`elite-longterm-memory`](../skills/elite-longterm-memory/) | Ultimate AI agent memory system for Cursor, Claude, ChatGPT &amp; Copilot. WAL protocol + vector search + git-notes + cloud backup. Never lose context again. Vibe-coding ready. | Catalog only |
 | [`env-setup`](../skills/env-setup/) | Claude Code 环境一键同步工具。从 GitHub 仓库同步所有配置到本地：output-styles 风格、CLAUDE.md 全局提示词、MCP 服务器配置、Agent 配置、Plugin 配置。适用于多设备统一环境、换电脑恢复、团队共享配置等场景。当用户需要从 GitHub 仓库同步 Claude Code/OpenClaw… | Catalog only |
-| [`file-organizer`](../skills/file-organizer/) | Intelligently organizes your files and folders across your computer by understanding context, finding duplicates, suggesting better structures, and automating cleanup tasks.… | Catalog only |
+| [`evomap`](../skills/evomap/) | Connect to the EvoMap collaborative evolution marketplace. Publish Gene+Capsule bundles, fetch promoted assets, claim bounty tasks, and earn credits via the GEP-A2A protocol. Use… | Catalog only |
+| [`fabric-pattern`](../skills/fabric-pattern/) | Description needs review; inspect source. | Catalog only |
 | [`find-skills`](../skills/find-skills/) | Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending… | Catalog only |
 | [`firm-orchestration`](../skills/firm-orchestration/) | Pyramid multi-agent orchestration for OpenClaw: routes objectives from a CEO agent down through departments, services and employees via sessions_send / sessions_spawn, collects… | Catalog only |
 | [`greenhelix-agent-workforce-orchestration`](../skills/greenhelix-agent-workforce-orchestration/) | Agent Workforce Orchestration: Hybrid Human+AI Teams. Build agent-led workforce orchestration: capability matching, escrow-based payments for AI agents and human gig workers,… | Catalog only |
-| [`internal-comms`](../skills/internal-comms/) | A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write… | Catalog only |
-| [`kanbanflow-skill`](../skills/kanbanflow-skill/) | Manage KanbanFlow boards, columns, and tasks for lightweight workflow | Catalog only |
-| [`last30days-skill`](../skills/last30days-skill/) | Research a topic from the last 30 days. Also triggered by 'last30'. Sources: Reddit, X, YouTube, Hacker News, Polymarket, web. Become an expert and write copy-paste-ready prompts. | Catalog only |
+| [`inference-optimizer`](../skills/inference-optimizer/) | Audit OpenClaw token usage, purge stale sessions, and optimize inference speed. Use when the user sends /optimize, /audit, asks to purge sessions, or wants a token/workspace audit. | Harness-specific assignment · generic installer skips · CTO |
 | [`mcp-agent-connect`](../skills/mcp-agent-connect/) | Connect to an AI agent via MCP using their mcp_url from CRM. Discovers capabilities via agent.json, registers MCP server, and enables tool-based communication. | Catalog only |
 | [`mcp-builder`](../skills/mcp-builder/) | Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP… | Catalog only |
 | [`mcp-installer`](../skills/mcp-installer/) | 从GitHub搜索并自动安装配置MCP(Model Context Protocol)服务器工具到Claude配置文件。当用户需要安装MCP工具时触发此技能。工作流程：搜索GitHub上的MCP项目 -&gt; 提取npx配置 -&gt; 添加到~/.claude.json -&gt; 处理API密钥（如有）。 | Catalog only |
@@ -97,7 +99,6 @@ Coordinate agents, context, memory, models, prompts, and tool protocols.
 | [`model-fallback`](../skills/model-fallback/) | 模型自动降级与故障切换。当主模型请求失败、超时、达到速率限制或配额耗尽时，自动切换到备用模型，确保服务连续性。支持多供应商、多优先级的智能模型选择，提供健康监控、自动重试和错误恢复机制。 | Harness-specific assignment · generic installer skips · CTO |
 | [`model-health-check`](../skills/model-health-check/) | 检查已配置模型供应商的连通性、延迟和可用性，用于快速诊断模型侧故障。 | Catalog only |
 | [`model-provider-manager`](../skills/model-provider-manager/) | Unified LLM provider and model configuration, health monitoring, and key management | Harness-specific assignment · generic installer skips · CTO |
-| [`model-usage`](../skills/model-usage/) | Use CodexBar CLI local cost usage to summarize per-model usage for Codex | Catalog only |
 | [`multi-agent-architecture`](../skills/multi-agent-architecture/) | 多 Agent 架构设计与智能 Spawn 系统。当需要设计多 Agent 系统、配置专业化 Agent、实现智能任务分发、或优化并发处理能力时使用此技能。 | Catalog only |
 | [`multi-agent-trading`](../skills/multi-agent-trading/) | multi-agent trading, 交易团队, analyst team, trading debate, bull bear debate, 协作交易, agent trading framework | Catalog only |
 | [`parallel-agents`](../skills/parallel-agents/) | Multi-agent orchestration patterns. Use when multiple independent tasks can run with different domain expertise or when comprehensive analysis requires multiple perspectives. | Catalog only |
@@ -110,20 +111,22 @@ Coordinate agents, context, memory, models, prompts, and tool protocols.
 | [`skill-config-checker`](../skills/skill-config-checker/) | 扫描本地所有 skills，检测需要配置的 API keys、tokens、secrets 等，生成配置需求清单和操作指南。 | Catalog only |
 | [`skill-creator`](../skills/skill-creator/) | Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with… | Catalog only |
 | [`skill-finder-cn`](../skills/skill-finder-cn/) | Skill 查找器 \| Skill Finder. 帮助发现和安装 ClawHub Skills \| Discover and install ClawHub Skills. 回答'有什么技能可以X'、'找一个技能' \| Answers 'what skill can X', 'find a skill'. 触发词：找 skill、find… | Harness-specific assignment · generic installer skips · CSO |
-| [`skill-gap-analyzer`](../skills/skill-gap-analyzer/) | 将军团战略蓝图与现有Agent能力矩阵进行对比，自动识别"能力鸿沟"，并发起招聘（硅基/碳基猎取）或培训（进化路径）需求。 | Catalog only |
-| [`slidev-agent-skill`](../skills/slidev-agent-skill/) | Create, edit, theme, build, and export Slidev presentations using a script-first workflow with detailed local references. Use when working on Slidev decks, themes, layouts,… | Catalog only |
 | [`sp-dispatching-parallel-agents`](../skills/sp-dispatching-parallel-agents/) | Use multiple Claude agents to investigate and fix independent problems concurrently | Catalog only |
 | [`sp-preserving-productive-tensions`](../skills/sp-preserving-productive-tensions/) | Recognize when disagreements reveal valuable context, preserve multiple valid approaches instead of forcing premature resolution | Catalog only |
 | [`sp-remembering-conversations`](../skills/sp-remembering-conversations/) | Search previous Claude Code conversations for facts, patterns, decisions, and context using semantic or text search | Catalog only |
+| [`sp-subagent-driven-development`](../skills/sp-subagent-driven-development/) | Execute implementation plan by dispatching fresh subagent for each task, with code review between tasks | Portable required assignment · structure checked · PE |
 | [`sp-using-skills`](../skills/sp-using-skills/) | Skills wiki intro - mandatory workflows, search tool, brainstorming triggers | Catalog only |
 | [`strategic-orchestration`](../skills/strategic-orchestration/) | Coordinate agents toward a unified objective; assign roles, sequence work, prevent conflicts, and define success criteria. | Catalog only |
+| [`subagent-driven-development`](../skills/subagent-driven-development/) | Use when executing implementation plans with independent tasks in the current session | Catalog only |
+| [`task-supervisor`](../skills/task-supervisor/) | 定时巡检 agent 任务执行状态，识别卡住、abort、无产出等异常并触发催促或告警。 | Catalog only |
 | [`tessl-skill-review`](../skills/tessl-skill-review/) | Evaluate, score, and review an Agent Skill or SKILL.md using Tessl as the primary evaluator. Use when asked to measure skill quality, score a skill, review a skill against best… | Catalog only |
 | [`token-budget-advisor`](../skills/token-budget-advisor/) | Intercept the response flow to offer the user a choice about response depth **before** Claude answers | Portable required assignment · structure checked · CEO |
 | [`token-reporter`](../skills/token-reporter/) | 每日自动统计 OpenClaw 实例 Token 消耗和工作产出，上报到飞书多维表格。扫描 JSONL 日志按模型聚合 token，收集各 | Harness-specific assignment · generic installer skips · CTO |
 | [`trailofbits-skills`](../skills/trailofbits-skills/) | Description needs review; inspect source. | Catalog only |
-| [`vcf-annotator`](../skills/vcf-annotator/) | Annotate VCF variants with VEP, ClinVar, gnomAD frequencies, and ancestry-aware context. Generates prioritised variant reports. | Catalog only |
+| [`using-superpowers`](../skills/using-superpowers/) | Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions | Catalog only |
 | [`work-to-skill`](../skills/work-to-skill/) | 工作即技能：每次完成一项有复用价值的工作后，自动评估并封装为可复用 Skill。让团队在工作中持续进化。 | Catalog only |
 | [`workspace-directory-manager`](../skills/workspace-directory-manager/) | Workspace directory manager — maintain cleanliness of ~/.openclaw/ and ~/clawd/ | Catalog only |
+| [`writing-skills`](../skills/writing-skills/) | Use when creating new skills, editing existing skills, or verifying skills work before deployment | Portable required assignment · structure checked · CEO |
 | [`xiaomo-assistant-template`](../skills/xiaomo-assistant-template/) | 小a助手配置模板。基于 xiaomo-starter-kit 改编，提供预配置的 OpenClaw 助手框架文件。当用户需要快速配置新助手、设置助手身份、创建助手配置文件时使用此技能。 | Catalog only |
 
 <a id="software-engineering"></a>
@@ -133,6 +136,8 @@ Build, test, review, debug, and maintain applications and developer tooling.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
+| [`api-design`](../skills/api-design/) | REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs. | Portable required assignment · structure checked · CTO, PE |
+| [`api-design-patterns`](../skills/api-design-patterns/) | Comprehensive API design patterns covering REST, GraphQL, gRPC, versioning, authentication, and modern API best practices | Portable required assignment · structure checked · CTO |
 | [`api-gateway`](../skills/api-gateway/) | Description needs review; inspect source. | Portable required assignment · structure checked · CDO |
 | [`api-provider-setup`](../skills/api-provider-setup/) | 添加和配置第三方 API 中转站供应商到 OpenClaw。当用户需要添加新的 API 供应商、配置中转站、设置自定义模型端点时使用此技能。支持 Anthropic 兼容和 OpenAI 兼容的 API 格式。 | Catalog only |
 | [`api-provider-status`](../skills/api-provider-status/) | 查询 API 供应商的余额、用量与可用状态，支持多供应商监控与定时汇报。 | Harness-specific assignment · generic installer skips · CTO |
@@ -149,18 +154,15 @@ Build, test, review, debug, and maintain applications and developer tooling.
 | [`code-material-gen`](../skills/code-material-gen/) | Description needs review; inspect source. | Catalog only |
 | [`code-review`](../skills/code-review/) | AI code review for PR or local changes | Catalog only |
 | [`code-review-quality`](../skills/code-review-quality/) | Conduct context-driven code reviews focusing on quality, testability, and maintainability. Use when reviewing code, providing feedback, or establishing review practices. | Harness-specific assignment · generic installer skips · PE |
-| [`codex-cc-guide`](../skills/codex-cc-guide/) | 如何用 ACP sessions_spawn 调用 Claude Code / Codex 写代码 — 小code 团队编码任务指南 | Harness-specific assignment · generic installer skips · PE |
 | [`collaboration`](../skills/collaboration/) | Guide for collaborating on GitHub projects. This skill should be used when contributing to projects, creating PRs, reviewing code, or managing issues on GitHub. | Catalog only |
 | [`commit-analyzer`](../skills/commit-analyzer/) | Analyze git commit frequency, categories, and timing patterns to diagnose | Catalog only |
 | [`conventional-commits`](../skills/conventional-commits/) | Format commit messages using the Conventional Commits specification. Use when creating commits, writing commit messages, or when the user mentions commits, git commits, or commit… | Catalog only |
 | [`css-ninja`](../skills/css-ninja/) | Master CSS with Tailwind, CSS-in-JS, responsive layouts, animations, and modern styling patterns. Use when: (1) responsive design implementation, (2) Tailwind CSS setup and… | Portable required assignment · structure checked · PE |
 | [`db-migrator`](../skills/db-migrator/) | Database schema migration, versioning, and rollback management for SQL and NoSQL databases. Use when: (1) creating database migrations, (2) modifying table schemas, (3)… | Portable required assignment · structure checked · PE |
-| [`deepwork-tracker`](../skills/deepwork-tracker/) | Track deep work sessions locally (start/stop/status) and generate a GitHub-contribution-graph style minutes-per-day heatmap for sharing (e.g., via Telegram). Use when the user… | Catalog only |
 | [`digital-human-api`](../skills/digital-human-api/) | Digital human video generation via Qingyun API — avatar-based talking head videos | Catalog only |
 | [`e2e-testing`](../skills/e2e-testing/) | Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies. | Portable required assignment · structure checked · CEO, PE |
 | [`e2e-testing-patterns`](../skills/e2e-testing-patterns/) | Master end-to-end testing with Playwright and Cypress to build reliable test suites that catch bugs, improve confidence, and enable fast deployment. Use when implementing E2E… | Catalog only |
 | [`electron-app-dev`](../skills/electron-app-dev/) | 老王我搞Electron好多年了，这玩意儿写跨平台应用真tm香！ | Catalog only |
-| [`elite-github-skills-hub`](../skills/elite-github-skills-hub/) | Curated hub of the highest-value GitHub skills/repos for Claude Code, Cursor, Codex, Gemini CLI, and OpenClaw. Links to 20+ elite repos organized by tier. Use when discovering,… | Catalog only |
 | [`entropy-manager`](../skills/entropy-manager/) | Entropy scanner for codebases — detect disorder and suggest cleanup actions | Catalog only |
 | [`eval-harness`](../skills/eval-harness/) | Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles | Catalog only |
 | [`expo-tailwind-setup`](../skills/expo-tailwind-setup/) | Set up Tailwind CSS v4 in Expo with react-native-css and NativeWind v5 for universal styling | Catalog only |
@@ -169,9 +171,7 @@ Build, test, review, debug, and maintain applications and developer tooling.
 | [`ghost-scan-code`](../skills/ghost-scan-code/) | Ghost Security - SAST code scanner. Finds security vulnerabilities in source code by planning and executing targeted scans for issues like SQL injection, XSS, BOLA, BFLA, SSRF,… | Portable required assignment · structure checked · PE |
 | [`git-workflow`](../skills/git-workflow/) | OpenClaw Git 工作流技能。 当用户提及以下任务时使用： - 提交代码或文档 - 推送到远程仓库 - 管理多个 Git 仓库 - 查看 Git 状态 核心能力: - 自动检测文件变更 - 自动生成提交信息 - 自动推送到远程仓库 - 多仓库管理 | Catalog only |
 | [`github`](../skills/github/) | Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries. | Portable required assignment · structure checked · PE |
-| [`gitlab-automation`](../skills/gitlab-automation/) | Automate GitLab project management, issues, merge requests, pipelines, branches, and user operations via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`langsmith-fetch`](../skills/langsmith-fetch/) | Debug LangChain and LangGraph agents by fetching execution traces from LangSmith Studio. Use when debugging agent behavior, investigating errors, analyzing tool calls, checking… | Catalog only |
-| [`liuyao-yijing`](../skills/liuyao-yijing/) | 六爻易经占卜器，基于京房纳甲体系，模拟铜钱起卦，完成纳甲装卦（天干地支、世应、六亲、六神）， 通过用神旺衰和生克制化断卦。当用户提及「六爻」「易经占卜」「铜钱起卦」「纳甲」「帮我起一卦」 「六爻预测」时触发。装卦为确定性计算 + LLM 综合断卦，无外部 API 依赖。 不适用于：梅花易数、奇门遁甲、星座运势、塔罗占卜、八字命理等其他领域 → 建议使用… | Catalog only |
 | [`market-ab-test-setup`](../skills/market-ab-test-setup/) | When the user wants to plan, design, or implement an A/B test or experiment. Also use when the user mentions "A/B test," "split test," "experiment," "test this change," "variant… | Catalog only |
 | [`micro-saas-launcher`](../skills/micro-saas-launcher/) | Expert in launching small, focused SaaS products fast - the indie hacker approach to building profitable software. Covers idea validation, MVP development, pricing, launch… | Catalog only |
 | [`minimax-tts`](../skills/minimax-tts/) | Text-to-speech synthesis via MiniMax WebSocket API | Catalog only |
@@ -179,7 +179,6 @@ Build, test, review, debug, and maintain applications and developer tooling.
 | [`openrouter-usage`](../skills/openrouter-usage/) | Track OpenRouter API spending — credit balance, per-model cost breakdown, | Catalog only |
 | [`pine-developer`](../skills/pine-developer/) | Writes production-quality Pine Script v6 code following TradingView guidelines and best practices. Use when implementing indicators, strategies, or any Pine Script code. Triggers… | Catalog only |
 | [`postgresql-database-engineering`](../skills/postgresql-database-engineering/) | Comprehensive PostgreSQL database engineering skill covering indexing strategies, query optimization, performance tuning, partitioning, replication, backup and recovery, high… | Portable required assignment · structure checked · CEO |
-| [`provider-key-manager`](../skills/provider-key-manager/) | Provider key manager — rotate and sync API keys across multi-agent workspaces | Harness-specific assignment · generic installer skips · CTO |
 | [`python-performance-optimization`](../skills/python-performance-optimization/) | Profile and optimize Python code using cProfile, memory profilers, and performance best practices. Use when debugging slow Python code, optimizing bottlenecks, or improving… | Catalog only |
 | [`qingyun-api`](../skills/qingyun-api/) | 青云聚合API多模态调用 Skill — 覆盖生图、生视频、语音、Embedding 等能力。 | Catalog only |
 | [`qmd-extended`](../skills/qmd-extended/) | Extended QMD knowledge base with multi-backend embedding (Google AI Studio / Ollama / local). Use when managing QMD embeddings, switching backends, testing embedding quality,… | Catalog only |
@@ -190,15 +189,18 @@ Build, test, review, debug, and maintain applications and developer tooling.
 | [`receiving-code-review`](../skills/receiving-code-review/) | Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and… | Portable required assignment · structure checked · PE |
 | [`redis-inspect`](../skills/redis-inspect/) | Inspect Redis cache keys, values, and TTLs for debugging. Supports both main cache and system cache. Use for debugging cache issues, checking cached values, and monitoring cache… | Portable required assignment · structure checked · PE |
 | [`requesting-code-review`](../skills/requesting-code-review/) | Use when completing tasks, implementing major features, or before merging to verify work meets requirements | Portable required assignment · structure checked · PE |
+| [`senior-architect`](../skills/senior-architect/) | This skill should be used when the user asks to "design system architecture", "evaluate microservices vs monolith", "create architecture diagrams", "analyze dependencies",… | Catalog only |
 | [`shell-expert`](../skills/shell-expert/) | Shell scripting expertise, command-line tools, automation, and cross-platform scripting best practices. Covers shell script development, CLI tool usage, and system automation… | Catalog only |
-| [`sp-subagent-driven-development`](../skills/sp-subagent-driven-development/) | Execute implementation plan by dispatching fresh subagent for each task, with code review between tasks | Portable required assignment · structure checked · PE |
+| [`software-architecture-design`](../skills/software-architecture-design/) | Designs system structure across monolith/microservices/serverless. Use when structuring systems, scaling, decomposing monoliths, or choosing patterns. | Catalog only |
+| [`sp-condition-based-waiting`](../skills/sp-condition-based-waiting/) | Replace arbitrary timeouts with condition polling for reliable async tests | Portable required assignment · structure checked · PE |
+| [`sp-simplification-cascades`](../skills/sp-simplification-cascades/) | Find one insight that eliminates multiple components - "if this is true, we don't need X, Y, or Z" | Catalog only |
 | [`sp-systematic-debugging`](../skills/sp-systematic-debugging/) | Four-phase debugging framework that ensures root cause investigation before attempting fixes. Never jump to solutions. | Harness-specific assignment · generic installer skips · COO |
 | [`sp-test-driven-development`](../skills/sp-test-driven-development/) | Write the test first, watch it fail, write minimal code to pass | Portable required assignment · structure checked · PE |
 | [`sp-testing-anti-patterns`](../skills/sp-testing-anti-patterns/) | Never test mock behavior. Never add test-only methods to production classes. Understand dependencies before mocking. | Portable required assignment · structure checked · PE |
 | [`sp-using-git-worktrees`](../skills/sp-using-git-worktrees/) | Create isolated git worktrees with smart directory selection and safety verification | Harness-specific assignment · generic installer skips · PE |
 | [`sql-optimization`](../skills/sql-optimization/) | Universal SQL performance optimization assistant for comprehensive query tuning, indexing strategies, and database performance analysis across all SQL databases (MySQL,… | Portable required assignment · structure checked · PE |
 | [`sql-pro`](../skills/sql-pro/) | Master modern SQL with cloud-native databases, OLTP/OLAP optimization, and advanced query techniques. Expert in performance tuning, data modeling, and hybrid analytical systems.… | Catalog only |
-| [`subagent-driven-development`](../skills/subagent-driven-development/) | Use when executing implementation plans with independent tasks in the current session | Catalog only |
+| [`static-code-analysis`](../skills/static-code-analysis/) | Implement static code analysis with linters, formatters, and security scanners to catch bugs early. Use when enforcing code standards, detecting security vulnerabilities, or… | Catalog only |
 | [`supabase`](../skills/supabase/) | Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR… | Catalog only |
 | [`supabase-automation`](../skills/supabase-automation/) | Automate Supabase database queries, table management, project administration, storage, edge functions, and SQL execution via Rube MCP (Composio). Always search tools first for… | Portable required assignment · structure checked · CTO |
 | [`supabase-postgres-best-practices`](../skills/supabase-postgres-best-practices/) | Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database… | Catalog only |
@@ -211,8 +213,10 @@ Build, test, review, debug, and maintain applications and developer tooling.
 | [`test-driven-development`](../skills/test-driven-development/) | Use when implementing any feature or bugfix, before writing implementation code | Catalog only |
 | [`using-git-worktrees`](../skills/using-git-worktrees/) | Use when starting feature work that needs isolation from current workspace or before executing implementation plans - creates isolated git worktrees with smart directory… | Catalog only |
 | [`verification-before-completion`](../skills/verification-before-completion/) | Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any… | Portable required assignment · structure checked · CEO, PE |
+| [`vibe-code-auditor`](../skills/vibe-code-auditor/) | Audit rapidly generated or AI-produced code for structural flaws, fragility, and production risks. | Catalog only |
 | [`vitest`](../skills/vitest/) | Vitest testing framework patterns for test setup, async testing, mocking with vi.*, snapshots, and test performance (formerly test-vitest). This skill should be used when writing… | Catalog only |
 | [`webapp-testing`](../skills/webapp-testing/) | Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots,… | Catalog only |
+| [`wiki-qa`](../skills/wiki-qa/) | Answers questions about a code repository using source file analysis. Use when the user asks a question about how something works, wants to understand a component, or needs help… | Catalog only |
 
 <a id="cloud-devops-reliability"></a>
 ## ☁️ Cloud, DevOps & Reliability
@@ -223,6 +227,8 @@ Deploy, observe, troubleshoot, and operate cloud and local infrastructure.
 |---|---|---|
 | [`aws-cost-cleanup`](../skills/aws-cost-cleanup/) | Automated cleanup of unused AWS resources to reduce costs | Catalog only |
 | [`cloudflare-pages`](../skills/cloudflare-pages/) | Deploy static sites to Cloudflare Pages with custom domains and CI/CD. Use when the user wants to deploy a site to Cloudflare Pages, add a custom domain to a Pages project, set… | Catalog only |
+| [`cost-optimization`](../skills/cost-optimization/) | Optimize cloud costs through resource rightsizing, tagging strategies, reserved instances, and spending analysis. Use when reducing cloud expenses, analyzing infrastructure… | Portable required assignment · structure checked · COO |
+| [`datadog-automation`](../skills/datadog-automation/) | Automate Datadog tasks via Rube MCP (Composio): query metrics, search logs, manage monitors/dashboards, create events and downtimes. Always search tools first for current schemas. | Catalog only |
 | [`deploy-website`](../skills/deploy-website/) | Website deployment via GitHub PR + Cloud Build | Catalog only |
 | [`deployment-automation`](../skills/deployment-automation/) | Automate application deployment to cloud platforms and servers. Use when setting up CI/CD pipelines, deploying to Docker/Kubernetes, or configuring cloud infrastructure. Handles… | Portable required assignment · structure checked · CEO, CTO, PE |
 | [`distributed-tracing`](../skills/distributed-tracing/) | Implement distributed tracing with Jaeger and Tempo for request flow visibility across microservices. | Catalog only |
@@ -235,10 +241,11 @@ Deploy, observe, troubleshoot, and operate cloud and local infrastructure.
 | [`kubernetes-specialist`](../skills/kubernetes-specialist/) | Use when deploying or managing Kubernetes workloads. Invoke to create deployment manifests, configure pod security policies, set up service accounts, define network isolation… | Portable required assignment · structure checked · CEO, CTO, PE |
 | [`linux-service-triage`](../skills/linux-service-triage/) | Diagnoses common Linux service issues using logs, systemd/PM2, file permissions, Nginx reverse proxy checks, and DNS sanity checks. Use when a server app is failing, unreachable,… | Catalog only |
 | [`linux-troubleshooting`](../skills/linux-troubleshooting/) | Linux system troubleshooting workflow for diagnosing and resolving system issues, performance problems, and service failures. | Catalog only |
+| [`microservices-patterns`](../skills/microservices-patterns/) | Comprehensive microservices patterns skill covering service mesh, traffic management, circuit breakers, resilience patterns, Istio, and production microservices architecture | Catalog only |
 | [`ml-engineer`](../skills/ml-engineer/) | Build production ML systems with PyTorch 2.x, TensorFlow, and modern ML frameworks. Implements model serving, feature engineering, A/B testing, and monitoring. Use PROACTIVELY… | Catalog only |
-| [`model-usage-linux`](../skills/model-usage-linux/) | Track OpenClaw AI token usage and cost per model on Linux by parsing session JSONL files. Use when asked about: token usage, API cost, how much has been spent, which model was… | Catalog only |
 | [`nginx`](../skills/nginx/) | Configure Nginx for reverse proxy, load balancing, SSL termination, and high-performance static serving. | Catalog only |
 | [`nginx-configuration`](../skills/nginx-configuration/) | Description needs review; inspect source. | Portable required assignment · structure checked · CTO |
+| [`observability-designer`](../skills/observability-designer/) | Design production observability strategies covering SLI/SLOs, metrics, | Catalog only |
 | [`op0-altar`](../skills/op0-altar/) | Create and manage self-rewarding meme coins on Solana via the OP0 Altar protocol. Deploy pump.fun tokens where holders automatically receive rewards in 129 payout token options… | Catalog only |
 | [`proxmox-ops-skill`](../skills/proxmox-ops-skill/) | Create a credential file at `~/.proxmox-credentials` | Catalog only |
 | [`remote-access`](../skills/remote-access/) | ttyd + Tailscale for mobile terminal access | Catalog only |
@@ -258,7 +265,6 @@ Collect evidence, search sources, analyze data, and communicate findings.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
-| [`a-share-analysis`](../skills/a-share-analysis/) | 此Skill实现了三层分析体系： 1. 情报采集层 — 7路并发多源新闻采集，自动匹配板块和个股 2. 盘面阅读层 — 美股映射 + 大盘多空判断 + 实时主线(&gt;9%题材分析) 3. 个股精选层 — 产业逻辑 + 形态8分类 + 盘口分析 + 题材排名 + 综合评分 4. 原始新闻浏览 (news.py) — 分类展示影响股票的新闻，源信息不做任何修改 | Catalog only |
 | [`ai-radar`](../skills/ai-radar/) | 雷达Skill（AI Radar）——零API、零Key、零服务器的中文AI资讯查询。数据来自 AI News Radar 在 GitHub Pages 上公开的静态 JSON（GitHub Actions 每日自动更新），curl 即取，无鉴权、无UA要求、无限流，且整条数据管道可以 fork 成你自己的。 当用户想知道"今天 AI… | Catalog only |
 | [`analytics-tracking`](../skills/analytics-tracking/) | Design, audit, and improve analytics tracking systems that produce reliable, decision-ready data. Use when the user wants to set up, fix, or evaluate analytics tracking (GA4,… | Catalog only |
 | [`apify-ultimate-scraper`](../skills/apify-ultimate-scraper/) | Universal AI-powered web scraper for any platform. Scrape data from Instagram, Facebook, TikTok, YouTube, LinkedIn, X/Twitter, Google Maps, Google Search, Google Trends, Reddit,… | Portable required assignment · structure checked · CDO |
@@ -266,6 +272,7 @@ Collect evidence, search sources, analyze data, and communicate findings.
 | [`arxiv-automation`](../skills/arxiv-automation/) | Search and monitor arXiv papers. Query by topic, author, or category. Track new papers, download PDFs, and summarize abstracts for research workflows. | Catalog only |
 | [`auto-drive`](../skills/auto-drive/) | --- name: auto-drive description: Upload and download files to Autonomys Network permanent decentralized storage via Auto-Drive. Save memories as a linked-list chain for… | Catalog only |
 | [`bio-orchestrator`](../skills/bio-orchestrator/) | Meta-agent that routes bioinformatics requests to specialised sub-skills. Handles file type detection, analysis planning, report generation, and reproducibility export. | Catalog only |
+| [`business-analyst`](../skills/business-analyst/) | Build KPI frameworks, predictive models, real-time dashboards, and strategic recommendations using modern BI tools and AI-powered analytics. Use when the user needs business… | Catalog only |
 | [`business-intelligence`](../skills/business-intelligence/) | Model business performance, define KPIs, and turn data into decision-ready dashboards, briefings, and operating cadences for teams and executives. | Catalog only |
 | [`call-prep`](../skills/call-prep/) | Call preparation: research, CRM, talking points, PDF | Catalog only |
 | [`claw-ancestry-pca`](../skills/claw-ancestry-pca/) | Ancestry decomposition PCA against the Simons Genome Diversity Project | Catalog only |
@@ -273,11 +280,11 @@ Collect evidence, search sources, analyze data, and communicate findings.
 | [`company-investment-research`](../skills/company-investment-research/) | Structured, multi-dimensional company investment research framework for AI agents and human analysts. Provides a 10-part checklist (moat, tech, market, customers, growth,… | Catalog only |
 | [`csv-pipeline`](../skills/csv-pipeline/) | Process, transform, analyze, and report on CSV and JSON data files. Use when the user needs to filter rows, join datasets, compute aggregates, convert formats, deduplicate, or… | Catalog only |
 | [`ct-monitor`](../skills/ct-monitor/) | Research crypto news, public market data, and monitored accounts with CT Monitor. Use for attributed briefings, watchlists, narrative review, and paper-only signal analysis. | Catalog only · review: credentials, external-write, financial-action |
+| [`daily-trending`](../skills/daily-trending/) | 获取今日热榜，从tophub.today抓取各平台热搜榜单。当用户询问"今天有什么热搜"、"热榜"、"微博热搜"时触发。 | Catalog only |
 | [`dashboard-builder`](../skills/dashboard-builder/) | Build monitoring dashboards that answer real operator questions for Grafana, SigNoz, and similar platforms. Use when turning metrics into a working dashboard instead of a vanity… | Portable required assignment · structure checked · CEO |
 | [`data-analyst`](../skills/data-analyst/) | Data visualization, report generation, SQL queries, and spreadsheet automation. Transform your AI agent into a data-savvy analyst that turns raw data into actionable insights. | Catalog only |
 | [`data-engineering-data-pipeline`](../skills/data-engineering-data-pipeline/) | You are a data pipeline architecture expert specializing in scalable, reliable, and cost-effective data pipelines for batch and streaming data processing. | Catalog only |
 | [`data-storytelling`](../skills/data-storytelling/) | Transform data into compelling narratives using visualization, context, and persuasive structure. Use when presenting analytics to stakeholders, creating data reports, or… | Catalog only |
-| [`datadog-automation`](../skills/datadog-automation/) | Automate Datadog tasks via Rube MCP (Composio): query metrics, search logs, manage monitors/dashboards, create events and downtimes. Always search tools first for current schemas. | Catalog only |
 | [`deep-research`](../skills/deep-research/) | Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants… | Harness-specific assignment · generic installer skips · CEO, CQO, CRO |
 | [`documents`](../skills/documents/) | Manage company &amp; personal documents — rekvizity, passport, INN, bank details, scans. Store locally + Google Drive. Send data blocks on request. | Catalog only |
 | [`duckdb-cli-ai-skills`](../skills/duckdb-cli-ai-skills/) | DuckDB CLI specialist for SQL analysis, data processing and file conversion. Use for SQL queries, CSV/Parquet/JSON analysis, database queries, or data conversion. Triggers on… | Catalog only |
@@ -293,22 +300,25 @@ Collect evidence, search sources, analyze data, and communicate findings.
 | [`infra-facebook-cdp`](../skills/infra-facebook-cdp/) | Facebook CDP automation: comments, data collection | Catalog only |
 | [`investment-research`](../skills/investment-research/) | Perform structured investment research (投研分析) for a company/stock/ETF/sector using a repeatable framework: fundamentals (basic/财务报表与商业模式), technical analysis (技术指标与关键价位),… | Catalog only |
 | [`kpi-dashboard-design`](../skills/kpi-dashboard-design/) | Design effective KPI dashboards with metrics selection, visualization best practices, and real-time monitoring patterns. Use when building business dashboards, selecting metrics,… | Portable required assignment · structure checked · GOVERNOR |
+| [`last30days-skill`](../skills/last30days-skill/) | Research a topic from the last 30 days. Also triggered by 'last30'. Sources: Reddit, X, YouTube, Hacker News, Polymarket, web. Become an expert and write copy-paste-ready prompts. | Catalog only |
 | [`lead-research-assistant`](../skills/lead-research-assistant/) | Identifies high-quality leads for your product or service by analyzing your business, searching for target companies, and providing actionable contact strategies. Perfect for… | Catalog only |
 | [`lit-synthesizer`](../skills/lit-synthesizer/) | Search PubMed and bioRxiv, summarise papers with LLM, build citation graphs, and generate literature review sections. | Catalog only |
 | [`log-activity`](../skills/log-activity/) | Log activity to activities.csv | Catalog only |
-| [`market-nightly-evolution`](../skills/market-nightly-evolution/) | Nightly market evolution report — overnight market analysis and strategy prep | Catalog only |
+| [`market-intelligence`](../skills/market-intelligence/) | Description needs review; inspect source. | Catalog only |
 | [`market-research`](../skills/market-research/) | Size markets, analyze competitors, and validate opportunities with practical frameworks and free data sources. | Portable required assignment · structure checked · CMO |
 | [`market-sizing-analysis`](../skills/market-sizing-analysis/) | Use when the user asks to calculate TAM, determine SAM, estimate SOM, size a market, calculate market opportunity, ask for total addressable market, or do market sizing for a… | Catalog only |
 | [`metrics-review`](../skills/metrics-review/) | Review and analyze product metrics with trend analysis and actionable insights. Use when running a weekly, monthly, or quarterly metrics review, investigating a sudden spike or… | Catalog only |
+| [`model-usage`](../skills/model-usage/) | Use CodexBar CLI local cost usage to summarize per-model usage for Codex | Catalog only |
+| [`model-usage-linux`](../skills/model-usage-linux/) | Track OpenClaw AI token usage and cost per model on Linux by parsing session JSONL files. Use when asked about: token usage, API cost, how much has been spent, which model was… | Catalog only |
 | [`multi-search-engine`](../skills/multi-search-engine/) | Description needs review; inspect source. | Catalog only |
 | [`news-aggregation`](../skills/news-aggregation/) | Aggregate and deduplicate recent news from multiple sources into concise topic summaries. | Catalog only |
 | [`news-predictor`](../skills/news-predictor/) | 你是Quant的新闻风控层。目标：在约120-180秒内完成新闻风险更新，输出人能直接看懂的结构化简报。 | Catalog only |
 | [`pharmgx-reporter`](../skills/pharmgx-reporter/) | Pharmacogenomic report from DTC genetic data (23andMe/AncestryDNA) | Catalog only |
 | [`qmd`](../skills/qmd/) | Local search/indexing CLI (BM25 + vectors + rerank) with MCP mode. | Catalog only |
 | [`ragflow-opencaio`](../skills/ragflow-opencaio/) | RAGFlow OpenCAIO 知识库文档上传与管理。当需要将文档上传到鲲界公司 OpenCAIO 知识库、检索知识库内容、或管理 RAGFlow 数据集时使用此 skill。 | Catalog only |
+| [`repro-enforcer`](../skills/repro-enforcer/) | Export any bioinformatics analysis as a reproducible bundle with Conda environment, Singularity container definition, and Nextflow pipeline. | Catalog only |
 | [`research-engineer`](../skills/research-engineer/) | An uncompromising Academic Research Engineer. Operates with absolute scientific rigor, objective criticism, and zero flair. Focuses on theoretical correctness, formal… | Catalog only |
 | [`risk-metrics-calculation`](../skills/risk-metrics-calculation/) | Calculate portfolio risk metrics including VaR, CVaR, Sharpe, Sortino, and drawdown analysis. Use when measuring portfolio risk, implementing risk limits, or building risk… | Catalog only |
-| [`roi-analysis`](../skills/roi-analysis/) | Use when calculating marketing ROI on Xiaohongshu, measuring campaign return on investment, analyzing cost per acquisition, evaluating marketing spend efficiency, or proving… | Catalog only |
 | [`saas-metrics-coach`](../skills/saas-metrics-coach/) | This skill should be used when the user asks to "calculate MRR", "analyze churn", "compute SaaS metrics", "do cohort retention analysis", "calculate LTV or CAC", "evaluate unit… | Catalog only |
 | [`search-first`](../skills/search-first/) | Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent. | Catalog only |
 | [`search-layer`](../skills/search-layer/) | 四源同级：Brave (`web_search`) + Exa + Tavily + Grok。按意图自动选策略、调权重、做合成。 | Catalog only |
@@ -318,21 +328,21 @@ Collect evidence, search sources, analyze data, and communicate findings.
 | [`session-logs`](../skills/session-logs/) | Search and analyze your own session logs (older/parent conversations) using jq. | Catalog only |
 | [`show-today`](../skills/show-today/) | Priority tasks for today — checks live sources (email, calendar) before showing stale CSV data | Catalog only |
 | [`skill-search-optimizer`](../skills/skill-search-optimizer/) | Optimize agent skills for discoverability on ClawdHub/MoltHub. Use when improving search ranking, writing descriptions for semantic search, understanding how the registry indexes… | Catalog only |
-| [`skillforge`](../skills/skillforge/) | Intelligent skill router and creator. Analyzes ANY input to recommend existing skills, improve them, or create new ones. Uses deep iterative analysis with 11 thinking models,… | Catalog only |
 | [`skills-search`](../skills/skills-search/) | Search skills.sh registry from CLI. Find and discover agent skills from the skills.sh ecosystem. | Catalog only |
+| [`soushen-hunter`](../skills/soushen-hunter/) | Description needs review; inspect source. | Catalog only |
 | [`sp-defense-in-depth`](../skills/sp-defense-in-depth/) | Validate at every layer data passes through to make bugs impossible | Portable required assignment · structure checked · COO |
 | [`sp-tracing-knowledge-lineages`](../skills/sp-tracing-knowledge-lineages/) | Understand how ideas evolved over time to find old solutions for new problems and avoid repeating past failures | Portable required assignment · structure checked · CRO |
 | [`startup-metrics-framework`](../skills/startup-metrics-framework/) | Description needs review; inspect source. | Portable required assignment · structure checked · CEO |
-| [`static-code-analysis`](../skills/static-code-analysis/) | Implement static code analysis with linters, formatters, and security scanners to catch bugs early. Use when enforcing code standards, detecting security vulnerabilities, or… | Catalog only |
 | [`synthetic-market-research`](../skills/synthetic-market-research/) | You are an expert market researcher who uses LLM-generated synthetic survey responses and Semantic Similarity Rating (SSR) to produce fast, cheap, dir | Catalog only |
 | [`tavily-search`](../skills/tavily-search/) | AI-optimized web search via Tavily API. Returns concise, relevant results for AI agents. | Portable required assignment · structure checked · CRO |
 | [`tech-selection-research`](../skills/tech-selection-research/) | Use when the user wants to research, compare, or evaluate a technology, framework, platform, or engineering tool for product R&amp;D decision-making, such as "调研 FastAPI", "技术选型",… | Catalog only |
 | [`telegram-scrape`](../skills/telegram-scrape/) | Search Telegram channels, read posts, ad contacts | Catalog only |
 | [`telegram-scraper-run`](../skills/telegram-scraper-run/) | Automatic Telegram scraping | Catalog only |
+| [`vcf-annotator`](../skills/vcf-annotator/) | Annotate VCF variants with VEP, ClinVar, gnomAD frequencies, and ancestry-aware context. Generates prioritised variant reports. | Catalog only |
 | [`web-scraping-automation`](../skills/web-scraping-automation/) | 自动化爬取网站数据和 API 接口。当用户需要抓取网页内容、调用 API、解析数据或创建爬虫脚本时使用此技能。 | Catalog only |
 | [`web-search`](../skills/web-search/) | 网络搜索与网页内容获取。当用户需要搜索互联网信息、获取网页内容、查找实时数据、进行 websearch 时使用此技能。支持多种搜索工具：WebFetch、Firecrawl skill、Tavily skill。 | Harness-specific assignment · generic installer skips · CDO, CEO, CRO |
-| [`wiki-qa`](../skills/wiki-qa/) | Answers questions about a code repository using source file analysis. Use when the user asks a question about how something works, wants to understand a component, or needs help… | Catalog only |
 | [`xlsx`](../skills/xlsx/) | Comprehensive spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization. When Claude needs to work with spreadsheets… | Catalog only |
+| [`youtube-knowledge-extractor`](../skills/youtube-knowledge-extractor/) | This skill performs deep analysis of YouTube videos through **both information channels** | Catalog only |
 
 <a id="security-privacy-legal"></a>
 ## 🛡️ Security, Privacy & Legal
@@ -341,7 +351,6 @@ Review security, privacy, compliance, permissions, contracts, and legal risk.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
-| [`accessibility-compliance-accessibility-audit`](../skills/accessibility-compliance-accessibility-audit/) | You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers, and provide… | Catalog only |
 | [`afrexai-compliance-audit`](../skills/afrexai-compliance-audit/) | Run internal compliance audits against major governance and security | Catalog only |
 | [`afrexai-compliance-engine`](../skills/afrexai-compliance-engine/) | Your AI compliance officer. Guides startups and scale-ups through SOC 2, ISO 27001, GDPR, HIPAA, and PCI DSS — from zero to audit-ready. No consultants needed. | Catalog only |
 | [`agentic-security-audit`](../skills/agentic-security-audit/) | Audit codebases, infrastructure, AND agentic AI systems for security issues. Covers traditional security (dependencies, secrets, OWASP web top 10, SSL/TLS, file permissions) PLUS… | Catalog only |
@@ -356,7 +365,6 @@ Review security, privacy, compliance, permissions, contracts, and legal risk.
 | [`employment-contract-templates`](../skills/employment-contract-templates/) | Create employment contracts, offer letters, and HR policy documents following legal best practices. Use when drafting employment agreements, creating HR policies, or… | Catalog only |
 | [`gdpr-compliance`](../skills/gdpr-compliance/) | Generate UK/EU GDPR compliance documents — privacy policies, cookie policies, DPIAs, ROPA, DSAR responses, data breach notifications, and consent forms. Use when a business needs… | Catalog only |
 | [`gdpr-dsgvo-expert`](../skills/gdpr-dsgvo-expert/) | GDPR and German DSGVO compliance automation. Scans codebases for privacy risks, generates DPIA documentation, tracks data subject rights requests. Use for GDPR compliance… | Portable required assignment · structure checked · CEO |
-| [`inference-optimizer`](../skills/inference-optimizer/) | Audit OpenClaw token usage, purge stale sessions, and optimize inference speed. Use when the user sends /optimize, /audit, asks to purge sessions, or wants a token/workspace audit. | Harness-specific assignment · generic installer skips · CTO |
 | [`key-rotation`](../skills/key-rotation/) | API key rotation manager — rotate provider keys across all agent workspaces | Catalog only |
 | [`legal-advisor`](../skills/legal-advisor/) | Draft privacy policies, terms of service, disclaimers, and legal notices. Creates GDPR-compliant texts, cookie policies, and data processing agreements. | Catalog only |
 | [`legal-cog`](../skills/legal-cog/) | Legal demands two things: frontier-level reasoning and precision document generation. CellCog delivers both. #1 on DeepResearch Bench (Feb 2026) for the intelligence that legal… | Catalog only |
@@ -368,13 +376,13 @@ Review security, privacy, compliance, permissions, contracts, and legal risk.
 | [`permission-manager`](../skills/permission-manager/) | 管理Claude Code的全局工具权限配置，自动将MCP命令或其他工具添加到allowedTools中，避免每次使用时都需要手动批准。工作流程：确认用户需要添加的命令 | Catalog only |
 | [`pre-push-security-scan`](../skills/pre-push-security-scan/) | 【铁律】Git push 前必须执行的安全扫描。防止 API keys、tokens、passwords、私钥等敏感信息被推送到远程仓库。适用于所有 git push、gh pr create、代码同步等场景。 | Catalog only |
 | [`privacy-compliance`](../skills/privacy-compliance/) | Multi-regulation privacy compliance navigator. Use for GDPR, CCPA, LGPD, POPIA, PIPEDA, PDPA, Privacy Act, PIPL, UK GDPR compliance assessments, DPA reviews, and data subject… | Catalog only |
+| [`provider-key-manager`](../skills/provider-key-manager/) | Provider key manager — rotate and sync API keys across multi-agent workspaces | Harness-specific assignment · generic installer skips · CTO |
 | [`security-audit`](../skills/security-audit/) | Comprehensive security auditing for Clawdbot deployments. Scans for exposed credentials, open ports, weak configs, and vulnerabilities. Auto-fix mode included. | Portable required assignment · structure checked · GOVERNOR, PE · review: system-change |
 | [`security-audit-toolkit`](../skills/security-audit-toolkit/) | Audit codebases and infrastructure for security issues. Use when scanning dependencies for vulnerabilities, detecting hardcoded secrets, checking OWASP top 10 issues, verifying… | Catalog only |
 | [`security-compliance-compliance-check`](../skills/security-compliance-compliance-check/) | You are a compliance expert specializing in regulatory requirements for software systems including GDPR, HIPAA, SOC2, PCI-DSS, and other industry standards. Perform compliance… | Catalog only |
 | [`self-improving-legal`](../skills/self-improving-legal/) | Captures clause risks, compliance gaps, precedent shifts, contract deviations, regulatory changes, and litigation exposure to enable continuous legal operations improvement. Use… | Catalog only |
 | [`skill-security-audit-v2`](../skills/skill-security-audit-v2/) | 已安装 Skills 的安全审计工具。用于批量审计 Skills 的安全性，包括命令执行、网络访问、文件访问、数据泄露、依赖风险、提示词越权和触发条件检查。适用于用户提供 Skills 列表和文件内容时进行安全扫描、护栏审查、提示词越权审查或强化建议。 | Catalog only |
 | [`skill-security-auditor`](../skills/skill-security-auditor/) | Description needs review; inspect source. | Catalog only |
-| [`vibe-code-auditor`](../skills/vibe-code-auditor/) | Audit rapidly generated or AI-produced code for structural flaws, fragility, and production risks. | Catalog only |
 
 <a id="product-design-ux"></a>
 ## 🎨 Product, Design & UX
@@ -383,25 +391,19 @@ Shape product requirements, interfaces, design systems, and user experience.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
+| [`accessibility-compliance-accessibility-audit`](../skills/accessibility-compliance-accessibility-audit/) | You are an accessibility expert specializing in WCAG compliance, inclusive design, and assistive technology compatibility. Conduct audits, identify barriers, and provide… | Catalog only |
 | [`afrexai-prd-engine`](../skills/afrexai-prd-engine/) | Complete product requirements methodology: from idea to spec to shipped feature. Not just a JSON template — a full system for writing PRDs that developers actually follow and… | Catalog only |
-| [`api-design`](../skills/api-design/) | REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs. | Portable required assignment · structure checked · CTO, PE |
-| [`api-design-patterns`](../skills/api-design-patterns/) | Comprehensive API design patterns covering REST, GraphQL, gRPC, versioning, authentication, and modern API best practices | Portable required assignment · structure checked · CTO |
 | [`canvas-design`](../skills/canvas-design/) | Create beautiful visual art in .png and .pdf documents using design philosophy. You should use this skill when the user asks to create a poster, piece of art, design, or other… | Catalog only |
-| [`cua-driver`](../skills/cua-driver/) | Drive a native GUI app (macOS, Windows, Linux) via the cua-driver CLI (default) or MCP server — snapshot its accessibility tree, click/type/scroll by element_index or pixel… | Catalog only |
 | [`design-thinking`](../skills/design-thinking/) | Design Thinking methodology for human-centered innovation. Covers the 5-phase IDEO/Stanford d.school approach (Empathize, Define, Ideate, Prototype, Test) with workshop… | Catalog only |
 | [`feature-requirements-clarification`](../skills/feature-requirements-clarification/) | 在任何创意性工作前必须使用：创建功能、构建组件、增加能力或修改行为。通过自然对话挖掘需求，产出高质量验收标准（AC），为后续 TDD 开发提供测试依据。当用户说'我想做一个XX功能'、'帮我想想XX怎么做'、'我需要加一个XX'等模糊需求描述时触发。 | Portable required assignment · structure checked · CEO |
 | [`figma-automation`](../skills/figma-automation/) | Automate Figma tasks via Rube MCP (Composio): files, components, design tokens, comments, exports. Always search tools first for current schemas. | Catalog only |
 | [`figma-implement-design`](../skills/figma-implement-design/) | Description needs review; inspect source. | Catalog only |
 | [`frontend-design-ultimate`](../skills/frontend-design-ultimate/) | Create distinctive, production-grade static sites with React, Tailwind CSS, and shadcn/ui — no mockups needed. Generates bold, memorable designs from plain text requirements with… | Harness-specific assignment · generic installer skips · CPO |
 | [`market-churn-prevention`](../skills/market-churn-prevention/) | Reduce voluntary and involuntary churn through cancel flow design, save offers, exit surveys, and dunning sequences. Use when designing or optimizing a cancel flow, building save… | Catalog only |
-| [`observability-designer`](../skills/observability-designer/) | Design production observability strategies covering SLI/SLOs, metrics, | Catalog only |
 | [`poster-design-generation`](../skills/poster-design-generation/) | Generate professional poster designs using each::sense AI. Create movie posters, event posters, motivational posters, product launch visuals, vintage designs, travel posters, and… | Catalog only |
 | [`prd-development`](../skills/prd-development/) | Guide product managers through structured PRD (Product Requirements Document) creation by orchestrating problem framing, user research synthesis, solution definition, and success… | Portable required assignment · structure checked · CEO, CPO |
 | [`prd-generator`](../skills/prd-generator/) | 专业级产品需求文档（PRD）生成器。自动生成包含 UML 用例模型、详细用例规格说明、数据字典、交互设计、UI 规范的完整 PRD。 Use when: 用户提到写PRD、写产品需求文档、产品设计、产品规划、新功能需求分析、用例分析、用例建模时触发。 NOT for: 已有完整需求文档的润色、代码生成、技术架构设计、数据分析报告。 | Catalog only |
-| [`prioritization-funnel`](../skills/prioritization-funnel/) | Evaluate and prioritize opportunities through a structured filtering process. Use for resource allocation, strategic decision support, and project management. | Portable required assignment · structure checked · CEO |
 | [`roadmap-planning`](../skills/roadmap-planning/) | Guide product managers through strategic roadmap planning by orchestrating prioritization, epic definition, stakeholder alignment, and release sequencing skills into a structured… | Portable required assignment · structure checked · CEO |
-| [`senior-architect`](../skills/senior-architect/) | This skill should be used when the user asks to "design system architecture", "evaluate microservices vs monolith", "create architecture diagrams", "analyze dependencies",… | Catalog only |
-| [`software-architecture-design`](../skills/software-architecture-design/) | Designs system structure across monolith/microservices/serverless. Use when structuring systems, scaling, decomposing monoliths, or choosing patterns. | Catalog only |
 | [`style-guide-generator`](../skills/style-guide-generator/) | Generate comprehensive website style guides and design systems from URLs, screenshots, and existing documentation. Use this skill when users ask to create a style guide, design… | Catalog only |
 | [`ui-ux-pro-max`](../skills/ui-ux-pro-max/) | UI/UX design intelligence. 50 styles, 21 palettes, 50 font pairings, 20 charts, 9 stacks (React, Next.js, Vue, Svelte, SwiftUI, React Native, Flutter, Tailwind, shadcn/ui).… | Catalog only |
 | [`uml-diagram-design`](../skills/uml-diagram-design/) | UML 图表设计和绘制。当用户需要创建系统架构图、类图、时序图、用例图或其他 UML 图表时使用此技能。 | Catalog only |
@@ -417,12 +419,8 @@ Acquire audiences through positioning, campaigns, search, ads, and social growth
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
-| [`activecampaign-automation`](../skills/activecampaign-automation/) | Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas. | Catalog only |
 | [`ads`](../skills/ads/) | Comprehensive ad account analysis across all major platforms (Google, Meta | Portable required assignment · structure checked · CEO |
 | [`ads-agent`](../skills/ads-agent/) | AI-агент для управления Facebook рекламой. Вызывай для анализа, оптимизации, создания кампаний и отчётов. | Catalog only |
-| [`ai-marketing-videos`](../skills/ai-marketing-videos/) | Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: product demos,… | Portable required assignment · structure checked · CCO |
-| [`ai-viral-team-script-writing`](../skills/ai-viral-team-script-writing/) | 脚本创作 - 短视频脚本撰写与分镜设计 职责：根据爆款模板生产内容、设计黄金3秒开头方案（3种以上）、撰写分镜脚本（包含镜头语言/场景氛围/角色动作/台词/BGM）、设计槽点埋梗与情绪钩子、规划结尾引导、自动推荐Vidu视频生成配置（模型版本/生成方式/时长/比例）、确保人物形象一致性、向视频生成(Leo)传递完整的分镜信息 适用场景：(1)… | Catalog only |
-| [`ai-viral-team-video-generation`](../skills/ai-viral-team-video-generation/) | 视频生成 - AI视频生成与后期剪辑制作 职责：调用Vidu生成视频、模型选择、Prompt调优、视频拼接、质量检测 | Catalog only |
 | [`apify-competitor-intelligence`](../skills/apify-competitor-intelligence/) | Analyze competitor strategies, content, pricing, ads, and market positioning across Google Maps, Booking.com, Facebook, Instagram, YouTube, and TikTok. | Catalog only |
 | [`b2b-saas-marketing`](../skills/b2b-saas-marketing/) | Эксперт по B2B SaaS маркетингу. Используй для стратегий генерации спроса, growth-маркетинга, PLG, расчёта CAC/LTV, оптимизации воронки и маркетинговых операций. | Catalog only |
 | [`brand-guidelines`](../skills/brand-guidelines/) | Applies Anthropic's official brand colors and typography to any sort of artifact that may benefit from having Anthropic's look-and-feel. Use it when brand colors or style… | Catalog only |
@@ -448,12 +446,12 @@ Acquire audiences through positioning, campaigns, search, ads, and social growth
 | [`influencer-analyzer`](../skills/influencer-analyzer/) | 分析抖音/小红书/B站博主的主页、内容风格、爆款规律。可根据链接、博主名、主题三种方式触发。输出结构化的博主画像和内容风格报告，为内容创作者提供可复制的对标参考。触发词：分析博主、分析网红、对标博主、博主风格、起号分析、博主推荐。 | Catalog only |
 | [`marketing-ideas`](../skills/marketing-ideas/) | Provide proven marketing strategies and growth ideas for SaaS and software products, prioritized using a marketing feasibility scoring system. | Catalog only |
 | [`marketing-psychology`](../skills/marketing-psychology/) | When the user wants to apply psychological principles, mental models, or behavioral science to marketing. Also use when the user mentions 'psychology,' 'mental models,'… | Catalog only |
-| [`microservices-patterns`](../skills/microservices-patterns/) | Comprehensive microservices patterns skill covering service mesh, traffic management, circuit breakers, resilience patterns, Istio, and production microservices architecture | Catalog only |
 | [`moltbook-interact`](../skills/moltbook-interact/) | Interact with Moltbook social network for AI agents. Post, reply, browse, and analyze engagement. Use when the user wants to engage with Moltbook, check their feed, reply to… | Catalog only |
 | [`paid-ads`](../skills/paid-ads/) | When the user wants help with paid advertising campaigns on Google Ads, Meta (Facebook/Instagram), LinkedIn, Twitter/X, or other ad platforms. Also use when the user mentions… | Catalog only |
 | [`pm-competitive-teardown`](../skills/pm-competitive-teardown/) | Run structured competitive teardowns using pricing, reviews, positioning, | Catalog only |
 | [`postbridge-social-growth`](../skills/postbridge-social-growth/) | Organic social media growth coach using the Post Bridge methodology (500M+ views, 132K+ downloads, $33K+ revenue). Act as a personalized growth coach for apps, products, and… | Catalog only |
 | [`programmatic-seo`](../skills/programmatic-seo/) | You are an expert in **programmatic SEO strategy**—designing systems that generate | Catalog only |
+| [`roi-analysis`](../skills/roi-analysis/) | Use when calculating marketing ROI on Xiaohongshu, measuring campaign return on investment, analyzing cost per acquisition, evaluating marketing spend efficiency, or proving… | Catalog only |
 | [`seo-audit`](../skills/seo-audit/) | Diagnose and audit SEO issues affecting crawlability, indexation, rankings, and organic performance. Use when the user asks for an SEO audit, technical SEO review, ranking… | Portable required assignment · structure checked · CMO |
 | [`seo-competitor-analysis`](../skills/seo-competitor-analysis/) | Deep SEO competitor analysis — keyword mapping, backlink profiling, content strategy audit, SERP share analysis, and technical SEO comparison. Use when user asks to 'analyze… | Catalog only |
 | [`seo-geo`](../skills/seo-geo/) | SEO &amp; GEO (Generative Engine Optimization) for websites. Analyze keywords, generate schema markup, optimize for AI search engines (ChatGPT, Perplexity, Gemini, Copilot, Claude)… | Catalog only |
@@ -477,7 +475,10 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
 | [`ai-image-generation`](../skills/ai-image-generation/) | Generate images using ModelScope Z-Image-Turbo API. Use when user asks to generate, create, or make images, pictures, or illustrations. | Catalog only |
+| [`ai-marketing-videos`](../skills/ai-marketing-videos/) | Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: product demos,… | Portable required assignment · structure checked · CCO |
 | [`ai-video-gen`](../skills/ai-video-gen/) | End-to-end AI video generation - create videos from text prompts using image generation, video synthesis, voice-over, and editing. Supports OpenAI DALL-E, Replicate models,… | Catalog only |
+| [`ai-viral-team-script-writing`](../skills/ai-viral-team-script-writing/) | 脚本创作 - 短视频脚本撰写与分镜设计 职责：根据爆款模板生产内容、设计黄金3秒开头方案（3种以上）、撰写分镜脚本（包含镜头语言/场景氛围/角色动作/台词/BGM）、设计槽点埋梗与情绪钩子、规划结尾引导、自动推荐Vidu视频生成配置（模型版本/生成方式/时长/比例）、确保人物形象一致性、向视频生成(Leo)传递完整的分镜信息 适用场景：(1)… | Catalog only |
+| [`ai-viral-team-video-generation`](../skills/ai-viral-team-video-generation/) | 视频生成 - AI视频生成与后期剪辑制作 职责：调用Vidu生成视频、模型选择、Prompt调优、视频拼接、质量检测 | Catalog only |
 | [`arch-video-cut`](../skills/arch-video-cut/) | Automatic architecture video editing workflow with self-learning preferences | Catalog only |
 | [`article-material-collect`](../skills/article-material-collect/) | 上层编排 Skill，通过 **Brave Search 发现 → 智能选择浏览器截图** 完成结构化素材采集。 | Catalog only |
 | [`article-to-infographic`](../skills/article-to-infographic/) | 长文/测评文章 → 知识视觉笔记套图（3-5张）。自动提炼核心逻辑、规划分镜、生成高阶图像Prompt（4模块结构）。支持手写笔记/思维导图/架构图/对比矩阵四种风格。Use when: 文章转知识笔记、知识笔记图片、思维导图、视觉笔记、长文转图、知识卡片、文章可视化、article to infographic、knowledge… | Catalog only |
@@ -499,9 +500,9 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | [`copy-editing`](../skills/copy-editing/) | When the user wants to edit, review, or improve existing marketing copy. Also use when the user mentions 'edit this copy,' 'review my copy,' 'copy feedback,' 'proofread,' 'polish… | Catalog only |
 | [`copywriting`](../skills/copywriting/) | Write, rewrite, or improve marketing copy for homepages, landing pages, pricing pages, feature pages, and about pages. Use when the user needs conversion-focused copy with clear… | Catalog only |
 | [`cross-platform-poster`](../skills/cross-platform-poster/) | Publish one piece of content across MoltX, Twitter/X, Discord, and Telegram | Catalog only |
+| [`doc-coauthoring`](../skills/doc-coauthoring/) | Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar… | Catalog only |
 | [`docx`](../skills/docx/) | Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. When Claude needs to work with… | Catalog only |
 | [`docx-perfect`](../skills/docx-perfect/) | Word文档美化与格式化专家。专门用于将Word文档中的文本内容转换为专业表格格式，应用一致的样式（深蓝色表头、斑马纹数据行、边框），支持版本化迭代管理。当用户需要美化Word文档、创建专业表格、或递增式优化文档章节时使用此技能。 | Catalog only |
-| [`evomap`](../skills/evomap/) | Connect to the EvoMap collaborative evolution marketplace. Publish Gene+Capsule bundles, fetch promoted assets, claim bounty tasks, and earn credits via the GEP-A2A protocol. Use… | Catalog only |
 | [`ffmpeg-video-editor`](../skills/ffmpeg-video-editor/) | Generate FFmpeg commands from natural language video editing requests - cut, trim, convert, compress, change aspect ratio, extract audio, and more. | Catalog only |
 | [`frontend-slides`](../skills/frontend-slides/) | Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or… | Catalog only |
 | [`heygen-avatar-lite`](../skills/heygen-avatar-lite/) | Create AI digital human videos with HeyGen API. Free starter guide. | Catalog only |
@@ -509,6 +510,8 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | [`image-enhancer`](../skills/image-enhancer/) | Improves the quality of images, especially screenshots, by enhancing resolution, sharpness, and clarity. Perfect for preparing images for presentations, documentation, or social… | Catalog only |
 | [`image-scraper`](../skills/image-scraper/) | Scrape and download all images from a given URL. Takes a URL, extracts image URLs from the page, and downloads them. Uses python3/curl as primary method, falls back to browser… | Catalog only |
 | [`image-vision`](../skills/image-vision/) | Image analysis using multimodal vision models. Use when user needs to: (1) Describe what's in an image, (2) Extract text from images (OCR), (3) Analyze visual content, (4)… | Catalog only |
+| [`internal-comms`](../skills/internal-comms/) | A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write… | Catalog only |
+| [`jimeng-storyboard`](../skills/jimeng-storyboard/) | 将口播视频剧本拆解为即梦AI数字人平台的分镜头脚本。输出格式为每个镜头的角色说（台词）和动作描述（镜头语言/数字人动作），适配即梦 jimeng.jianying.com 数字人视频生成界面。触发场景：用户需要生成口播视频分镜、数字人视频剧本拆解、即梦分镜脚本、短视频口播脚本分镜、数字人台词加动作拆分。 | Portable required assignment · structure checked · CCO |
 | [`longform-visual-notes`](../skills/longform-visual-notes/) | MediaClaw内容生产的核心配图skill。当有长篇文章需要转化为可传播的视觉笔记时调用。 | Catalog only |
 | [`lyrics-video-sync`](../skills/lyrics-video-sync/) | 歌词-视频精准匹配引擎。将MP3中的歌词片段按时间轴精准匹配到对应视频clip，支持歌词提取、时间轴对齐、情绪映射、字幕烧录、音频分段混合。触发词：歌词匹配、lyrics sync、歌词卡点、音频对齐、字幕视频、lyrics video、歌词视频、音乐视频字幕 | Catalog only |
 | [`mv-generator`](../skills/mv-generator/) | MediaClaw 内置的音乐视频端到端生成技能。 | Catalog only |
@@ -523,6 +526,7 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | [`relay-video-gen`](../skills/relay-video-gen/) | Multi-provider video generation with async polling and automatic model fallback | Catalog only |
 | [`seo-content-writer`](../skills/seo-content-writer/) | Write SEO blog posts, articles, landing pages with keyword integration, header optimization, and snippet targeting. SEO文章写作/内容优化 | Catalog only |
 | [`showcase-video-builder`](../skills/showcase-video-builder/) | Build polished showcase and demo videos from screenshots, avatars, and text overlays using ffmpeg. Use when creating demo reels, hackathon presentations, product walkthroughs, or… | Catalog only |
+| [`slidev-agent-skill`](../skills/slidev-agent-skill/) | Create, edit, theme, build, and export Slidev presentations using a script-first workflow with detailed local references. Use when working on Slidev decks, themes, layouts,… | Catalog only |
 | [`sp-writing-plans`](../skills/sp-writing-plans/) | Create detailed implementation plans with bite-sized tasks for engineers with zero codebase context | Catalog only |
 | [`summarize`](../skills/summarize/) | Summarize URLs or files with the summarize CLI (web, PDFs, images, audio, YouTube). | Catalog only |
 | [`suno-create`](../skills/suno-create/) | Create songs on Suno.com with custom lyrics and style. Use when user wants to (1) generate AI music on Suno with specific lyrics or theme, (2) create a song in a specific… | Catalog only |
@@ -549,11 +553,9 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | [`wechat-article-writer`](../skills/wechat-article-writer/) | 公众号文章自动化写作流程。支持资料搜索、文章撰写、爆款标题生成、排版优化。当用户提到写公众号、微信文章、自媒体写作、爆款文章、内容创作时使用此 | Catalog only |
 | [`wiki-page-writer`](../skills/wiki-page-writer/) | Generates rich technical documentation pages with dark-mode Mermaid diagrams, source code citations, and first-principles depth. Use when writing documentation, generating wiki… | Catalog only |
 | [`writing-plans`](../skills/writing-plans/) | Use when you have a spec or requirements for a multi-step task, before touching code | Catalog only |
-| [`writing-skills`](../skills/writing-skills/) | Use when creating new skills, editing existing skills, or verifying skills work before deployment | Portable required assignment · structure checked · CEO |
 | [`x-articles`](../skills/x-articles/) | Publish viral X (Twitter) Articles with AI. Long-form content that gets engagement. Proven hook patterns, browser automation. Works with Claude, Cursor, OpenClaw. | Portable required assignment · structure checked · CCO |
 | [`youtube-automation`](../skills/youtube-automation/) | Automate YouTube tasks via Rube MCP (Composio): upload videos, manage playlists, search content, get analytics, and handle comments. Always search tools first for current schemas. | Catalog only |
 | [`youtube-factory`](../skills/youtube-factory/) | Description needs review; inspect source. | Catalog only |
-| [`youtube-knowledge-extractor`](../skills/youtube-knowledge-extractor/) | This skill performs deep analysis of YouTube videos through **both information channels** | Catalog only |
 
 <a id="sales-crm-customer-success"></a>
 ## 🤝 Sales, CRM & Customer Success
@@ -564,6 +566,7 @@ Find, win, onboard, support, and retain customers with accountable workflows.
 |---|---|---|
 | [`abm-sales-enablement`](../skills/abm-sales-enablement/) | When the user wants to create sales collateral, pitch decks, one-pagers, objection handling docs, or demo scripts. Also use when the user mentions 'sales deck,' 'pitch deck,'… | Catalog only |
 | [`account-executive`](../skills/account-executive/) | Expert sales execution covering pipeline management, discovery, demos, negotiation, and deal closing. Use when qualifying opportunities, running MEDDIC discovery, building… | Catalog only |
+| [`activecampaign-automation`](../skills/activecampaign-automation/) | Automate ActiveCampaign tasks via Rube MCP (Composio): manage contacts, tags, list subscriptions, automation enrollment, and tasks. Always search tools first for current schemas. | Catalog only |
 | [`add-lead`](../skills/add-lead/) | Add company/person/relationship to CRM | Catalog only |
 | [`after-sales`](../skills/after-sales/) | Use when managing post-purchase experience, building customer loyalty, or increasing repeat purchases | Catalog only |
 | [`change-review`](../skills/change-review/) | Validate CRM/PM changes before PR | Catalog only |
@@ -584,8 +587,10 @@ Find, win, onboard, support, and retain customers with accountable workflows.
 | [`hubspot-automation`](../skills/hubspot-automation/) | Automate HubSpot CRM operations (contacts, companies, deals, tickets, properties) via Rube MCP using Composio integration. | Catalog only |
 | [`intercom-automation`](../skills/intercom-automation/) | Automate Intercom tasks via Rube MCP (Composio): conversations, contacts, companies, segments, admins. Always search tools first for current schemas. | Catalog only |
 | [`lead-intelligence`](../skills/lead-intelligence/) | AI-native lead intelligence and outreach pipeline. Replaces Apollo, Clay, and ZoomInfo with agent-powered signal scoring, mutual ranking, warm path discovery, source-derived… | Portable required assignment · structure checked · CEO |
+| [`linkedin-cdp`](../skills/linkedin-cdp/) | LinkedIn CDP: Input-only automation (mouse, keyboard, screenshots). Zero DOM access. | Catalog only |
 | [`mass-outreach`](../skills/mass-outreach/) | Multi-channel outreach via Telegram/Email/WhatsApp | Catalog only |
 | [`negotiation`](../skills/negotiation/) | Tactical negotiation framework based on Chris Voss's "Never Split the Difference." Use when preparing for negotiations, during live negotiation scenarios, analyzing counterpart… | Catalog only |
+| [`outbound-email-strategy`](../skills/outbound-email-strategy/) | Comprehensive outbound email strategy skill for cold outreach, email sequences, and multi-channel campaigns. Use when writing cold emails, creating outreach sequences, optimizing… | Catalog only |
 | [`outbound-optimizer`](../skills/outbound-optimizer/) | Use this skill when users need to improve cold outreach, optimize cold emails or DMs, increase response rates, or turn outbound from spam into revenue. Activates for cold… | Catalog only |
 | [`pipedrive-automation`](../skills/pipedrive-automation/) | Automate Pipedrive CRM operations including deals, contacts, organizations, activities, notes, and pipeline management via Rube MCP (Composio). Always search tools first for… | Catalog only |
 | [`query-leads`](../skills/query-leads/) | Search, filter, reports on CRM data | Catalog only |
@@ -608,6 +613,7 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 |---|---|---|
 | [`5minbtc`](../skills/5minbtc/) | BTC 5分钟K线实时方向预测。v5.7.3引擎HTTP并行化(4路ThreadPoolExecutor→~3s,原12-18s)。半K线策略——第2分钟执行(progress~40%)，12正交因子含half_body实体延续+momentum/decel冲突降权+V反转+放量突破+Chainlink价格对齐+Platt… | Catalog only |
 | [`a-fund-monitor`](../skills/a-fund-monitor/) | A股基金净值监控：盘中实时估值 + 盘后实际净值，定时推送到 Telegram。 | Catalog only |
+| [`a-share-analysis`](../skills/a-share-analysis/) | 此Skill实现了三层分析体系： 1. 情报采集层 — 7路并发多源新闻采集，自动匹配板块和个股 2. 盘面阅读层 — 美股映射 + 大盘多空判断 + 实时主线(&gt;9%题材分析) 3. 个股精选层 — 产业逻辑 + 形态8分类 + 盘口分析 + 题材排名 + 综合评分 4. 原始新闻浏览 (news.py) — 分类展示影响股票的新闻，源信息不做任何修改 | Catalog only |
 | [`afrexai-personal-finance`](../skills/afrexai-personal-finance/) | Complete personal finance system — budgeting, debt payoff, investing, tax optimization, net worth tracking, and financial independence planning. Use when managing money, building… | Catalog only |
 | [`ai-trader-arena`](../skills/ai-trader-arena/) | AI trading arena, 模型竞技, 多模型交易, trading competition, historical replay, MCP trading, ai4trade | Catalog only |
 | [`alpha101`](../skills/alpha101/) | WorldQuant 101 Formulaic Alphas — 因子计算、IC测试、回测一体化工具包。 基于Kakushadze (2015) 论文，提供101个价量/波动率/相关性因子的Python/Pandas实现。 Use when: "alpha101", "101因子", "formulaic alphas", "因子回测",… | Catalog only |
@@ -617,10 +623,11 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 | [`bankr`](../skills/bankr/) | AI-powered crypto trading agent and LLM gateway via natural language. Use when the user wants to trade crypto, check portfolio balances, view token prices, transfer crypto,… | Catalog only |
 | [`bankr-signals`](../skills/bankr-signals/) | Transaction-verified trading signals on Base blockchain. Agents publish trades | Catalog only |
 | [`billing-automation`](../skills/billing-automation/) | Build automated billing systems for recurring payments, invoicing, subscription lifecycle, and dunning management. Use when implementing subscription billing, automating… | Catalog only |
+| [`binance-trending`](../skills/binance-trending/) | Description needs review; inspect source. | Catalog only |
 | [`bookkeeping-basics`](../skills/bookkeeping-basics/) | Set up and maintain basic bookkeeping for a solopreneur business. Use when tracking income and expenses, preparing for taxes, managing invoices and receipts, understanding cash… | Catalog only |
 | [`btc-5min-scalper`](../skills/btc-5min-scalper/) | BTC 5-minute Up/Down paper trading on Polymarket. Scans Binance 1m candles for momentum/mean-reversion/volume signals, makes virtual trades on Polymarket 5-min markets, tracks… | Catalog only |
 | [`clanker`](../skills/clanker/) | Plan and review ERC20 deployment with the Clanker SDK. Use for token configuration, vesting, airdrops, rewards, metadata, and transaction preparation on supported EVM chains. | Catalog only · review: external-write, financial-action |
-| [`cost-optimization`](../skills/cost-optimization/) | Optimize cloud costs through resource rightsizing, tagging strategies, reserved instances, and spending analysis. Use when reducing cloud expenses, analyzing infrastructure… | Portable required assignment · structure checked · COO |
+| [`company-analyzer`](../skills/company-analyzer/) | Description needs review; inspect source. | Catalog only |
 | [`crypto-bd-agent`](../skills/crypto-bd-agent/) | This skill teaches AI agents systematic crypto business development: discover | Catalog only |
 | [`crypto-derivatives-tracker`](../skills/crypto-derivatives-tracker/) | Comprehensive derivatives market analysis across centralized and decentralized exchanges. This skill aggregates funding rates, open interest, liquidat | Catalog only |
 | [`crypto-hunt`](../skills/crypto-hunt/) | 版本: 6.0 \| 日期: 2026-05-03 \| 风格: 稳健 + 风投双层 | Catalog only |
@@ -628,6 +635,7 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 | [`crypto-portfolio-tracker`](../skills/crypto-portfolio-tracker/) | Description needs review; inspect source. | Catalog only |
 | [`crypto-signal-generator`](../skills/crypto-signal-generator/) | Multi-indicator signal generation system that analyzes price action using 7 technical indicators and produces composite BUY/SELL signals with confiden | Catalog only |
 | [`daily-portfolio`](../skills/daily-portfolio/) | Description needs review; inspect source. | Catalog only |
+| [`daily-reflection`](../skills/daily-reflection/) | Description needs review; inspect source. | Catalog only |
 | [`defi-risk-assessment`](../skills/defi-risk-assessment/) | Framework for evaluating DeFi protocol risk — smart contract audits, TVL analysis, governance structure, oracle dependencies, and token economics. Use when helping users assess… | Catalog only |
 | [`elon-tweets`](../skills/elon-tweets/) | 你是Quant。独立策略，不受全局新闻风险等级约束。 先用 scanelonmarkets.py 自动发现活跃盘，按结算时间决定分析深度。 | Catalog only |
 | [`equity`](../skills/equity/) | Model cap tables, dilution scenarios, and vesting schedules for startups. Use when planning fundraising, pricing options, or tracking equity. | Catalog only |
@@ -655,18 +663,16 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 | [`polymarket-profit`](../skills/polymarket-profit/) | 围绕 Polymarket 预测市场执行小资金量化交易与收益跟踪策略。 | Harness-specific assignment · generic installer skips · CQO |
 | [`portfolio-manager`](../skills/portfolio-manager/) | Comprehensive portfolio analysis using Alpaca MCP Server integration to fetch holdings and positions, then analyze asset allocation, risk metrics, individual stock positions,… | Catalog only |
 | [`position-monitor`](../skills/position-monitor/) | 你是Quant。每小时检查持仓，执行止盈止损/Claim结算。 | Catalog only |
-| [`quality-convergence-engine`](../skills/quality-convergence-engine/) | Multi-dimensional Quality Acceptance and Problem Convergence Engine - Deeply deconstruct requirements, eliminate extreme defects, define absolutely objective acceptance and… | Portable required assignment · structure checked · GOVERNOR |
 | [`quant-analyst`](../skills/quant-analyst/) | Build financial models, backtest trading strategies, and analyze market data. Implements risk metrics, portfolio optimization, and statistical arbitrage. Use PROACTIVELY for… | Catalog only |
 | [`relayer-trade`](../skills/relayer-trade/) | Polymarket链上交易skill。通过Relayer v2 API绕过CLOB geo-block，执行buy(split)/sell(merge+transfer)/redeem/claim。零CLOB依赖，纯链上gasless。Triggers: 'relayer buy', 'relayer sell', 'relayer claim',… | Catalog only · review: credentials, external-write, financial-action |
-| [`repro-enforcer`](../skills/repro-enforcer/) | Export any bioinformatics analysis as a reproducible bundle with Conda environment, Singularity container definition, and Nextflow pipeline. | Catalog only |
 | [`senior-pm`](../skills/senior-pm/) | Senior Project Manager for enterprise software, SaaS, and digital transformation projects. Specializes in portfolio management, quantitative risk analysis, resource optimization,… | Catalog only |
-| [`setting-okrs-goals`](../skills/setting-okrs-goals/) | Help users set effective OKRs and goals. Use when someone is creating quarterly objectives, defining key results, setting team goals, planning annual targets, or struggling with… | Catalog only |
 | [`sp-scale-game`](../skills/sp-scale-game/) | Test at extremes (1000x bigger/smaller, instant/year-long) to expose fundamental truths hidden at normal scales | Catalog only |
 | [`sperax-defi-guide`](../skills/sperax-defi-guide/) | Comprehensive guide to DeFi yield farming strategies — lending, liquidity provision, auto-compounding, stablecoin yield, and risk management. Use when helping users find yield,… | Catalog only |
 | [`startup-financial-modeling`](../skills/startup-financial-modeling/) | Use when the user asks to create financial projections, build a financial model, forecast revenue, calculate burn rate, estimate runway, model cash flow, or do 3-5 year startup… | Catalog only |
 | [`stripe-automation`](../skills/stripe-automation/) | Automate Stripe tasks via Rube MCP (Composio): customers, charges, subscriptions, invoices, products, refunds. Always search tools first for current schemas. | Catalog only |
 | [`stripe-webhook`](../skills/stripe-webhook/) | Manage AI Kitchen Pro Stripe webhook — deploy, test, switch test/prod, view logs | Catalog only |
 | [`technical-analysis`](../skills/technical-analysis/) | Master of price action, chart patterns, and technical indicators - combining classical Wyckoff/Dow theory with modern quantitative validation for edge identificationUse when… | Catalog only |
+| [`thinking-simon`](../skills/thinking-simon/) | 蒸馏 Jim Simons（文艺复兴科技）思维模式的实用框架：量化思维、大量小交易、数学即优势 | Catalog only |
 | [`trade-prediction-markets`](../skills/trade-prediction-markets/) | Build and test Polymarket prediction market trading strategies for YES/NO token trading. Provides 6 tools: get_all_prediction_events (browse markets, $0.001),… | Portable required assignment · structure checked · CQO |
 | [`trading-strategy-backtester`](../skills/trading-strategy-backtester/) | Validate trading strategies against historical data before risking real capital. This skill provides a complete backtesting framework with 8 built-in | Catalog only |
 | [`whale-alert-monitor`](../skills/whale-alert-monitor/) | Track large cryptocurrency transactions and whale wallet movements across multiple blockchains. Monitor exchange inflows/outflows, manage watchlists, | Catalog only |
@@ -680,24 +686,22 @@ Plan work, make decisions, manage teams, and improve operating systems.
 |---|---|---|
 | [`blue-blood-culture-codifier`](../skills/blue-blood-culture-codifier/) | 将"蓝血文化"从抽象理念具象化为可传播的故事、仪式、符号和内部语言，让每个成员（硅基/碳基）都能感知、认同并践行。 | Catalog only |
 | [`brainstorming`](../skills/brainstorming/) | You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design… | Portable required assignment · structure checked · CEO |
-| [`business-analyst`](../skills/business-analyst/) | Build KPI frameworks, predictive models, real-time dashboards, and strategic recommendations using modern BI tools and AI-powered analytics. Use when the user needs business… | Catalog only |
 | [`ceo-delegation`](../skills/ceo-delegation/) | CEO式任务委派工作流程。当收到任何任务时使用此流程：不亲自执行，而是派发子代理执行、监控进度、汇报、验收。适用于需要高效并行处理多任务的场景。 | Catalog only |
-| [`company-analyzer`](../skills/company-analyzer/) | Description needs review; inspect source. | Catalog only |
 | [`company-wiki`](../skills/company-wiki/) | Company knowledge base — domains, services, infrastructure, accounts, credentials locations, architecture decisions | Catalog only |
 | [`create-project`](../skills/create-project/) | Create new project with breakdown | Catalog only |
 | [`cross-team-comm`](../skills/cross-team-comm/) | 通过 Tailscale、SSH、Gateway API 与 sessions_send 实现跨团队、跨实例的 OpenClaw 协作通信。 | Catalog only |
 | [`cto-advisor`](../skills/cto-advisor/) | Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Includes tech debt analyzer, team scaling calculator, engineering metrics… | Catalog only |
 | [`daily-briefing`](../skills/daily-briefing/) | Morning briefing: tasks + email + follow-ups | Catalog only |
-| [`daily-reflection`](../skills/daily-reflection/) | Description needs review; inspect source. | Catalog only |
-| [`daily-trending`](../skills/daily-trending/) | 获取今日热榜，从tophub.today抓取各平台热搜榜单。当用户询问"今天有什么热搜"、"热榜"、"微博热搜"时触发。 | Catalog only |
 | [`delegation`](../skills/delegation/) | Architecture-first workflow for delegating complex projects to AI coding agents. Ensures code fits the system before it's written. | Catalog only |
 | [`first-principles-thinking`](../skills/first-principles-thinking/) | Socratic coach for breaking down problems to fundamental truths. Use when users want to think through a problem deeply, challenge assumptions, or find innovative solutions.… | Catalog only |
 | [`linkedin-inbound-run`](../skills/linkedin-inbound-run/) | Automatic inbound LinkedIn message processing | Catalog only |
+| [`market-nightly-evolution`](../skills/market-nightly-evolution/) | Nightly market evolution report — overnight market analysis and strategy prep | Catalog only |
 | [`meeting-insights-analyzer`](../skills/meeting-insights-analyzer/) | Analyzes meeting transcripts and recordings to uncover behavioral patterns, communication insights, and actionable feedback. Identifies when you avoid conflict, use filler words,… | Portable required assignment · structure checked · CEO |
 | [`meeting-notes`](../skills/meeting-notes/) | Description needs review; inspect source. | Catalog only |
 | [`okr`](../skills/okr/) | 基于流行 OKR 体系管理智能体目标（O）与关键结果（KR）。当用户提到目标管理、季度计划、OKR、关键结果、复盘、评分、经验沉淀时使用，并将信息维护到 memory/okr.md。 | Harness-specific assignment · generic installer skips · CEO, GOVERNOR |
 | [`pm-done`](../skills/pm-done/) | Mark task done + schedule follow-up | Catalog only |
 | [`pricing-strategy`](../skills/pricing-strategy/) | When the user wants help with pricing decisions, packaging, or monetization strategy. Also use when the user mentions 'pricing,' 'pricing tiers,' 'freemium,' 'free trial,'… | Catalog only |
+| [`prioritization-funnel`](../skills/prioritization-funnel/) | Evaluate and prioritize opportunities through a structured filtering process. Use for resource allocation, strategic decision support, and project management. | Portable required assignment · structure checked · CEO |
 | [`process-analyst`](../skills/process-analyst/) | Process analysis, gap finding, human dialogue, spec generation | Catalog only |
 | [`project-autoloop`](../skills/project-autoloop/) | Project autoloop engine — cron-driven automated project iteration with CEO coordination | Catalog only |
 | [`project-management`](../skills/project-management/) | 项目管理和产品需求分析。当用户需要制定项目计划、编写 PRD 文档、管理任务或进行需求分析时使用此技能。 | Catalog only |
@@ -705,6 +709,8 @@ Plan work, make decisions, manage teams, and improve operating systems.
 | [`ralph-ceo-loop`](../skills/ralph-ceo-loop/) | 以持续计划-执行-检查-重试循环驱动项目推进，直到开发、部署与验收目标完成。 | Catalog only |
 | [`scrum-master`](../skills/scrum-master/) | Advanced Scrum Master with data-driven team health analysis, velocity forecasting, retrospective insights, and team development expertise. Features comprehensive sprint health… | Catalog only |
 | [`seq-wrangler`](../skills/seq-wrangler/) | Sequence QC, alignment, and BAM processing. Wraps FastQC, BWA/Bowtie2, SAMtools for automated read-to-BAM pipelines. | Catalog only |
+| [`setting-okrs-goals`](../skills/setting-okrs-goals/) | Help users set effective OKRs and goals. Use when someone is creating quarterly objectives, defining key results, setting team goals, planning annual targets, or struggling with… | Catalog only |
+| [`skill-gap-analyzer`](../skills/skill-gap-analyzer/) | 将军团战略蓝图与现有Agent能力矩阵进行对比，自动识别"能力鸿沟"，并发起招聘（硅基/碳基猎取）或培训（进化路径）需求。 | Catalog only |
 | [`sp-brainstorming`](../skills/sp-brainstorming/) | Interactive idea refinement using Socratic method to develop fully-formed designs | Catalog only |
 | [`startup-analyst`](../skills/startup-analyst/) | Expert startup business analysis for market sizing, financial modeling, competitive analysis, and strategic planning. Use PROACTIVELY when the user asks about TAM/SAM/SOM,… | Catalog only |
 | [`startup-business-analyst-business-case`](../skills/startup-business-analyst-business-case/) | Description needs review; inspect source. | Catalog only |
@@ -712,7 +718,6 @@ Plan work, make decisions, manage teams, and improve operating systems.
 | [`tailored-resume-generator`](../skills/tailored-resume-generator/) | Analyzes job descriptions and generates tailored resumes that highlight relevant experience, skills, and achievements to maximize interview chances | Catalog only |
 | [`task-prioritization`](../skills/task-prioritization/) | Task prioritization and scoring | Catalog only |
 | [`task-status`](../skills/task-status/) | Send short status descriptions in chat for long-running tasks. Use when you need to provide periodic updates during multi-step operations, confirm task completion, or notify of… | Catalog only |
-| [`task-supervisor`](../skills/task-supervisor/) | 定时巡检 agent 任务执行状态，识别卡住、abort、无产出等异常并触发催促或告警。 | Catalog only |
 | [`team-coordinator`](../skills/team-coordinator/) | 团队协调与智能任务分配。作为高管，将用户任务拆解并分配给最合适的员工 agent 执行，协调多 agent 并行协作，汇总审核产出。 | Harness-specific assignment · generic installer skips · CEO |
 | [`team-daily-report`](../skills/team-daily-report/) | 自动汇总团队内 agent、cron、skill 进展与关键事件，生成并推送结构化日报。 | Catalog only |
 | [`team-foreman`](../skills/team-foreman/) | 问题：每次巡检信息不同步，重复催促已完成的任务。 方案：以 git log + progress 文件 + CEO memory 为进度真相源。 | Catalog only |
@@ -744,11 +749,11 @@ Plan work, make decisions, manage teams, and improve operating systems.
 | [`thinking-ogilvy`](../skills/thinking-ogilvy/) | 蒸馏David Ogilvy思维模式的实用框架——广告教父、调研驱动、大创意、品牌形象 | Catalog only |
 | [`thinking-ray-dalio`](../skills/thinking-ray-dalio/) | 蒸馏Ray Dalio思维模式的实用框架——原则体系、经济机器、极度透明 | Catalog only |
 | [`thinking-seth-godin`](../skills/thinking-seth-godin/) | 蒸馏Seth Godin思维模式的实用框架——紫牛法则、许可营销、最小可行受众 | Catalog only |
-| [`thinking-simon`](../skills/thinking-simon/) | 蒸馏 Jim Simons（文艺复兴科技）思维模式的实用框架：量化思维、大量小交易、数学即优势 | Catalog only |
 | [`thinking-steve-jobs`](../skills/thinking-steve-jobs/) | 蒸馏Steve Jobs思维模式的实用框架。当需要极简设计、用户体验偏执、产品哲学式思考时激活。 | Catalog only |
 | [`thinking-warren-buffett`](../skills/thinking-warren-buffett/) | 蒸馏Warren Buffett思维模式的实用框架——价值投资、能力圈、护城河、安全边际、反向思考 | Catalog only |
 | [`thinking-yingshi-juufeng`](../skills/thinking-yingshi-juufeng/) | 蒸馏影视飓风Tim思维模式的实用框架——视觉叙事、技术科普平民化、B站爆款方法论 | Catalog only |
 | [`todo-tracker`](../skills/todo-tracker/) | Description needs review; inspect source. | Catalog only |
+| [`vp-cpo-readiness-advisor`](../skills/vp-cpo-readiness-advisor/) | Coaches Directors and executives through the transition to VP or CPO across four situations: preparing, interviewing, newly landed, or recalibrating at executive level. | Catalog only |
 | [`weekly-review`](../skills/weekly-review/) | 你是Quant。每周一做周度绩效统计和策略调整。 | Catalog only |
 
 <a id="apps-workflow-automation"></a>
@@ -758,6 +763,7 @@ Connect everyday apps, browsers, messaging systems, and repeatable workflows.
 
 | Skill | What it helps with | Support / review signals |
 |---|---|---|
+| [`agent-browser`](../skills/agent-browser/) | A fast Rust-based headless browser automation CLI with Node.js fallback that enables AI agents to navigate, click, type, and snapshot pages via structured commands. | Catalog only |
 | [`airtable-automation`](../skills/airtable-automation/) | Automate Airtable tasks via Rube MCP (Composio): records, bases, tables, fields, views. Always search tools first for current schemas. | Catalog only |
 | [`amplitude-automation`](../skills/amplitude-automation/) | Automate Amplitude tasks via Rube MCP (Composio): events, user activity, cohorts, user identification. Always search tools first for current schemas. | Catalog only |
 | [`asana-automation`](../skills/asana-automation/) | Automate Asana tasks via Rube MCP (Composio): tasks, projects, sections, teams, workspaces. Always search tools first for current schemas. | Catalog only |
@@ -778,8 +784,8 @@ Connect everyday apps, browsers, messaging systems, and repeatable workflows.
 | [`coda-automation`](../skills/coda-automation/) | Automate Coda tasks via Rube MCP (Composio): manage docs, pages, tables, rows, formulas, permissions, and publishing. Always search tools first for current schemas. | Catalog only |
 | [`confluence-automation`](../skills/confluence-automation/) | Automate Confluence page creation, content search, space management, labels, and hierarchy navigation via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`convertkit-automation`](../skills/convertkit-automation/) | Automate ConvertKit (Kit) tasks via Rube MCP (Composio): manage subscribers, tags, broadcasts, and broadcast stats. Always search tools first for current schemas. | Catalog only |
+| [`cua-driver`](../skills/cua-driver/) | Drive a native GUI app (macOS, Windows, Linux) via the cua-driver CLI (default) or MCP server — snapshot its accessibility tree, click/type/scroll by element_index or pixel… | Catalog only |
 | [`discord-automation`](../skills/discord-automation/) | Automate Discord tasks via Rube MCP (Composio): messages, channels, roles, webhooks, reactions. Always search tools first for current schemas. | Catalog only |
-| [`doc-coauthoring`](../skills/doc-coauthoring/) | Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar… | Catalog only |
 | [`docusign-automation`](../skills/docusign-automation/) | Automate DocuSign tasks via Rube MCP (Composio): templates, envelopes, signatures, document management. Always search tools first for current schemas. | Catalog only |
 | [`dropbox-automation`](../skills/dropbox-automation/) | Automate Dropbox file management, sharing, search, uploads, downloads, and folder operations via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`email-automation`](../skills/email-automation/) | 邮箱自动化：读取、搜索、草拟和发送邮件，支持 Gmail API 以及通用 IMAP/SMTP 流程。 | Catalog only |
@@ -788,10 +794,10 @@ Connect everyday apps, browsers, messaging systems, and repeatable workflows.
 | [`email-read`](../skills/email-read/) | Read inbox and sent via Gmail API | Catalog only |
 | [`email-send-bulk`](../skills/email-send-bulk/) | Gmail API bulk email sending | Catalog only · review: credentials, external-write, personal-data |
 | [`email-send-direct`](../skills/email-send-direct/) | Single email: dry-run, reply, attachments | Catalog only · review: credentials, external-write, personal-data |
-| [`fabric-pattern`](../skills/fabric-pattern/) | Description needs review; inspect source. | Catalog only |
 | [`facebook-automation`](../skills/facebook-automation/) | Automate Facebook tasks via Rube MCP (Composio): pages, posts, insights, comments, and ad accounts. Always search tools first for current schemas. | Catalog only |
 | [`fast-browser-use`](../skills/fast-browser-use/) | Use when the user wants extremely fast browser automation via fast-browser-use / fbu, especially for DOM-heavy pages, fast extraction, or browser tasks on macOS/Linux with Chrome… | Catalog only |
 | [`github-automation`](../skills/github-automation/) | 自动化 GitHub 操作。当用户需要推送代码到 GitHub、管理仓库、创建 PR、处理 Issue、git push 失败时使用此技能。优先使用 mcporter call github.push_files 而不是 git push。 | Portable required assignment · structure checked · CTO · review: credentials, external-write, system-change |
+| [`gitlab-automation`](../skills/gitlab-automation/) | Automate GitLab project management, issues, merge requests, pipelines, branches, and user operations via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`gmail-automation`](../skills/gmail-automation/) | Automate Gmail tasks via Rube MCP (Composio): send/reply, search, labels, drafts, attachments. Always search tools first for current schemas. | Catalog only |
 | [`google-calendar-automation`](../skills/google-calendar-automation/) | Automate Google Calendar events, scheduling, availability checks, and attendee management via Rube MCP (Composio). Create events, find free slots, manage attendees, and list… | Catalog only |
 | [`google-drive`](../skills/google-drive/) | Upload files, create folders, list and search Google Drive via CLI | Catalog only |
@@ -800,10 +806,10 @@ Connect everyday apps, browsers, messaging systems, and repeatable workflows.
 | [`hr-automation`](../skills/hr-automation/) | HR workflow automation - recruiting, onboarding, employee management, and offboarding processes | Catalog only |
 | [`instagram-automation`](../skills/instagram-automation/) | Automate Instagram tasks via Rube MCP (Composio): create posts, carousels, manage media, get insights, and publishing limits. Always search tools first for current schemas. | Catalog only |
 | [`jira-automation`](../skills/jira-automation/) | Automate Jira tasks via Rube MCP (Composio): issues, projects, sprints, boards, comments, users. Always search tools first for current schemas. | Catalog only |
+| [`kanbanflow-skill`](../skills/kanbanflow-skill/) | Manage KanbanFlow boards, columns, and tasks for lightweight workflow | Catalog only |
 | [`klaviyo-automation`](../skills/klaviyo-automation/) | Automate Klaviyo tasks via Rube MCP (Composio): manage email/SMS campaigns, inspect campaign messages, track tags, and monitor send jobs. Always search tools first for current… | Catalog only |
 | [`linear-automation`](../skills/linear-automation/) | Automate Linear tasks via Rube MCP (Composio): issues, projects, cycles, teams, labels. Always search tools first for current schemas. | Catalog only |
 | [`linkedin-automation`](../skills/linkedin-automation/) | Automate LinkedIn tasks via Rube MCP (Composio): create posts, manage profile, company info, comments, and image uploads. Always search tools first for current schemas. | Catalog only |
-| [`linkedin-cdp`](../skills/linkedin-cdp/) | LinkedIn CDP: Input-only automation (mouse, keyboard, screenshots). Zero DOM access. | Catalog only |
 | [`mailchimp-automation`](../skills/mailchimp-automation/) | Automate Mailchimp email marketing including campaigns, audiences, subscribers, segments, and analytics via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`make-automation`](../skills/make-automation/) | Automate Make (Integromat) tasks via Rube MCP (Composio): operations, enums, language and timezone lookups. Always search tools first for current schemas. | Catalog only |
 | [`microsoft-teams-automation`](../skills/microsoft-teams-automation/) | Automate Microsoft Teams tasks via Rube MCP (Composio): send messages, manage channels, create meetings, handle chats, and search messages. Always search tools first for current… | Catalog only |
@@ -812,7 +818,6 @@ Connect everyday apps, browsers, messaging systems, and repeatable workflows.
 | [`monday-automation`](../skills/monday-automation/) | Automate Monday.com work management including boards, items, columns, groups, subitems, and updates via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
 | [`notion-automation`](../skills/notion-automation/) | 自动化 Notion 操作。当用户需要管理 Notion 页面、数据库、块内容、项目跟踪或进行内容组织和搜索时使用此技能。 | Catalog only |
 | [`one-drive-automation`](../skills/one-drive-automation/) | Automate OneDrive file management, search, uploads, downloads, sharing, permissions, and folder operations via Rube MCP (Composio). Always search tools first for current schemas. | Catalog only |
-| [`outbound-email-strategy`](../skills/outbound-email-strategy/) | Comprehensive outbound email strategy skill for cold outreach, email sequences, and multi-channel campaigns. Use when writing cold emails, creating outreach sequences, optimizing… | Catalog only |
 | [`outlook-automation`](../skills/outlook-automation/) | Automate Outlook tasks via Rube MCP (Composio): emails, calendar, contacts, folders, attachments. Always search tools first for current schemas. | Catalog only |
 | [`pagerduty-automation`](../skills/pagerduty-automation/) | Automate PagerDuty tasks via Rube MCP (Composio): manage incidents, services, schedules, escalation policies, and on-call rotations. Always search tools first for current schemas. | Catalog only |
 | [`playwright-automation`](../skills/playwright-automation/) | Playwright 浏览器自动化。用于自动化爬虫、数据采集、表单填写、UI 测试等需要浏览器自动化的场景。无需人工干预，适合 cron 定时任务。 | Catalog only |
@@ -903,48 +908,45 @@ Domain-specific helpers and cross-functional tools that need a dedicated review 
 |---|---|---|
 | [`bat-cat`](../skills/bat-cat/) | A cat clone with syntax highlighting, line numbers, and Git integration - a modern replacement for cat. | Catalog only |
 | [`bazi-fortune`](../skills/bazi-fortune/) | 八字四柱命理分析工具，属于 fortune-telling-skills 运势测算套件。基于子平真诠体系， 通过出生年月日时推算四柱八字、十神关系、五行旺衰、大运流年，揭示命局格局和人生走向。 排盘为确定性计算 + LLM 综合解读，无外部 API 依赖。 触发词：八字、四柱、命理、生辰八字、bazi、八字排盘、五行、命局分析。… | Catalog only |
-| [`binance-trending`](../skills/binance-trending/) | Description needs review; inspect source. | Catalog only |
 | [`channel-truth-run`](../skills/channel-truth-run/) | Automatic channel and contact synchronization | Catalog only |
 | [`claw-metagenomics`](../skills/claw-metagenomics/) | Shotgun metagenomics profiling — taxonomy, resistome, and functional pathways | Catalog only |
 | [`composio-sdk`](../skills/composio-sdk/) | Build AI agents and apps with Composio - access 200+ external tools with Tool Router or direct execution | Catalog only |
 | [`continuous-learning-v2`](../skills/continuous-learning-v2/) | Instinct-based learning system that observes sessions via hooks, creates atomic instincts with confidence scoring, and evolves them into skills/commands/agents. v2.1 adds… | Catalog only |
+| [`deepwork-tracker`](../skills/deepwork-tracker/) | Track deep work sessions locally (start/stop/status) and generate a GitHub-contribution-graph style minutes-per-day heatmap for sharing (e.g., via Telegram). Use when the user… | Catalog only |
 | [`erc-8004`](../skills/erc-8004/) | Register AI agents on Ethereum mainnet using ERC-8004 (Trustless Agents). Use when the user wants to register their agent identity on-chain, create an agent profile, claim an… | Catalog only |
 | [`executing-plans`](../skills/executing-plans/) | Use when you have a written implementation plan to execute in a separate session with review checkpoints | Portable required assignment · structure checked · CEO |
+| [`file-organizer`](../skills/file-organizer/) | Intelligently organizes your files and folders across your computer by understanding context, finding duplicates, suggesting better structures, and automating cleanup tasks.… | Catalog only |
 | [`google-auth`](../skills/google-auth/) | Google OAuth setup, refresh tokens | Catalog only |
 | [`healthcare-monitor`](../skills/healthcare-monitor/) | 医疗行业企业融资监控系统。实时监控医疗健康企业的工商变更，识别融资信号，自动推送告警。支持天眼查/企查查数据采集、AI融资判断、多渠道推送。 | Catalog only |
 | [`hookify-rules`](../skills/hookify-rules/) | This skill should be used when the user asks to create a hookify rule, write a hook rule, configure hookify, add a hookify rule, or needs guidance on hookify rule syntax and… | Catalog only |
 | [`jimeng-digital-human`](../skills/jimeng-digital-human/) | 即梦AI数字人视频生成全流程自动化。通过浏览器自动化操控 jimeng.jianying.com 数字人界面，完成角色上传、音色选择、台词填入、视频生成和下载。触发场景：用户需要生成数字人视频、即梦数字人、AI数字人口播视频、数字人视频制作。依赖 jimeng-login skill 处理登录。 | Harness-specific assignment · generic installer skips · CCO |
 | [`jimeng-login`](../skills/jimeng-login/) | 即梦AI平台(jimeng.jianying.com)浏览器登录。当需要操作即梦数字人、视频生成等功能前检测到未登录时触发。处理协议同意、抖音OAuth扫码、登录态持久化。 | Harness-specific assignment · generic installer skips · CCO |
-| [`jimeng-storyboard`](../skills/jimeng-storyboard/) | 将口播视频剧本拆解为即梦AI数字人平台的分镜头脚本。输出格式为每个镜头的角色说（台词）和动作描述（镜头语言/数字人动作），适配即梦 jimeng.jianying.com 数字人视频生成界面。触发场景：用户需要生成口播视频分镜、数字人视频剧本拆解、即梦分镜脚本、短视频口播脚本分镜、数字人台词加动作拆分。 | Portable required assignment · structure checked · CCO |
 | [`kanxiang`](../skills/kanxiang/) | 看相分析技能。通过用户上传的人体部位图片，识别图片类型（面相/手相/体相/骨相），调用相应的相术规则知识库，结合图片内容进行专业分析。支持面相（五官、三庭、十二宫）、手相（掌线、指形、掌丘）、骨相（头骨、体骨、九骨）、体相（体型、体态、气质）的综合分析。基于《麻衣神相》《柳庄相法》《神相全编》《水镜神相》《冰鉴》等经典相书整理。 | Catalog only |
 | [`liuyao`](../skills/liuyao/) | 六爻铜钱卦占卜技能。核心理念："解一卦就是传一道，说一言就是传一智"。支持真实/虚拟起卦，集成儒道哲学。 | Catalog only |
-| [`market-intelligence`](../skills/market-intelligence/) | Description needs review; inspect source. | Catalog only |
+| [`liuyao-yijing`](../skills/liuyao-yijing/) | 六爻易经占卜器，基于京房纳甲体系，模拟铜钱起卦，完成纳甲装卦（天干地支、世应、六亲、六神）， 通过用神旺衰和生克制化断卦。当用户提及「六爻」「易经占卜」「铜钱起卦」「纳甲」「帮我起一卦」 「六爻预测」时触发。装卦为确定性计算 + LLM 综合断卦，无外部 API 依赖。 不适用于：梅花易数、奇门遁甲、星座运势、塔罗占卜、八字命理等其他领域 → 建议使用… | Catalog only |
 | [`mcstatus`](../skills/mcstatus/) | 生成 Agent 与 Cron 的模型配置状态报告，展示主模型、fallback 链和任务分配情况。 | Catalog only |
 | [`multimodal-gen`](../skills/multimodal-gen/) | 多模态内容生成（图片、视频）。当用户需要生成图片、生成图像、生成视频、AI绘画、AI作图、画一张图、做个视频、文生图、文生视频时使用此技能。自动调用 multimodal-agent 进行生成。 | Catalog only |
 | [`nutrigx_advisor`](../skills/nutrigx_advisor/) | Nutrigenomics advisor — personalized nutrition guidance based on genetic profiles | Catalog only |
 | [`openhr`](../skills/openhr/) | Boss直聘全流程AI自动化招聘智能体。自动登录、筛选候选人、个性化打招呼、智能聊天跟进、简历解析、飞书同步。触发词：启动招聘、自动打招呼、boss greet、openhr、简历解析、上传飞书。 | Catalog only · review: credentials, external-write, personal-data |
 | [`polyclaw`](../skills/polyclaw/) | Description needs review; inspect source. | Catalog only |
+| [`quality-convergence-engine`](../skills/quality-convergence-engine/) | Multi-dimensional Quality Acceptance and Problem Convergence Engine - Deeply deconstruct requirements, eliminate extreme defects, define absolutely objective acceptance and… | Portable required assignment · structure checked · GOVERNOR |
 | [`raffle-winner-picker`](../skills/raffle-winner-picker/) | Picks random winners from lists, spreadsheets, or Google Sheets for giveaways, raffles, and contests. Ensures fair, unbiased selection with transparency. | Catalog only |
 | [`ralph`](../skills/ralph/) | Use when the user explicitly asks to use Ralph mode for persistent plan-execute-check-retry loops that keep going until the target outcome is achieved. | Catalog only |
 | [`remote-ollama-gpu-scheduler`](../skills/remote-ollama-gpu-scheduler/) | 调度远程 Ollama GPU 资源执行批量 embedding 或推理任务，提升多机环境下的算力利用率。 | Catalog only |
 | [`shrimp-coach`](../skills/shrimp-coach/) | 训练垂直领域 agent 的教练型 skill，用于按宪章、手册和复盘机制持续提升 agent 能力。 | Catalog only |
 | [`silicon-performance-reviewer`](../skills/silicon-performance-reviewer/) | Quarterly Silicon Agent performance evaluation with ByteDance-style calibration, forced distribution ranking, dual-track (technical/management) assessment, and automated score… | Harness-specific assignment · generic installer skips · GOVERNOR |
-| [`soushen-hunter`](../skills/soushen-hunter/) | Description needs review; inspect source. | Catalog only |
+| [`skillforge`](../skills/skillforge/) | Intelligent skill router and creator. Analyzes ANY input to recommend existing skills, improve them, or create new ones. Uses deep iterative analysis with 11 thinking models,… | Catalog only |
 | [`sp-collision-zone-thinking`](../skills/sp-collision-zone-thinking/) | Force unrelated concepts together to discover emergent properties - "What if we treated X like Y?" | Catalog only |
-| [`sp-condition-based-waiting`](../skills/sp-condition-based-waiting/) | Replace arbitrary timeouts with condition polling for reliable async tests | Portable required assignment · structure checked · PE |
 | [`sp-executing-plans`](../skills/sp-executing-plans/) | Execute detailed plans in batches with review checkpoints | Catalog only |
 | [`sp-inversion-exercise`](../skills/sp-inversion-exercise/) | Flip core assumptions to reveal hidden constraints and alternative approaches - "what if the opposite were true?" | Catalog only |
 | [`sp-meta-pattern-recognition`](../skills/sp-meta-pattern-recognition/) | Spot patterns appearing in 3+ domains to find universal principles | Catalog only |
 | [`sp-root-cause-tracing`](../skills/sp-root-cause-tracing/) | Systematically trace bugs backward through call stack to find original trigger | Harness-specific assignment · generic installer skips · COO |
-| [`sp-simplification-cascades`](../skills/sp-simplification-cascades/) | Find one insight that eliminates multiple components - "if this is true, we don't need X, Y, or Z" | Catalog only |
 | [`sp-verification-before-completion`](../skills/sp-verification-before-completion/) | Run verification commands and confirm output before claiming success | Portable required assignment · structure checked · COO |
 | [`sp-when-stuck`](../skills/sp-when-stuck/) | Dispatch to the right problem-solving technique based on how you're stuck | Catalog only |
 | [`struct-predictor`](../skills/struct-predictor/) | Local protein structure prediction with AlphaFold, Boltz, or Chai. Compare predicted structures, compute RMSD, visualise 3D models. | Catalog only |
 | [`tcm-meridian-inference`](../skills/tcm-meridian-inference/) | TCM meridian inference engine — health scoring from 6-meridian measurements | Catalog only |
 | [`timezone`](../skills/timezone/) | Local time detection, timezone conversion | Catalog only |
 | [`twitter-algorithm-optimizer`](../skills/twitter-algorithm-optimizer/) | Analyze and optimize tweets for maximum reach using Twitter's open-source algorithm insights. Rewrite and edit user tweets to improve engagement and visibility based on how the… | Catalog only |
-| [`using-superpowers`](../skills/using-superpowers/) | Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions | Catalog only |
-| [`vp-cpo-readiness-advisor`](../skills/vp-cpo-readiness-advisor/) | Coaches Directors and executives through the transition to VP or CPO across four situations: preparing, interviewing, newly landed, or recalibrating at executive level. | Catalog only |
 | [`yijing-divination`](../skills/yijing-divination/) | 易经占卜系统。支持铜钱法、蓍草法起卦，生成本卦、互卦、变卦，提供Oracle Voice诠释。当用户请求占卜、问卦、易经解读、或寻求决策指引时使用。 | Catalog only |
 
 ## 🛡️ Support, portability, and evidence boundary

--- a/catalog/skill-index.json
+++ b/catalog/skill-index.json
@@ -2,77 +2,77 @@
   "$schema": "../config/skill-index.schema.json",
   "categories": [
     {
-      "count": 77,
+      "count": 78,
       "description": "Coordinate agents, context, memory, models, prompts, and tool protocols.",
       "emoji": "🤖",
       "id": "ai-agents-orchestration",
       "title": "AI Agents & Orchestration"
     },
     {
-      "count": 80,
+      "count": 81,
       "description": "Build, test, review, debug, and maintain applications and developer tooling.",
       "emoji": "💻",
       "id": "software-engineering",
       "title": "Software Engineering"
     },
     {
-      "count": 29,
+      "count": 32,
       "description": "Deploy, observe, troubleshoot, and operate cloud and local infrastructure.",
       "emoji": "☁️",
       "id": "cloud-devops-reliability",
       "title": "Cloud, DevOps & Reliability"
     },
     {
-      "count": 75,
+      "count": 78,
       "description": "Collect evidence, search sources, analyze data, and communicate findings.",
       "emoji": "📊",
       "id": "data-analytics-research",
       "title": "Data, Analytics & Research"
     },
     {
-      "count": 34,
+      "count": 32,
       "description": "Review security, privacy, compliance, permissions, contracts, and legal risk.",
       "emoji": "🛡️",
       "id": "security-privacy-legal",
       "title": "Security, Privacy & Legal"
     },
     {
-      "count": 26,
+      "count": 20,
       "description": "Shape product requirements, interfaces, design systems, and user experience.",
       "emoji": "🎨",
       "id": "product-design-ux",
       "title": "Product, Design & UX"
     },
     {
-      "count": 51,
+      "count": 47,
       "description": "Acquire audiences through positioning, campaigns, search, ads, and social growth.",
       "emoji": "📈",
       "id": "marketing-seo-growth",
       "title": "Marketing, SEO & Growth"
     },
     {
-      "count": 78,
+      "count": 82,
       "description": "Create, edit, repurpose, and publish writing, images, audio, and video.",
       "emoji": "✍️",
       "id": "content-media-publishing",
       "title": "Content, Media & Publishing"
     },
     {
-      "count": 36,
+      "count": 39,
       "description": "Find, win, onboard, support, and retain customers with accountable workflows.",
       "emoji": "🤝",
       "id": "sales-crm-customer-success",
       "title": "Sales, CRM & Customer Success"
     },
     {
-      "count": 64,
+      "count": 65,
       "description": "Analyze markets, backtest strategies, track portfolios, and review financial risk.",
       "emoji": "💹",
       "id": "finance-trading-markets",
       "title": "Finance, Trading & Markets"
     },
     {
-      "count": 72,
+      "count": 71,
       "description": "Plan work, make decisions, manage teams, and improve operating systems.",
       "emoji": "🧭",
       "id": "business-operations-strategy",
@@ -93,7 +93,7 @@
       "title": "Chinese Platform Workflows"
     },
     {
-      "count": 45,
+      "count": 42,
       "description": "Domain-specific helpers and cross-functional tools that need a dedicated review path.",
       "emoji": "🧰",
       "id": "general-utilities",
@@ -138,12 +138,12 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "slug:fund;metadata:frontmatter",
+      "classification": "outcome:大量小交易|投资组合|估值|交易风控;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "fund"
+          "大量小交易|投资组合|估值|交易风控"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -151,7 +151,7 @@
           "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "fund"
+            "大量小交易|投资组合|估值|交易风控"
           ],
           "priority": 120,
           "tie_detected": false
@@ -168,23 +168,23 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "slug:analysis;metadata:fallback",
+      "category_id": "finance-trading-markets",
+      "classification": "slug:(?:^|-)(?:a-share|stock|equity)(?:-|$).{0,24}(?:analysis|screening)|A股|个股|选股;metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "(?:^|-)(?:a-share|stock|equity)(?:-|$).{0,24}(?:analysis|screening)|A股|个股|选股"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
+          "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "analysis"
+            "(?:^|-)(?:a-share|stock|equity)(?:-|$).{0,24}(?:analysis|screening)|A股|个股|选股"
           ],
-          "priority": 95,
+          "priority": 120,
           "tie_detected": false
         }
       },
@@ -230,35 +230,25 @@
     },
     {
       "assignments": [],
-      "category_id": "security-privacy-legal",
-      "classification": "slug:compliance,audit;metadata:frontmatter",
+      "category_id": "product-design-ux",
+      "classification": "outcome:\\bwcag\\b,(?:wcag|accessibility).{0,28}(?:audit|testing|barrier|remediation|inclusive);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "compliance",
-          "audit"
+          "\\bwcag\\b",
+          "(?:wcag|accessibility).{0,28}(?:audit|testing|barrier|remediation|inclusive)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "product-design-ux",
-            "match_count": 1,
-            "matched_signals": [
-              "accessibility"
-            ],
-            "priority": 90,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "security-privacy-legal",
+          "category_id": "product-design-ux",
           "match_count": 2,
           "matched_signals": [
-            "compliance",
-            "audit"
+            "\\bwcag\\b",
+            "(?:wcag|accessibility).{0,28}(?:audit|testing|barrier|remediation|inclusive)"
           ],
-          "priority": 115,
+          "priority": 90,
           "tie_detected": false
         }
       },
@@ -304,11 +294,11 @@
     },
     {
       "assignments": [],
-      "category_id": "marketing-seo-growth",
-      "classification": "slug:campaign;metadata:frontmatter",
+      "category_id": "sales-crm-customer-success",
+      "classification": "slug:(?:^|-)activecampaign(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "campaign"
+          "(?:^|-)activecampaign(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -325,12 +315,12 @@
           }
         ],
         "winner": {
-          "category_id": "marketing-seo-growth",
+          "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "campaign"
+            "(?:^|-)activecampaign(?:-|$)"
           ],
-          "priority": 105,
+          "priority": 110,
           "tie_detected": true
         }
       },
@@ -464,22 +454,20 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:compliance,audit;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "compliance",
-          "audit"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "compliance",
-            "audit"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -497,12 +485,12 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:compliance;metadata:fallback",
+      "classification": "outcome:\\b(?:gdpr|pci dss|threat model)\\b;metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "compliance"
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -510,7 +498,7 @@
           "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "compliance"
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -622,34 +610,36 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$);metadata:frontmatter",
+      "category_id": "apps-workflow-automation",
+      "classification": "slug:browser,(?:^|-)(?:agent-browser|browser-driver|computer-use|cua)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)"
+          "browser",
+          "(?:^|-)(?:agent-browser|browser-driver|computer-use|cua)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "apps-workflow-automation",
+            "category_id": "ai-agents-orchestration",
             "match_count": 1,
             "matched_signals": [
-              "browser"
+              "(?:^|-)agent(?:-|$)"
             ],
-            "priority": 70,
-            "tied_for_first": true
+            "priority": 75,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "ai-agents-orchestration",
-          "match_count": 1,
+          "category_id": "apps-workflow-automation",
+          "match_count": 2,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)"
+            "browser",
+            "(?:^|-)(?:agent-browser|browser-driver|computer-use|cua)(?:-|$)"
           ],
-          "priority": 75,
-          "tie_detected": true
+          "priority": 70,
+          "tie_detected": false
         }
       },
       "description": "A fast Rust-based headless browser automation CLI with Node.js fallback that enables AI agents to navigate, click, type, and snapshot pages via structured commands.",
@@ -887,22 +877,20 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)",
-          "(?:^|-)skills?(?:-|$)"
+          "(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)",
-            "(?:^|-)skills?(?:-|$)"
+            "(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?"
           ],
           "priority": 75,
           "tie_detected": false
@@ -925,32 +913,22 @@
         }
       ],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "slug:(?:^|-)agent(?:-|$),(?:^|-)skills(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
           "(?:^|-)agent(?:-|$)",
-          "(?:^|-)skills?(?:-|$)"
+          "(?:^|-)skills(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "security-privacy-legal",
-            "match_count": 1,
-            "matched_signals": [
-              "audit"
-            ],
-            "priority": 115,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
           "match_count": 2,
           "matched_signals": [
             "(?:^|-)agent(?:-|$)",
-            "(?:^|-)skills?(?:-|$)"
+            "(?:^|-)skills(?:-|$)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -970,33 +948,23 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)"
+          "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "task"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)"
+            "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
           ],
           "priority": 75,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Use when confirming whether a dispatched agent task was actually received, activated, and progressing after sessions_send or other task handoff actions.",
@@ -1011,32 +979,20 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),orchestrat;metadata:frontmatter",
+      "classification": "outcome:(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)",
-          "orchestrat"
+          "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "team"
-            ],
-            "priority": 65,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)",
-            "orchestrat"
+            "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -1116,11 +1072,11 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:security,audit;metadata:frontmatter",
+      "classification": "slug:security,(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
           "security",
-          "audit"
+          "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -1131,7 +1087,7 @@
           "match_count": 2,
           "matched_signals": [
             "security",
-            "audit"
+            "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -1184,34 +1140,24 @@
           "level": "required"
         }
       ],
-      "category_id": "marketing-seo-growth",
-      "classification": "slug:marketing;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "marketing"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "video"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "marketing-seo-growth",
+          "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "marketing"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
-          "priority": 105,
-          "tie_detected": true
+          "priority": 100,
+          "tie_detected": false
         }
       },
       "description": "Create AI marketing videos for ads, promos, product launches, and brand content. Models: Veo, Seedance, Wan, FLUX for visuals, Kokoro for voiceover. Types: product demos,…",
@@ -1234,19 +1180,9 @@
           "news"
         ],
         "method": "description",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "github"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "data-analytics-research",
           "match_count": 1,
@@ -1254,7 +1190,7 @@
             "news"
           ],
           "priority": 95,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "雷达Skill（AI Radar）——零API、零Key、零服务器的中文AI资讯查询。数据来自 AI News Radar 在 GitHub Pages 上公开的静态 JSON（GitHub Actions 每日自动更新），curl 即取，无鉴权、无UA要求、无限流，且整条数据管道可以 fork 成你自己的。 当用户想知道\"今天 AI…",
@@ -1269,12 +1205,12 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:audit;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "audit"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -1282,7 +1218,7 @@
           "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "audit"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -1305,9 +1241,10 @@
         "base_candidates": [
           {
             "category_id": "finance-trading-markets",
-            "match_count": 1,
+            "match_count": 2,
             "matched_signals": [
-              "trading"
+              "trading",
+              "\\bp&l\\b|量化|交易|投资组合|风控"
             ],
             "priority": 120,
             "tied_for_first": true
@@ -1319,7 +1256,7 @@
               "\\bmcp\\b"
             ],
             "priority": 75,
-            "tied_for_first": true
+            "tied_for_first": false
           }
         ],
         "base_method": "description",
@@ -1349,12 +1286,12 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "slug:video;metadata:frontmatter",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "video"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -1362,7 +1299,7 @@
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "video"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -1379,25 +1316,17 @@
     },
     {
       "assignments": [],
-      "category_id": "marketing-seo-growth",
-      "classification": "slug:viral;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:writing,(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "viral"
+          "writing",
+          "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "writing"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          },
           {
             "category_id": "business-operations-strategy",
             "match_count": 1,
@@ -1405,17 +1334,18 @@
               "team"
             ],
             "priority": 65,
-            "tied_for_first": true
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "marketing-seo-growth",
-          "match_count": 1,
+          "category_id": "content-media-publishing",
+          "match_count": 2,
           "matched_signals": [
-            "viral"
+            "writing",
+            "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
           ],
-          "priority": 105,
-          "tie_detected": true
+          "priority": 100,
+          "tie_detected": false
         }
       },
       "description": "脚本创作 - 短视频脚本撰写与分镜设计 职责：根据爆款模板生产内容、设计黄金3秒开头方案（3种以上）、撰写分镜脚本（包含镜头语言/场景氛围/角色动作/台词/BGM）、设计槽点埋梗与情绪钩子、规划结尾引导、自动推荐Vidu视频生成配置（模型版本/生成方式/时长/比例）、确保人物形象一致性、向视频生成(Leo)传递完整的分镜信息 适用场景：(1)…",
@@ -1429,25 +1359,16 @@
     },
     {
       "assignments": [],
-      "category_id": "marketing-seo-growth",
-      "classification": "slug:viral;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:video;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "viral"
+          "video"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
         "review_state": "unreviewed",
         "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "video"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          },
           {
             "category_id": "business-operations-strategy",
             "match_count": 1,
@@ -1459,12 +1380,12 @@
           }
         ],
         "winner": {
-          "category_id": "marketing-seo-growth",
+          "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "viral"
+            "video"
           ],
-          "priority": 105,
+          "priority": 100,
           "tie_detected": true
         }
       },
@@ -1645,34 +1566,24 @@
           "level": "required"
         }
       ],
-      "category_id": "product-design-ux",
-      "classification": "slug:design;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:\\b(?:api|rest|graphql|grpc) design\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design"
+          "\\b(?:api|rest|graphql|grpc) design\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "\\bapi\\b"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "design"
+            "\\b(?:api|rest|graphql|grpc) design\\b"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs.",
@@ -1694,34 +1605,24 @@
           "level": "required"
         }
       ],
-      "category_id": "product-design-ux",
-      "classification": "slug:design;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:\\b(?:api|rest|graphql|grpc) design\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design"
+          "\\b(?:api|rest|graphql|grpc) design\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "\\bapi\\b"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "design"
+            "\\b(?:api|rest|graphql|grpc) design\\b"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "Comprehensive API design patterns covering REST, GraphQL, gRPC, versioning, authentication, and modern API best practices",
@@ -1943,12 +1844,12 @@
         }
       ],
       "category_id": "data-analytics-research",
-      "classification": "slug:scrap;metadata:frontmatter",
+      "classification": "outcome:(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "scrap"
+          "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -1956,7 +1857,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "scrap"
+            "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -2132,12 +2033,12 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:architecture;metadata:frontmatter",
+      "classification": "outcome:\\b(?:software|system) architecture\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "architecture"
+          "\\b(?:software|system) architecture\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -2145,7 +2046,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "architecture"
+            "\\b(?:software|system) architecture\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -2610,22 +2511,13 @@
             "category_id": "finance-trading-markets",
             "match_count": 1,
             "matched_signals": [
-              "backtest"
+              "(?:quantitative|algorithmic).{0,20}(?:trading|finance|investment)"
             ],
             "priority": 120,
             "tied_for_first": true
-          },
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "test-"
-            ],
-            "priority": 80,
-            "tied_for_first": true
           }
         ],
-        "base_method": "slug",
+        "base_method": "outcome",
         "matched_signals": [],
         "method": "override",
         "rationale": "Backtesting is a finance and market-risk workflow in this repository.",
@@ -3109,9 +3001,19 @@
           "binance-square"
         ],
         "method": "slug",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "finance-trading-markets",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:^|-)binance(?:-|$)"
+            ],
+            "priority": 120,
+            "tied_for_first": true
+          }
+        ],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
@@ -3119,7 +3021,7 @@
             "binance-square"
           ],
           "priority": 130,
-          "tie_detected": false
+          "tie_detected": true
         }
       },
       "description": "从 Binance Square 热门话题排行榜获取话题列表，逐个进入话题页抓取最新帖子，提取社区交易信号、情绪方向和小币提及统计。",
@@ -3133,19 +3035,23 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:fallback",
+      "category_id": "finance-trading-markets",
+      "classification": "slug:(?:^|-)binance(?:-|$);metadata:fallback",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)binance(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "finance-trading-markets",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)binance(?:-|$)"
+          ],
+          "priority": 120,
           "tie_detected": false
         }
       },
@@ -3161,33 +3067,23 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:bio-;metadata:frontmatter",
+      "classification": "outcome:\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "bio-"
+          "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "orchestrat"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "bio-"
+            "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
           ],
           "priority": 95,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Meta-agent that routes bioinformatics requests to specialised sub-skills. Handles file type detection, analysis planning, report generation, and reproducibility export.",
@@ -3583,12 +3479,12 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "slug:\\bbtc\\b;metadata:frontmatter",
+      "classification": "outcome:(?:trade|execute|backtest|price|monitor).{0,24}(?:prediction markets?|binance|polymarket);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bbtc\\b"
+          "(?:trade|execute|backtest|price|monitor).{0,24}(?:prediction markets?|binance|polymarket)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -3596,7 +3492,7 @@
           "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "\\bbtc\\b"
+            "(?:trade|execute|backtest|price|monitor).{0,24}(?:prediction markets?|binance|polymarket)"
           ],
           "priority": 120,
           "tie_detected": false
@@ -3613,42 +3509,11 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:business;metadata:frontmatter",
-      "classification_details": {
-        "matched_signals": [
-          "business"
-        ],
-        "method": "slug",
-        "resolution_status": "rule-match",
-        "review_state": "unreviewed",
-        "runner_ups": [],
-        "winner": {
-          "category_id": "business-operations-strategy",
-          "match_count": 1,
-          "matched_signals": [
-            "business"
-          ],
-          "priority": 65,
-          "tie_detected": false
-        }
-      },
-      "description": "Build KPI frameworks, predictive models, real-time dashboards, and strategic recommendations using modern BI tools and AI-powered analytics. Use when the user needs business…",
-      "description_status": "source-text",
-      "path": "skills/business-analyst/SKILL.md",
-      "portability_class": "catalog-only",
-      "review_signals": [],
-      "skill_id": "business-analyst",
-      "support_level": "catalog",
-      "used_by": []
-    },
-    {
-      "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:business-intelligence;metadata:frontmatter",
+      "classification": "slug:(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "business-intelligence"
+          "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -3668,10 +3533,53 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "business-intelligence"
+            "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
           ],
           "priority": 95,
           "tie_detected": true
+        }
+      },
+      "description": "Build KPI frameworks, predictive models, real-time dashboards, and strategic recommendations using modern BI tools and AI-powered analytics. Use when the user needs business…",
+      "description_status": "source-text",
+      "path": "skills/business-analyst/SKILL.md",
+      "portability_class": "catalog-only",
+      "review_signals": [],
+      "skill_id": "business-analyst",
+      "support_level": "catalog",
+      "used_by": []
+    },
+    {
+      "assignments": [],
+      "category_id": "data-analytics-research",
+      "classification": "slug:business-intelligence,(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$);metadata:frontmatter",
+      "classification_details": {
+        "matched_signals": [
+          "business-intelligence",
+          "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
+        "review_state": "unreviewed",
+        "runner_ups": [
+          {
+            "category_id": "business-operations-strategy",
+            "match_count": 1,
+            "matched_signals": [
+              "business"
+            ],
+            "priority": 65,
+            "tied_for_first": false
+          }
+        ],
+        "winner": {
+          "category_id": "data-analytics-research",
+          "match_count": 2,
+          "matched_signals": [
+            "business-intelligence",
+            "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
+          ],
+          "priority": 95,
+          "tie_detected": false
         }
       },
       "description": "Model business performance, define KPIs, and turn data into decision-ready dashboards, briefings, and operating cadences for teams and executives.",
@@ -3802,10 +3710,10 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:campaign;metadata:frontmatter",
+      "classification": "slug:(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "campaign"
+          "(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -3825,7 +3733,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "campaign"
+            "(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b"
           ],
           "priority": 105,
           "tie_detected": true
@@ -4167,15 +4075,6 @@
       "classification_details": {
         "base_candidates": [
           {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "data"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          },
-          {
             "category_id": "cloud-devops-reliability",
             "match_count": 1,
             "matched_signals": [
@@ -4215,10 +4114,10 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -4238,7 +4137,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": true
@@ -4261,10 +4160,10 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -4284,7 +4183,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": true
@@ -4678,10 +4577,10 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -4691,7 +4590,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -4709,12 +4608,12 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "outcome:\\bcode (?:repository|review|testing|debugging)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "\\bcode (?:repository|review|testing|debugging)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -4722,7 +4621,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "\\bcode (?:repository|review|testing|debugging)\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -4745,10 +4644,10 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -4758,7 +4657,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -4791,7 +4690,7 @@
             "category_id": "software-engineering",
             "match_count": 1,
             "matched_signals": [
-              "code"
+              "(?:^|-)code(?:-|$)|\\bcode\\b"
             ],
             "priority": 80,
             "tied_for_first": true
@@ -4823,34 +4722,26 @@
           "level": "harnessSpecific"
         }
       ],
-      "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:codex,(?:^|-)codex-(?:cc|cli|guide)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "codex",
+          "(?:^|-)codex-(?:cc|cli|guide)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "codex"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
-          "match_count": 1,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 2,
           "matched_signals": [
-            "code"
+            "codex",
+            "(?:^|-)codex-(?:cc|cli|guide)(?:-|$)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "如何用 ACP sessions_spawn 调用 Claude Code / Codex 写代码 — 小code 团队编码任务指南",
@@ -4943,33 +4834,23 @@
         }
       ],
       "category_id": "sales-crm-customer-success",
-      "classification": "slug:cold-email;metadata:frontmatter",
+      "classification": "outcome:(?:cold|outbound).{0,16}(?:email|outreach|sales);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "cold-email"
+          "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "email-"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "cold-email"
+            "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
           ],
           "priority": 110,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Generate personalized cold email sequences (7-14 emails) with A/B test subject lines, follow-up timing recommendations, and integrated social proof. Creates multi-touch campaigns…",
@@ -4986,14 +4867,13 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "description:code,github;metadata:frontmatter",
+      "classification": "description:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code",
-          "github"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "description",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
         "runner_ups": [
           {
@@ -5003,18 +4883,17 @@
               "project"
             ],
             "priority": 65,
-            "tied_for_first": false
+            "tied_for_first": true
           }
         ],
         "winner": {
           "category_id": "software-engineering",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "code",
-            "github"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
-          "tie_detected": false
+          "tie_detected": true
         }
       },
       "description": "Guide for collaborating on GitHub projects. This skill should be used when contributing to projects, creating PRs, reviewing code, or managing issues on GitHub.",
@@ -5090,24 +4969,34 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:company;metadata:fallback",
+      "category_id": "finance-trading-markets",
+      "classification": "slug:(?:^|-)company-(?:analy[sz]er|valuation|fundamentals)(?:-|$);metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "company"
+          "(?:^|-)company-(?:analy[sz]er|valuation|fundamentals)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "business-operations-strategy",
+            "match_count": 1,
+            "matched_signals": [
+              "company"
+            ],
+            "priority": 65,
+            "tied_for_first": true
+          }
+        ],
         "winner": {
-          "category_id": "business-operations-strategy",
+          "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "company"
+            "(?:^|-)company-(?:analy[sz]er|valuation|fundamentals)(?:-|$)"
           ],
-          "priority": 65,
-          "tie_detected": false
+          "priority": 120,
+          "tie_detected": true
         }
       },
       "description": "company-analyzer",
@@ -5254,15 +5143,6 @@
             ],
             "priority": 105,
             "tied_for_first": true
-          },
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
           }
         ],
         "base_method": "slug",
@@ -5331,9 +5211,19 @@
           "competitive"
         ],
         "method": "slug",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "software-engineering",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:^|-)(?:senior-)?architect(?:-|$)"
+            ],
+            "priority": 80,
+            "tied_for_first": true
+          }
+        ],
         "winner": {
           "category_id": "marketing-seo-growth",
           "match_count": 1,
@@ -5341,7 +5231,7 @@
             "competitive"
           ],
           "priority": 105,
-          "tie_detected": false
+          "tie_detected": true
         }
       },
       "description": "Design irresistible offer packages with real salary benchmarks, negotiation playbooks, and competitive counter-strategies. Co-designed with Siku (司库). Includes total compensation…",
@@ -5365,12 +5255,12 @@
         }
       ],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:competitor;metadata:frontmatter",
+      "classification": "outcome:\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "competitor"
+          "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -5378,7 +5268,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "competitor"
+            "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
           ],
           "priority": 105,
           "tie_detected": false
@@ -5877,22 +5767,20 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "slug:content,writer;metadata:frontmatter",
+      "classification": "outcome:(?:publish|repurpose).{0,24}(?:article|video|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "content",
-          "writer"
+          "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "content-media-publishing",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "content",
-            "writer"
+            "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -6275,12 +6163,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:\\bllm\\b;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bllm\\b"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -6288,7 +6176,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "\\bllm\\b"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -6310,43 +6198,24 @@
           "level": "required"
         }
       ],
-      "category_id": "finance-trading-markets",
-      "classification": "description:expense;metadata:frontmatter",
+      "category_id": "cloud-devops-reliability",
+      "classification": "outcome:(?:cloud|infrastructure).{0,32}(?:cost|spend|expense|rightsizing|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "expense"
+          "(?:cloud|infrastructure).{0,32}(?:cost|spend|expense|rightsizing|optimization)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "cloud-devops-reliability",
-            "match_count": 1,
-            "matched_signals": [
-              "cloud"
-            ],
-            "priority": 85,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "finance-trading-markets",
+          "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "expense"
+            "(?:cloud|infrastructure).{0,32}(?:cost|spend|expense|rightsizing|optimization)"
           ],
-          "priority": 120,
-          "tie_detected": true
+          "priority": 85,
+          "tie_detected": false
         }
       },
       "description": "Optimize cloud costs through resource rightsizing, tagging strategies, reserved instances, and spending analysis. Use when reducing cloud expenses, analyzing infrastructure…",
@@ -6394,10 +6263,10 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:viral;metadata:frontmatter",
+      "classification": "slug:(?:^|-)viral-(?:content|campaign|growth)(?:-|$)|\\bviral (?:content|campaign|growth)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "viral"
+          "(?:^|-)viral-(?:content|campaign|growth)(?:-|$)|\\bviral (?:content|campaign|growth)\\b"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -6417,7 +6286,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "viral"
+            "(?:^|-)viral-(?:content|campaign|growth)(?:-|$)|\\bviral (?:content|campaign|growth)\\b"
           ],
           "priority": 105,
           "tie_detected": true
@@ -6628,36 +6497,23 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "description:content,publish;metadata:frontmatter",
+      "classification": "outcome:(?:publish|repurpose).{0,24}(?:article|video|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "content",
-          "publish"
+          "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 2,
-            "matched_signals": [
-              "discord",
-              "telegram"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "content-media-publishing",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "content",
-            "publish"
+            "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
           ],
           "priority": 100,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Publish one piece of content across MoltX, Twitter/X, Discord, and Telegram",
@@ -6980,12 +6836,11 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:research,data,analysis,search,news;metadata:frontmatter",
+      "classification": "description:research,(?:^|-)data(?:-|$)|\\bdata\\b,search,news;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
           "research",
-          "data",
-          "analysis",
+          "(?:^|-)data(?:-|$)|\\bdata\\b",
           "search",
           "news"
         ],
@@ -7005,11 +6860,10 @@
         ],
         "winner": {
           "category_id": "data-analytics-research",
-          "match_count": 5,
+          "match_count": 4,
           "matched_signals": [
             "research",
-            "data",
-            "analysis",
+            "(?:^|-)data(?:-|$)|\\bdata\\b",
             "search",
             "news"
           ],
@@ -7033,50 +6887,20 @@
     {
       "assignments": [],
       "category_id": "business-operations-strategy",
-      "classification": "description:strategy,decision;metadata:frontmatter",
+      "classification": "slug:(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "strategy",
-          "decision"
+          "(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$)"
         ],
-        "method": "description",
+        "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "sales-crm-customer-success",
-            "match_count": 1,
-            "matched_signals": [
-              "lead"
-            ],
-            "priority": 110,
-            "tied_for_first": false
-          },
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "metrics"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          },
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "architecture"
-            ],
-            "priority": 80,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "business-operations-strategy",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "strategy",
-            "decision"
+            "(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$)"
           ],
           "priority": 65,
           "tie_detected": false
@@ -7093,52 +6917,24 @@
     },
     {
       "assignments": [],
-      "category_id": "product-design-ux",
-      "classification": "description:accessibility;metadata:frontmatter",
+      "category_id": "apps-workflow-automation",
+      "classification": "outcome:(?:native gui|accessibility tree).{0,36}(?:snapshot|click|type|scroll);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "accessibility"
+          "(?:native gui|accessibility tree).{0,36}(?:snapshot|click|type|scroll)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "cloud-devops-reliability",
-            "match_count": 1,
-            "matched_signals": [
-              "linux"
-            ],
-            "priority": 85,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)cli(?:-|$)|\\bcli\\b"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "\\bmcp\\b"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "apps-workflow-automation",
           "match_count": 1,
           "matched_signals": [
-            "accessibility"
+            "(?:native gui|accessibility tree).{0,36}(?:snapshot|click|type|scroll)"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 70,
+          "tie_detected": false
         }
       },
       "description": "Drive a native GUI app (macOS, Windows, Linux) via the cua-driver CLI (default) or MCP server — snapshot its accessibility tree, click/type/scroll by element_index or pixel…",
@@ -7153,23 +6949,33 @@
     {
       "assignments": [],
       "category_id": "sales-crm-customer-success",
-      "classification": "slug:customer;metadata:frontmatter",
+      "classification": "outcome:\\b(?:sales pipeline|customer success|crm contacts?)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "customer"
+          "\\b(?:sales pipeline|customer success|crm contacts?)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "rule-match",
+        "method": "outcome",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "business-operations-strategy",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:recruiting|onboarding|employee management|offboarding)"
+            ],
+            "priority": 65,
+            "tied_for_first": true
+          }
+        ],
         "winner": {
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "customer"
+            "\\b(?:sales pipeline|customer success|crm contacts?)\\b"
           ],
           "priority": 110,
-          "tie_detected": false
+          "tie_detected": true
         }
       },
       "description": "Customer success management - onboarding, health scoring, QBRs, expansion playbooks, and retention strategies",
@@ -7184,12 +6990,12 @@
     {
       "assignments": [],
       "category_id": "sales-crm-customer-success",
-      "classification": "slug:customer;metadata:frontmatter",
+      "classification": "outcome:\\b(?:sales pipeline|customer success|crm contacts?)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "customer"
+          "\\b(?:sales pipeline|customer success|crm contacts?)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -7197,7 +7003,7 @@
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "customer"
+            "\\b(?:sales pipeline|customer success|crm contacts?)\\b"
           ],
           "priority": 110,
           "tie_detected": false
@@ -7258,10 +7064,10 @@
     {
       "assignments": [],
       "category_id": "business-operations-strategy",
-      "classification": "slug:daily-;metadata:frontmatter",
+      "classification": "slug:daily-(?:brief|planning|standup|operations|review);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "daily-"
+          "daily-(?:brief|planning|standup|operations|review)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7271,7 +7077,7 @@
           "category_id": "business-operations-strategy",
           "match_count": 1,
           "matched_signals": [
-            "daily-"
+            "daily-(?:brief|planning|standup|operations|review)"
           ],
           "priority": 65,
           "tie_detected": false
@@ -7305,15 +7111,6 @@
               "content"
             ],
             "priority": 100,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "daily-"
-            ],
-            "priority": 65,
             "tied_for_first": true
           }
         ],
@@ -7356,15 +7153,6 @@
             ],
             "priority": 100,
             "tied_for_first": true
-          },
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "daily-"
-            ],
-            "priority": 65,
-            "tied_for_first": true
           }
         ],
         "winner": {
@@ -7395,19 +7183,9 @@
           "portfolio"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "daily-"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "finance-trading-markets",
           "match_count": 1,
@@ -7415,7 +7193,7 @@
             "portfolio"
           ],
           "priority": 120,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "你是Quant。早间全量盘点，输出持仓日报。",
@@ -7429,23 +7207,23 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:daily-;metadata:fallback",
+      "category_id": "finance-trading-markets",
+      "classification": "description:quant;metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "daily-"
+          "quant"
         ],
-        "method": "slug",
+        "method": "description",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "business-operations-strategy",
+          "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "daily-"
+            "quant"
           ],
-          "priority": 65,
+          "priority": 120,
           "tie_detected": false
         }
       },
@@ -7460,23 +7238,23 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:daily-;metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "slug:(?:^|-)(?:daily|today)-trending(?:-|$)|热榜|热搜;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "daily-"
+          "(?:^|-)(?:daily|today)-trending(?:-|$)|热榜|热搜"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "business-operations-strategy",
+          "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "daily-"
+            "(?:^|-)(?:daily|today)-trending(?:-|$)|热榜|热搜"
           ],
-          "priority": 65,
+          "priority": 95,
           "tie_detected": false
         }
       },
@@ -7508,15 +7286,6 @@
               "content"
             ],
             "priority": 100,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "daily-"
-            ],
-            "priority": 65,
             "tied_for_first": true
           }
         ],
@@ -7580,10 +7349,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7593,7 +7362,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -7611,10 +7380,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7624,7 +7393,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -7642,10 +7411,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7655,7 +7424,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -7672,43 +7441,24 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "category_id": "cloud-devops-reliability",
+      "classification": "outcome:\\b(?:datadog|grafana|kubernetes|docker)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "\\b(?:datadog|grafana|kubernetes|docker)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "cloud-devops-reliability",
-            "match_count": 1,
-            "matched_signals": [
-              "datadog"
-            ],
-            "priority": 85,
-            "tied_for_first": true
-          },
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "automation"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
+          "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "\\b(?:datadog|grafana|kubernetes|docker)\\b"
           ],
-          "priority": 95,
-          "tie_detected": true
+          "priority": 85,
+          "tie_detected": false
         }
       },
       "description": "Automate Datadog tasks via Rube MCP (Composio): query metrics, search logs, manage monitors/dashboards, create events and downtimes. Always search tools first for current schemas.",
@@ -7737,17 +7487,7 @@
         "method": "description",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "data"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "software-engineering",
           "match_count": 2,
@@ -7791,16 +7531,15 @@
         "base_candidates": [
           {
             "category_id": "data-analytics-research",
-            "match_count": 2,
+            "match_count": 1,
             "matched_signals": [
-              "research",
-              "search"
+              "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
             ],
             "priority": 95,
             "tied_for_first": true
           }
         ],
-        "base_method": "slug",
+        "base_method": "outcome",
         "matched_signals": [],
         "method": "override",
         "rationale": "Evidence collection and synthesis are the primary outcomes.",
@@ -7830,34 +7569,24 @@
     },
     {
       "assignments": [],
-      "category_id": "software-engineering",
-      "classification": "description:github;metadata:frontmatter",
+      "category_id": "general-utilities",
+      "classification": "outcome:(?:deep work|focus sessions?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "github"
+          "(?:deep work|focus sessions?)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "telegram"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
+          "category_id": "general-utilities",
           "match_count": 1,
           "matched_signals": [
-            "github"
+            "(?:deep work|focus sessions?)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 0,
+          "tie_detected": false
         }
       },
       "description": "Track deep work sessions locally (start/stop/status) and generate a GitHub-contribution-graph style minutes-per-day heatmap for sharing (e.g., via Telegram). Use when the user…",
@@ -7872,10 +7601,10 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "slug:defi;metadata:frontmatter",
+      "classification": "slug:(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "defi"
+          "(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7885,7 +7614,7 @@
           "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "defi"
+            "(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b"
           ],
           "priority": 120,
           "tie_detected": false
@@ -7934,10 +7663,10 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:audit;metadata:frontmatter",
+      "classification": "slug:(?:^|-)dependency-auditor(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "audit"
+          "(?:^|-)dependency-auditor(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -7947,7 +7676,7 @@
           "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "audit"
+            "(?:^|-)dependency-auditor(?:-|$)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -8009,33 +7738,23 @@
         }
       ],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:deploy;metadata:frontmatter",
+      "classification": "outcome:\\b(?:datadog|grafana|kubernetes|docker)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "deploy"
+          "\\b(?:datadog|grafana|kubernetes|docker)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "automation"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "deploy"
+            "\\b(?:datadog|grafana|kubernetes|docker)\\b"
           ],
           "priority": 85,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Automate application deployment to cloud platforms and servers. Use when setting up CI/CD pipelines, deploying to Docker/Kubernetes, or configuring cloud infrastructure. Handles…",
@@ -8094,15 +7813,6 @@
         "resolution_status": "priority-tie",
         "review_state": "unreviewed",
         "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          },
           {
             "category_id": "software-engineering",
             "match_count": 1,
@@ -8277,12 +7987,12 @@
     {
       "assignments": [],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:distributed-tracing;metadata:frontmatter",
+      "classification": "outcome:\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "distributed-tracing"
+          "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -8290,7 +8000,7 @@
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "distributed-tracing"
+            "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
           ],
           "priority": 85,
           "tie_detected": false
@@ -8307,34 +8017,24 @@
     },
     {
       "assignments": [],
-      "category_id": "apps-workflow-automation",
-      "classification": "description:workflow;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "workflow"
+          "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "decision"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "apps-workflow-automation",
+          "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "workflow"
+            "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
           ],
-          "priority": 70,
-          "tie_detected": true
+          "priority": 100,
+          "tie_detected": false
         }
       },
       "description": "Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar…",
@@ -8358,12 +8058,12 @@
         }
       ],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:docker;metadata:frontmatter",
+      "classification": "outcome:\\b(?:datadog|grafana|kubernetes|docker)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "docker"
+          "\\b(?:datadog|grafana|kubernetes|docker)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -8371,7 +8071,7 @@
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "docker"
+            "\\b(?:datadog|grafana|kubernetes|docker)\\b"
           ],
           "priority": 85,
           "tie_detected": false
@@ -8392,10 +8092,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:data;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "description",
         "resolution_status": "priority-tie",
@@ -8415,7 +8115,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": true
@@ -8667,33 +8367,23 @@
         }
       ],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:douyin;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "douyin"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "douyin"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "抖音图文/视频发布（OpenClaw Browser 自动化）：登录检测→内容校验→上传页导航→填标题/正文→上传封面+素材→暂存离开。",
@@ -8718,33 +8408,23 @@
         }
       ],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:douyin;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "douyin"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "douyin"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "抖音创作者平台智能发布（视频/图文）：内容适配→上传→填描述/#话题→封面→存草稿→截图回传确认。默认只存草稿；只有在 Daniel 明确确认后才允许点击发布。覆盖标题(≤55字)、描述(建议≤200字)、#话题标签(3-5个)、封面设置、定时发布、可见性、合拍/下载开关。Playwright 自动化。触发：'发抖音'、'抖音发布'、'douyin…",
@@ -8862,7 +8542,7 @@
             "category_id": "ai-agents-orchestration",
             "match_count": 1,
             "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
+              "(?:^|-)skills(?:-|$)"
             ],
             "priority": 75,
             "tied_for_first": true
@@ -8904,12 +8584,12 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:testing;metadata:frontmatter",
+      "classification": "outcome:(?:async|flaky).{0,20}tests?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "testing"
+          "(?:async|flaky).{0,20}tests?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -8917,7 +8597,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "testing"
+            "(?:async|flaky).{0,20}tests?"
           ],
           "priority": 80,
           "tie_detected": false
@@ -9061,34 +8741,26 @@
     },
     {
       "assignments": [],
-      "category_id": "software-engineering",
-      "classification": "slug:github;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:(?:^|-)skills(?:-|$),(?:^|-)skills-(?:hub|repository|index|library)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "github"
+          "(?:^|-)skills(?:-|$)",
+          "(?:^|-)skills-(?:hub|repository|index|library)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
-          "match_count": 1,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 2,
           "matched_signals": [
-            "github"
+            "(?:^|-)skills(?:-|$)",
+            "(?:^|-)skills-(?:hub|repository|index|library)(?:-|$)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Curated hub of the highest-value GitHub skills/repos for Claude Code, Cursor, Codex, Gemini CLI, and OpenClaw. Links to 20+ elite repos organized by tier. Use when discovering,…",
@@ -9476,10 +9148,10 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "description:code;metadata:frontmatter",
+      "classification": "description:\\bcodebases?\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "\\bcodebases?\\b"
         ],
         "method": "description",
         "resolution_status": "rule-match",
@@ -9489,7 +9161,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "\\bcodebases?\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -9520,10 +9192,9 @@
         "runner_ups": [
           {
             "category_id": "software-engineering",
-            "match_count": 2,
+            "match_count": 1,
             "matched_signals": [
-              "code",
-              "github"
+              "(?:^|-)code(?:-|$)|\\bcode\\b"
             ],
             "priority": 80,
             "tied_for_first": false
@@ -9642,12 +9313,12 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:\\betl\\b;metadata:frontmatter",
+      "classification": "outcome:(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\betl\\b"
+          "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -9655,7 +9326,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "\\betl\\b"
+            "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -9673,10 +9344,10 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "description:code,development;metadata:frontmatter",
+      "classification": "description:(?:^|-)code(?:-|$)|\\bcode\\b,development;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code",
+          "(?:^|-)code(?:-|$)|\\bcode\\b",
           "development"
         ],
         "method": "description",
@@ -9697,7 +9368,7 @@
           "category_id": "software-engineering",
           "match_count": 2,
           "matched_signals": [
-            "code",
+            "(?:^|-)code(?:-|$)|\\bcode\\b",
             "development"
           ],
           "priority": 80,
@@ -9715,34 +9386,24 @@
     },
     {
       "assignments": [],
-      "category_id": "content-media-publishing",
-      "classification": "description:publish;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "outcome:\\b(?:a2a|agent-to-agent) protocol\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "publish"
+          "\\b(?:a2a|agent-to-agent) protocol\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "task"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "content-media-publishing",
+          "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "publish"
+            "\\b(?:a2a|agent-to-agent) protocol\\b"
           ],
-          "priority": 100,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Connect to the EvoMap collaborative evolution marketplace. Publish Gene+Capsule bundles, fetch promoted assets, claim bounty tasks, and earn credits via the GEP-A2A protocol. Use…",
@@ -9883,23 +9544,23 @@
     },
     {
       "assignments": [],
-      "category_id": "apps-workflow-automation",
-      "classification": "description:workflow;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "outcome:\\bfabric patterns?\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "workflow"
+          "\\bfabric patterns?\\b"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "apps-workflow-automation",
+          "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "workflow"
+            "\\bfabric patterns?\\b"
           ],
-          "priority": 70,
+          "priority": 75,
           "tie_detected": false
         }
       },
@@ -10153,33 +9814,23 @@
     {
       "assignments": [],
       "category_id": "product-design-ux",
-      "classification": "slug:figma;metadata:frontmatter",
+      "classification": "outcome:\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "figma"
+          "\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "automation"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "product-design-ux",
           "match_count": 1,
           "matched_signals": [
-            "figma"
+            "\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag)"
           ],
           "priority": 90,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Automate Figma tasks via Rube MCP (Composio): files, components, design tokens, comments, exports. Always search tools first for current schemas.",
@@ -10194,22 +9845,20 @@
     {
       "assignments": [],
       "category_id": "product-design-ux",
-      "classification": "slug:design,figma;metadata:frontmatter",
+      "classification": "outcome:\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design",
-          "figma"
+          "\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "product-design-ux",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "design",
-            "figma"
+            "\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag)"
           ],
           "priority": 90,
           "tie_detected": false
@@ -10226,34 +9875,24 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "description:context;metadata:frontmatter",
+      "category_id": "general-utilities",
+      "classification": "outcome:(?:organize|deduplicate|clean up).{0,24}(?:local )?(?:files|folders);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "context"
+          "(?:organize|deduplicate|clean up).{0,24}(?:local )?(?:files|folders)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "task"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "general-utilities",
           "match_count": 1,
           "matched_signals": [
-            "context"
+            "(?:organize|deduplicate|clean up).{0,24}(?:local )?(?:files|folders)"
           ],
-          "priority": 75,
-          "tie_detected": true
+          "priority": 0,
+          "tie_detected": false
         }
       },
       "description": "Intelligently organizes your files and folders across your computer by understanding context, finding duplicates, suggesting better structures, and automating cleanup tasks.…",
@@ -10368,12 +10007,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -10381,7 +10020,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
           ],
           "priority": 75,
           "tie_detected": false
@@ -10468,12 +10107,12 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:crawl;metadata:frontmatter",
+      "classification": "outcome:(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "crawl"
+          "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -10481,7 +10120,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "crawl"
+            "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -10499,12 +10138,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:orchestrat;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "orchestrat"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -10512,7 +10151,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "orchestrat"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -10561,10 +10200,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -10574,7 +10213,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -10664,33 +10303,23 @@
     {
       "assignments": [],
       "category_id": "sales-crm-customer-success",
-      "classification": "slug:freshservice;metadata:frontmatter",
+      "classification": "outcome:(?:cold|outbound).{0,16}(?:email|outreach|sales);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "freshservice"
+          "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "automation"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "freshservice"
+            "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
           ],
           "priority": 110,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Automate Freshservice ITSM tasks via Rube MCP (Composio): create/update tickets, bulk operations, service requests, and outbound emails. Always search tools first for current…",
@@ -10802,22 +10431,20 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:compliance,gdpr;metadata:frontmatter",
+      "classification": "outcome:\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "compliance",
-          "gdpr"
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "compliance",
-            "gdpr"
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -10840,20 +10467,22 @@
         }
       ],
       "category_id": "security-privacy-legal",
-      "classification": "slug:gdpr;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment),\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "gdpr"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)",
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "gdpr"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)",
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -10990,20 +10619,32 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "description:github;metadata:frontmatter",
+      "classification": "outcome:(?:github )?issues?.{0,48}(?:implement fixes|fix bugs),open (?:pull requests?|prs?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "github"
+          "(?:github )?issues?.{0,48}(?:implement fixes|fix bugs)",
+          "open (?:pull requests?|prs?)"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "ai-agents-orchestration",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
+            ],
+            "priority": 75,
+            "tied_for_first": false
+          }
+        ],
         "winner": {
           "category_id": "software-engineering",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "github"
+            "(?:github )?issues?.{0,48}(?:implement fixes|fix bugs)",
+            "open (?:pull requests?|prs?)"
           ],
           "priority": 80,
           "tie_detected": false
@@ -11028,10 +10669,10 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -11041,7 +10682,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -11107,20 +10748,22 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:github;metadata:frontmatter",
+      "classification": "description:\\bapi\\b,(?:^|-)cli(?:-|$)|\\bcli\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "github"
+          "\\bapi\\b",
+          "(?:^|-)cli(?:-|$)|\\bcli\\b"
         ],
-        "method": "slug",
+        "method": "description",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "software-engineering",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "github"
+            "\\bapi\\b",
+            "(?:^|-)cli(?:-|$)|\\bcli\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -11149,19 +10792,11 @@
       "classification_details": {
         "base_candidates": [
           {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "github"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          },
-          {
             "category_id": "apps-workflow-automation",
-            "match_count": 1,
+            "match_count": 2,
             "matched_signals": [
-              "automation"
+              "automation",
+              "(?:^|-)(?:github|gitlab)-automation(?:-|$)"
             ],
             "priority": 70,
             "tied_for_first": true
@@ -11199,34 +10834,24 @@
     },
     {
       "assignments": [],
-      "category_id": "software-engineering",
-      "classification": "slug:gitlab;metadata:frontmatter",
+      "category_id": "apps-workflow-automation",
+      "classification": "outcome:(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "gitlab"
+          "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "apps-workflow-automation",
-            "match_count": 1,
-            "matched_signals": [
-              "automation"
-            ],
-            "priority": 70,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
+          "category_id": "apps-workflow-automation",
           "match_count": 1,
           "matched_signals": [
-            "gitlab"
+            "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 70,
+          "tie_detected": false
         }
       },
       "description": "Automate GitLab project management, issues, merge requests, pipelines, branches, and user operations via Rube MCP (Composio). Always search tools first for current schemas.",
@@ -11310,12 +10935,12 @@
         }
       ],
       "category_id": "data-analytics-research",
-      "classification": "slug:analytics;metadata:frontmatter",
+      "classification": "outcome:(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analytics"
+          "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -11323,7 +10948,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "analytics"
+            "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -11580,22 +11205,20 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),orchestrat;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)",
-          "orchestrat"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)",
-            "orchestrat"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -11755,33 +11378,23 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "description:video;metadata:frontmatter",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "video"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "\\bapi\\b"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "video"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
           "priority": 100,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Create AI digital human videos with HeyGen API. Free starter guide.",
@@ -11796,12 +11409,12 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "slug:quant;metadata:frontmatter",
+      "classification": "outcome:(?:quantitative|algorithmic).{0,20}(?:trading|finance|investment);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "quant"
+          "(?:quantitative|algorithmic).{0,20}(?:trading|finance|investment)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -11809,7 +11422,7 @@
           "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "quant"
+            "(?:quantitative|algorithmic).{0,20}(?:trading|finance|investment)"
           ],
           "priority": 120,
           "tie_detected": false
@@ -12132,12 +11745,12 @@
     {
       "assignments": [],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:incident;metadata:frontmatter",
+      "classification": "outcome:(?:incident|reliability).{0,24}(?:response|runbook|operations);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "incident"
+          "(?:incident|reliability).{0,24}(?:response|runbook|operations)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -12145,7 +11758,7 @@
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "incident"
+            "(?:incident|reliability).{0,24}(?:response|runbook|operations)"
           ],
           "priority": 85,
           "tie_detected": false
@@ -12167,34 +11780,24 @@
           "level": "harnessSpecific"
         }
       ],
-      "category_id": "security-privacy-legal",
-      "classification": "description:audit;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "description:openclaw;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "audit"
+          "openclaw"
         ],
         "method": "description",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "openclaw"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "security-privacy-legal",
+          "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "audit"
+            "openclaw"
           ],
-          "priority": 115,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Audit OpenClaw token usage, purge stale sessions, and optimize inference speed. Use when the user sends /optimize, /audit, asks to purge sessions, or wants a token/workspace audit.",
@@ -12242,10 +11845,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:data;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "description",
         "resolution_status": "priority-tie",
@@ -12265,7 +11868,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": true
@@ -12354,34 +11957,24 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "description:claude;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "claude"
+          "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "company"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "claude"
+            "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
           ],
-          "priority": 75,
-          "tie_detected": true
+          "priority": 100,
+          "tie_detected": false
         }
       },
       "description": "A set of resources to help me write all kinds of internal communications, using the formats that my company likes to use. Claude should use this skill whenever asked to write…",
@@ -12622,19 +12215,23 @@
           "level": "required"
         }
       ],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$);metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "content-media-publishing",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"
+          ],
+          "priority": 100,
           "tie_detected": false
         }
       },
@@ -12652,22 +12249,20 @@
     {
       "assignments": [],
       "category_id": "apps-workflow-automation",
-      "classification": "slug:automation,jira;metadata:frontmatter",
+      "classification": "outcome:(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "automation",
-          "jira"
+          "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "apps-workflow-automation",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "automation",
-            "jira"
+            "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
           ],
           "priority": 70,
           "tie_detected": false
@@ -12729,33 +12324,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:juejin;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "juejin"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "juejin"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "掘金技术社区智能发布：Markdown编辑器全功能支持。覆盖标题(15-35字)、分类(必选)、标签(1-5个)、封面上传、摘要填写、GFM排版。Playwright自动化+API双通道发布。触发：发掘金、掘金发布、juejin publish、掘金文章、技术博客发布。",
@@ -12769,11 +12354,11 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "category_id": "apps-workflow-automation",
+      "classification": "slug:(?:^|-)kanbanflow(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:^|-)kanbanflow(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -12790,12 +12375,12 @@
           }
         ],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "apps-workflow-automation",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:^|-)kanbanflow(?:-|$)"
           ],
-          "priority": 75,
+          "priority": 70,
           "tie_detected": true
         }
       },
@@ -12957,13 +12542,13 @@
     {
       "assignments": [],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:deploy,kubernetes;metadata:frontmatter",
+      "classification": "outcome:\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b,\\b(?:datadog|grafana|kubernetes|docker)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "deploy",
-          "kubernetes"
+          "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b",
+          "\\b(?:datadog|grafana|kubernetes|docker)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -12971,8 +12556,8 @@
           "category_id": "cloud-devops-reliability",
           "match_count": 2,
           "matched_signals": [
-            "deploy",
-            "kubernetes"
+            "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b",
+            "\\b(?:datadog|grafana|kubernetes|docker)\\b"
           ],
           "priority": 85,
           "tie_detected": false
@@ -13003,12 +12588,12 @@
         }
       ],
       "category_id": "cloud-devops-reliability",
-      "classification": "slug:kubernetes;metadata:frontmatter",
+      "classification": "outcome:\\b(?:datadog|grafana|kubernetes|docker)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "kubernetes"
+          "\\b(?:datadog|grafana|kubernetes|docker)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -13016,7 +12601,7 @@
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "kubernetes"
+            "\\b(?:datadog|grafana|kubernetes|docker)\\b"
           ],
           "priority": 85,
           "tie_detected": false
@@ -13068,23 +12653,23 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "outcome:\\bresearch (?:a|any|the) topic\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "\\bresearch (?:a|any|the) topic\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "\\bresearch (?:a|any|the) topic\\b"
           ],
-          "priority": 75,
+          "priority": 95,
           "tie_detected": false
         }
       },
@@ -13181,12 +12766,12 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:legal;metadata:frontmatter",
+      "classification": "outcome:\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "legal"
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -13194,7 +12779,7 @@
           "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "legal"
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -13286,12 +12871,12 @@
         }
       ],
       "category_id": "security-privacy-legal",
-      "classification": "slug:legal;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "legal"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -13299,7 +12884,7 @@
           "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "legal"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -13382,23 +12967,23 @@
     },
     {
       "assignments": [],
-      "category_id": "apps-workflow-automation",
-      "classification": "description:automation;metadata:frontmatter",
+      "category_id": "sales-crm-customer-success",
+      "classification": "slug:(?:^|-)linkedin-(?:cdp|outreach|lead|sales|connect)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "automation"
+          "(?:^|-)linkedin-(?:cdp|outreach|lead|sales|connect)(?:-|$)"
         ],
-        "method": "description",
+        "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "apps-workflow-automation",
+          "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "automation"
+            "(?:^|-)linkedin-(?:cdp|outreach|lead|sales|connect)(?:-|$)"
           ],
-          "priority": 70,
+          "priority": 110,
           "tie_detected": false
         }
       },
@@ -13538,17 +13123,21 @@
     {
       "assignments": [],
       "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "classification": "outcome:\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜;metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
+        ],
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
+          "match_count": 1,
+          "matched_signals": [
+            "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
+          ],
           "priority": 0,
           "tie_detected": false
         }
@@ -13564,34 +13153,24 @@
     },
     {
       "assignments": [],
-      "category_id": "software-engineering",
-      "classification": "description:\\bapi\\b;metadata:frontmatter",
+      "category_id": "general-utilities",
+      "classification": "outcome:\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bapi\\b"
+          "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "\\bllm\\b"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
+          "category_id": "general-utilities",
           "match_count": 1,
           "matched_signals": [
-            "\\bapi\\b"
+            "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 0,
+          "tie_detected": false
         }
       },
       "description": "六爻易经占卜器，基于京房纳甲体系，模拟铜钱起卦，完成纳甲装卦（天干地支、世应、六亲、六神）， 通过用神旺衰和生克制化断卦。当用户提及「六爻」「易经占卜」「铜钱起卦」「纳甲」「帮我起一卦」 「六爻预测」时触发。装卦为确定性计算 + LLM 综合断卦，无外部 API 依赖。 不适用于：梅花易数、奇门遁甲、星座运势、塔罗占卜、八字命理等其他领域 → 建议使用…",
@@ -13867,19 +13446,23 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:fallback",
+      "category_id": "data-analytics-research",
+      "classification": "slug:(?:^|-)market-intelligence(?:-|$);metadata:fallback",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)market-intelligence(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "data-analytics-research",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)market-intelligence(?:-|$)"
+          ],
+          "priority": 95,
           "tie_detected": false
         }
       },
@@ -13925,34 +13508,24 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "description:analysis;metadata:frontmatter",
+      "category_id": "business-operations-strategy",
+      "classification": "description:strategy;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "strategy"
         ],
         "method": "description",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "strategy"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
+          "category_id": "business-operations-strategy",
           "match_count": 1,
           "matched_signals": [
-            "analysis"
+            "strategy"
           ],
-          "priority": 95,
-          "tie_detected": true
+          "priority": 65,
+          "tie_detected": false
         }
       },
       "description": "Nightly market evolution report — overnight market analysis and strategy prep",
@@ -14069,10 +13642,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:analysis;metadata:frontmatter",
+      "classification": "slug:(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -14082,7 +13655,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "analysis"
+            "(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -14226,12 +13799,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:\\bmcp\\b;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bmcp\\b"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -14239,7 +13812,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "\\bmcp\\b"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -14257,12 +13830,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:\\bmcp\\b;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bmcp\\b"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -14270,7 +13843,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "\\bmcp\\b"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -14582,12 +14155,12 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:metrics;metadata:frontmatter",
+      "classification": "outcome:(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "metrics"
+          "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -14595,7 +14168,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "metrics"
+            "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -14643,34 +14216,24 @@
     },
     {
       "assignments": [],
-      "category_id": "marketing-seo-growth",
-      "classification": "description:traffic;metadata:frontmatter",
+      "category_id": "cloud-devops-reliability",
+      "classification": "outcome:\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "traffic"
+          "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "architecture"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "marketing-seo-growth",
+          "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "traffic"
+            "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
           ],
-          "priority": 105,
-          "tie_detected": true
+          "priority": 85,
+          "tie_detected": false
         }
       },
       "description": "Comprehensive microservices patterns skill covering service mesh, traffic management, circuit breakers, resilience patterns, Istio, and production microservices architecture",
@@ -14966,42 +14529,11 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)model(?:-|$);metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "slug:(?:^|-)model-usage(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)model(?:-|$)"
-        ],
-        "method": "slug",
-        "resolution_status": "rule-match",
-        "review_state": "unreviewed",
-        "runner_ups": [],
-        "winner": {
-          "category_id": "ai-agents-orchestration",
-          "match_count": 1,
-          "matched_signals": [
-            "(?:^|-)model(?:-|$)"
-          ],
-          "priority": 75,
-          "tie_detected": false
-        }
-      },
-      "description": "Use CodexBar CLI local cost usage to summarize per-model usage for Codex",
-      "description_status": "source-text",
-      "path": "skills/model-usage/SKILL.md",
-      "portability_class": "catalog-only",
-      "review_signals": [],
-      "skill_id": "model-usage",
-      "support_level": "catalog",
-      "used_by": []
-    },
-    {
-      "assignments": [],
-      "category_id": "cloud-devops-reliability",
-      "classification": "slug:linux;metadata:frontmatter",
-      "classification_details": {
-        "matched_signals": [
-          "linux"
+          "(?:^|-)model-usage(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "priority-tie",
@@ -15018,12 +14550,62 @@
           }
         ],
         "winner": {
-          "category_id": "cloud-devops-reliability",
+          "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "linux"
+            "(?:^|-)model-usage(?:-|$)"
           ],
-          "priority": 85,
+          "priority": 95,
+          "tie_detected": true
+        }
+      },
+      "description": "Use CodexBar CLI local cost usage to summarize per-model usage for Codex",
+      "description_status": "source-text",
+      "path": "skills/model-usage/SKILL.md",
+      "portability_class": "catalog-only",
+      "review_signals": [],
+      "skill_id": "model-usage",
+      "support_level": "catalog",
+      "used_by": []
+    },
+    {
+      "assignments": [],
+      "category_id": "data-analytics-research",
+      "classification": "slug:(?:^|-)model-usage(?:-|$);metadata:frontmatter",
+      "classification_details": {
+        "matched_signals": [
+          "(?:^|-)model-usage(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "priority-tie",
+        "review_state": "unreviewed",
+        "runner_ups": [
+          {
+            "category_id": "cloud-devops-reliability",
+            "match_count": 1,
+            "matched_signals": [
+              "linux"
+            ],
+            "priority": 85,
+            "tied_for_first": true
+          },
+          {
+            "category_id": "ai-agents-orchestration",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:^|-)model(?:-|$)"
+            ],
+            "priority": 75,
+            "tied_for_first": true
+          }
+        ],
+        "winner": {
+          "category_id": "data-analytics-research",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)model-usage(?:-|$)"
+          ],
+          "priority": 95,
           "tie_detected": true
         }
       },
@@ -15103,32 +14685,20 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),multi-agent;metadata:frontmatter",
+      "classification": "outcome:(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)",
-          "multi-agent"
+          "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "architecture"
-            ],
-            "priority": 80,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)",
-            "multi-agent"
+            "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -15609,34 +15179,24 @@
     },
     {
       "assignments": [],
-      "category_id": "product-design-ux",
-      "classification": "slug:design;metadata:frontmatter",
+      "category_id": "cloud-devops-reliability",
+      "classification": "outcome:\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design"
+          "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "cloud-devops-reliability",
-            "match_count": 1,
-            "matched_signals": [
-              "observability"
-            ],
-            "priority": 85,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "cloud-devops-reliability",
           "match_count": 1,
           "matched_signals": [
-            "design"
+            "\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 85,
+          "tie_detected": false
         }
       },
       "description": "Design production observability strategies covering SLI/SLOs, metrics,",
@@ -15660,10 +15220,11 @@
         }
       ],
       "category_id": "business-operations-strategy",
-      "classification": "slug:\\bokr\\b;metadata:frontmatter",
+      "classification": "slug:\\bokr\\b,(?:^|-)okrs?(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bokr\\b"
+          "\\bokr\\b",
+          "(?:^|-)okrs?(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -15671,9 +15232,10 @@
         "runner_ups": [],
         "winner": {
           "category_id": "business-operations-strategy",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "\\bokr\\b"
+            "\\bokr\\b",
+            "(?:^|-)okrs?(?:-|$)"
           ],
           "priority": 65,
           "tie_detected": false
@@ -15890,34 +15452,24 @@
     },
     {
       "assignments": [],
-      "category_id": "apps-workflow-automation",
-      "classification": "slug:email-;metadata:frontmatter",
+      "category_id": "sales-crm-customer-success",
+      "classification": "outcome:(?:cold|outbound).{0,16}(?:email|outreach|sales);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "email-"
+          "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "strategy"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "apps-workflow-automation",
+          "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "email-"
+            "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
           ],
-          "priority": 70,
-          "tie_detected": true
+          "priority": 110,
+          "tie_detected": false
         }
       },
       "description": "Comprehensive outbound email strategy skill for cold outreach, email sequences, and multi-channel campaigns. Use when writing cold emails, creating outreach sequences, optimizing…",
@@ -15932,12 +15484,12 @@
     {
       "assignments": [],
       "category_id": "sales-crm-customer-success",
-      "classification": "description:outreach;metadata:frontmatter",
+      "classification": "outcome:(?:cold|outbound).{0,16}(?:email|outreach|sales);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "outreach"
+          "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -15945,7 +15497,7 @@
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "outreach"
+            "(?:cold|outbound).{0,16}(?:email|outreach|sales)"
           ],
           "priority": 110,
           "tie_detected": false
@@ -16058,41 +15610,20 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "description:orchestrat,multi-agent;metadata:frontmatter",
+      "classification": "outcome:(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "orchestrat",
-          "multi-agent"
+          "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          },
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "task"
-            ],
-            "priority": 65,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "orchestrat",
-            "multi-agent"
+            "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -16203,22 +15734,20 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:compliance,pci;metadata:frontmatter",
+      "classification": "outcome:\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "compliance",
-          "pci"
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "compliance",
-            "pci"
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -16280,7 +15809,7 @@
             "category_id": "software-engineering",
             "match_count": 1,
             "matched_signals": [
-              "code"
+              "(?:^|-)code(?:-|$)|\\bcode\\b"
             ],
             "priority": 80,
             "tied_for_first": true
@@ -16339,10 +15868,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:data;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "description",
         "resolution_status": "rule-match",
@@ -16352,7 +15881,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -16936,17 +16465,7 @@
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "data"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "software-engineering",
           "match_count": 2,
@@ -17065,12 +16584,12 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "slug:pptx;metadata:frontmatter",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "pptx"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -17078,7 +16597,7 @@
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "pptx"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -17246,34 +16765,24 @@
           "level": "required"
         }
       ],
-      "category_id": "product-design-ux",
-      "classification": "slug:prioritization;metadata:frontmatter",
+      "category_id": "business-operations-strategy",
+      "classification": "outcome:(?:prioritize|allocate).{0,24}(?:resources?|projects?|opportunities);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "prioritization"
+          "(?:prioritize|allocate).{0,24}(?:resources?|projects?|opportunities)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "priorit"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "business-operations-strategy",
           "match_count": 1,
           "matched_signals": [
-            "prioritization"
+            "(?:prioritize|allocate).{0,24}(?:resources?|projects?|opportunities)"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 65,
+          "tie_detected": false
         }
       },
       "description": "Evaluate and prioritize opportunities through a structured filtering process. Use for resource allocation, strategic decision support, and project management.",
@@ -17290,13 +16799,13 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:privacy,compliance;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment),\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "privacy",
-          "compliance"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)",
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -17304,8 +16813,8 @@
           "category_id": "security-privacy-legal",
           "match_count": 2,
           "matched_signals": [
-            "privacy",
-            "compliance"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)",
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -17385,12 +16894,12 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:\\bseo\\b;metadata:frontmatter",
+      "classification": "outcome:\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bseo\\b"
+          "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -17398,7 +16907,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "\\bseo\\b"
+            "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
           ],
           "priority": 105,
           "tie_detected": false
@@ -17551,34 +17060,24 @@
           "level": "harnessSpecific"
         }
       ],
-      "category_id": "software-engineering",
-      "classification": "description:\\bapi\\b;metadata:frontmatter",
+      "category_id": "security-privacy-legal",
+      "classification": "outcome:(?:audit|rotate|manage|sync).{0,24}(?:api keys?|credentials?|secrets?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bapi\\b"
+          "(?:audit|rotate|manage|sync).{0,24}(?:api keys?|credentials?|secrets?)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "multi-agent"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "software-engineering",
+          "category_id": "security-privacy-legal",
           "match_count": 1,
           "matched_signals": [
-            "\\bapi\\b"
+            "(?:audit|rotate|manage|sync).{0,24}(?:api keys?|credentials?|secrets?)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 115,
+          "tie_detected": false
         }
       },
       "description": "Provider key manager — rotate and sync API keys across multi-agent workspaces",
@@ -17601,19 +17100,9 @@
           "proxmox"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "cloud-devops-reliability",
           "match_count": 1,
@@ -17621,7 +17110,7 @@
             "proxmox"
           ],
           "priority": 85,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Create a credential file at `~/.proxmox-credentials`",
@@ -17636,10 +17125,10 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "description:code,debug;metadata:frontmatter",
+      "classification": "description:(?:^|-)code(?:-|$)|\\bcode\\b,debug;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code",
+          "(?:^|-)code(?:-|$)|\\bcode\\b",
           "debug"
         ],
         "method": "description",
@@ -17660,7 +17149,7 @@
           "category_id": "software-engineering",
           "match_count": 2,
           "matched_signals": [
-            "code",
+            "(?:^|-)code(?:-|$)|\\bcode\\b",
             "debug"
           ],
           "priority": 80,
@@ -17840,34 +17329,24 @@
           "level": "required"
         }
       ],
-      "category_id": "finance-trading-markets",
-      "classification": "description:defi;metadata:frontmatter",
+      "category_id": "general-utilities",
+      "classification": "slug:(?:^|-)quality-(?:convergence|acceptance)(?:-|$)|(?:^|-)acceptance-engine(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "defi"
+          "(?:^|-)quality-(?:convergence|acceptance)(?:-|$)|(?:^|-)acceptance-engine(?:-|$)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "product-design-ux",
-            "match_count": 1,
-            "matched_signals": [
-              "requirements"
-            ],
-            "priority": 90,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "finance-trading-markets",
+          "category_id": "general-utilities",
           "match_count": 1,
           "matched_signals": [
-            "defi"
+            "(?:^|-)quality-(?:convergence|acceptance)(?:-|$)|(?:^|-)acceptance-engine(?:-|$)"
           ],
-          "priority": 120,
-          "tie_detected": true
+          "priority": 0,
+          "tie_detected": false
         }
       },
       "description": "Multi-dimensional Quality Acceptance and Problem Convergence Engine - Deeply deconstruct requirements, eliminate extreme defects, define absolutely objective acceptance and…",
@@ -18098,10 +17577,11 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:react;metadata:frontmatter",
+      "classification": "slug:react,(?:^|-)(?:senior-)?architect(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "react"
+          "react",
+          "(?:^|-)(?:senior-)?architect(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -18109,9 +17589,10 @@
         "runner_ups": [],
         "winner": {
           "category_id": "software-engineering",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "react"
+            "react",
+            "(?:^|-)(?:senior-)?architect(?:-|$)"
           ],
           "priority": 80,
           "tie_detected": false
@@ -18241,12 +17722,12 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "outcome:\\bcode (?:repository|review|testing|debugging)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "\\bcode (?:repository|review|testing|debugging)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -18254,7 +17735,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "\\bcode (?:repository|review|testing|debugging)\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -18436,10 +17917,11 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "description:polymarket;metadata:frontmatter",
+      "classification": "description:polymarket,\\bp&l\\b|量化|交易|投资组合|风控;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "polymarket"
+          "polymarket",
+          "\\bp&l\\b|量化|交易|投资组合|风控"
         ],
         "method": "description",
         "resolution_status": "rule-match",
@@ -18447,9 +17929,10 @@
         "runner_ups": [],
         "winner": {
           "category_id": "finance-trading-markets",
-          "match_count": 1,
+          "match_count": 2,
           "matched_signals": [
-            "polymarket"
+            "polymarket",
+            "\\bp&l\\b|量化|交易|投资组合|风控"
           ],
           "priority": 120,
           "tie_detected": false
@@ -18576,34 +18059,24 @@
     },
     {
       "assignments": [],
-      "category_id": "finance-trading-markets",
-      "classification": "description:defi;metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "outcome:\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "defi"
+          "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "finance-trading-markets",
+          "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "defi"
+            "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
           ],
-          "priority": 120,
-          "tie_detected": true
+          "priority": 95,
+          "tie_detected": false
         }
       },
       "description": "Export any bioinformatics analysis as a reproducible bundle with Conda environment, Singularity container definition, and Nextflow pipeline.",
@@ -18623,10 +18096,10 @@
         }
       ],
       "category_id": "software-engineering",
-      "classification": "slug:code;metadata:frontmatter",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "code"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -18636,7 +18109,7 @@
           "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "code"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
           "priority": 80,
           "tie_detected": false
@@ -18767,23 +18240,46 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "slug:analysis;metadata:frontmatter",
+      "category_id": "marketing-seo-growth",
+      "classification": "description:marketing,(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b,acquisition;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "marketing",
+          "(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b",
+          "acquisition"
         ],
-        "method": "slug",
+        "method": "description",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "chinese-platform-workflows",
+            "match_count": 1,
+            "matched_signals": [
+              "xiaohongshu"
+            ],
+            "priority": 130,
+            "tied_for_first": false
+          },
+          {
+            "category_id": "finance-trading-markets",
+            "match_count": 1,
+            "matched_signals": [
+              "investment"
+            ],
+            "priority": 120,
+            "tied_for_first": false
+          }
+        ],
         "winner": {
-          "category_id": "data-analytics-research",
-          "match_count": 1,
+          "category_id": "marketing-seo-growth",
+          "match_count": 3,
           "matched_signals": [
-            "analysis"
+            "marketing",
+            "(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b",
+            "acquisition"
           ],
-          "priority": 95,
+          "priority": 105,
           "tie_detected": false
         }
       },
@@ -18892,12 +18388,12 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:metrics;metadata:frontmatter",
+      "classification": "outcome:(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "metrics"
+          "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -18905,7 +18401,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "metrics"
+            "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"
           ],
           "priority": 95,
           "tie_detected": false
@@ -19197,16 +18693,15 @@
         "base_candidates": [
           {
             "category_id": "security-privacy-legal",
-            "match_count": 2,
+            "match_count": 1,
             "matched_signals": [
-              "security",
-              "audit"
+              "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
             ],
             "priority": 115,
             "tied_for_first": true
           }
         ],
-        "base_method": "slug",
+        "base_method": "outcome",
         "matched_signals": [],
         "method": "override",
         "rationale": "Security risk review is the explicit purpose and must outrank generic audit wording.",
@@ -19238,11 +18733,11 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:security,audit;metadata:frontmatter",
+      "classification": "slug:security,(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
           "security",
-          "audit"
+          "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -19253,7 +18748,7 @@
           "match_count": 2,
           "matched_signals": [
             "security",
-            "audit"
+            "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -19271,22 +18766,20 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:security,compliance;metadata:frontmatter",
+      "classification": "outcome:\\b(?:gdpr|pci dss|threat model)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "security",
-          "compliance"
+          "\\b(?:gdpr|pci dss|threat model)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "security",
-            "compliance"
+            "\\b(?:gdpr|pci dss|threat model)\\b"
           ],
           "priority": 115,
           "tie_detected": false
@@ -19470,34 +18963,24 @@
     },
     {
       "assignments": [],
-      "category_id": "product-design-ux",
-      "classification": "description:design;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:\\b(?:software|system) architecture\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design"
+          "\\b(?:software|system) architecture\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "architecture"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "product-design-ux",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "design"
+            "\\b(?:software|system) architecture\\b"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "This skill should be used when the user asks to \"design system architecture\", \"evaluate microservices vs monolith\", \"create architecture diagrams\", \"analyze dependencies\",…",
@@ -19512,10 +18995,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -19525,7 +19008,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -19543,10 +19026,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "slug:data;metadata:frontmatter",
+      "classification": "slug:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -19556,7 +19039,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -19615,15 +19098,6 @@
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          },
           {
             "category_id": "business-operations-strategy",
             "match_count": 1,
@@ -19714,25 +19188,16 @@
       "classification_details": {
         "base_candidates": [
           {
-            "category_id": "security-privacy-legal",
-            "match_count": 1,
-            "matched_signals": [
-              "audit"
-            ],
-            "priority": 115,
-            "tied_for_first": true
-          },
-          {
             "category_id": "marketing-seo-growth",
             "match_count": 1,
             "matched_signals": [
-              "\\bseo\\b"
+              "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
             ],
             "priority": 105,
             "tied_for_first": true
           }
         ],
-        "base_method": "slug",
+        "base_method": "outcome",
         "matched_signals": [],
         "method": "override",
         "rationale": "Search acquisition is the explicit outcome and must outrank generic audit wording.",
@@ -19761,32 +19226,20 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:\\bseo\\b,competitor;metadata:frontmatter",
+      "classification": "outcome:\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bseo\\b",
-          "competitor"
+          "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "marketing-seo-growth",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "\\bseo\\b",
-            "competitor"
+            "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
           ],
           "priority": 105,
           "tie_detected": false
@@ -19847,12 +19300,12 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:\\bseo\\b;metadata:frontmatter",
+      "classification": "outcome:\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bseo\\b"
+          "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -19860,7 +19313,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "\\bseo\\b"
+            "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
           ],
           "priority": 105,
           "tie_detected": false
@@ -19909,33 +19362,23 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:\\bseo\\b;metadata:frontmatter",
+      "classification": "outcome:\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bseo\\b"
+          "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "strategy"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "\\bseo\\b"
+            "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b"
           ],
           "priority": 105,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Build and execute an SEO strategy for organic search traffic. Use when planning keyword targeting, optimizing content for search engines, building backlinks, improving site…",
@@ -19987,19 +19430,9 @@
           "serp"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "marketing-seo-growth",
           "match_count": 1,
@@ -20007,7 +19440,7 @@
             "serp"
           ],
           "priority": 105,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Analyze Google SERP (Search Engine Results Pages) — featured snippets, PAA (People Also Ask), AI Overview, knowledge panels, local packs. Detect AI Overview trigger conditions…",
@@ -20052,34 +19485,24 @@
     },
     {
       "assignments": [],
-      "category_id": "finance-trading-markets",
-      "classification": "description:defi;metadata:frontmatter",
+      "category_id": "business-operations-strategy",
+      "classification": "slug:(?:^|-)okrs?(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "defi"
+          "(?:^|-)okrs?(?:-|$)"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "planning"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "finance-trading-markets",
+          "category_id": "business-operations-strategy",
           "match_count": 1,
           "matched_signals": [
-            "defi"
+            "(?:^|-)okrs?(?:-|$)"
           ],
-          "priority": 120,
-          "tie_detected": true
+          "priority": 65,
+          "tie_detected": false
         }
       },
       "description": "Help users set effective OKRs and goals. Use when someone is creating quarterly objectives, defining key results, setting team goals, planning annual targets, or struggling with…",
@@ -20168,10 +19591,10 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:data,\\bcsv\\b;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b,\\bcsv\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data",
+          "(?:^|-)data(?:-|$)|\\bdata\\b",
           "\\bcsv\\b"
         ],
         "method": "description",
@@ -20202,7 +19625,7 @@
           "category_id": "data-analytics-research",
           "match_count": 2,
           "matched_signals": [
-            "data",
+            "(?:^|-)data(?:-|$)|\\bdata\\b",
             "\\bcsv\\b"
           ],
           "priority": 95,
@@ -20313,33 +19736,23 @@
     {
       "assignments": [],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:\\bads?\\b;metadata:frontmatter",
+      "classification": "outcome:(?:launch|manage).{0,20}(?:campaigns?|ads?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bads?\\b"
+          "(?:launch|manage).{0,20}(?:campaigns?|ads?)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "marketing-seo-growth",
           "match_count": 1,
           "matched_signals": [
-            "\\bads?\\b"
+            "(?:launch|manage).{0,20}(?:campaigns?|ads?)"
           ],
           "priority": 105,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Amazon Ads API v3 skill for OpenClaw agents. List profiles, manage Sponsored Products campaigns, view budgets and performance. Works with any advertiser account.",
@@ -20354,10 +19767,10 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "slug:(?:^|-)(?:skill-(?:authoring|creation|review|quality|evaluation|config|configuration)|work-to-skill)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:^|-)(?:skill-(?:authoring|creation|review|quality|evaluation|config|configuration)|work-to-skill)(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -20367,7 +19780,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:^|-)(?:skill-(?:authoring|creation|review|quality|evaluation|config|configuration)|work-to-skill)(?:-|$)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -20385,12 +19798,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -20398,7 +19811,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
           ],
           "priority": 75,
           "tie_detected": false
@@ -20421,12 +19834,12 @@
         }
       ],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -20434,7 +19847,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?"
           ],
           "priority": 75,
           "tie_detected": false
@@ -20453,23 +19866,23 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:fallback",
+      "category_id": "business-operations-strategy",
+      "classification": "outcome:战略.{0,20}能力.{0,12}(?:缺口|鸿沟)|能力.{0,12}(?:招聘|培训);metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "战略.{0,20}能力.{0,12}(?:缺口|鸿沟)|能力.{0,12}(?:招聘|培训)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "business-operations-strategy",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "战略.{0,20}能力.{0,12}(?:缺口|鸿沟)|能力.{0,12}(?:招聘|培训)"
           ],
-          "priority": 75,
+          "priority": 65,
           "tie_detected": false
         }
       },
@@ -20491,19 +19904,9 @@
           "search"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "data-analytics-research",
           "match_count": 1,
@@ -20511,7 +19914,7 @@
             "search"
           ],
           "priority": 95,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Optimize agent skills for discoverability on ClawdHub/MoltHub. Use when improving search ranking, writing descriptions for semantic search, understanding how the registry indexes…",
@@ -20526,32 +19929,22 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:security,audit;metadata:frontmatter",
+      "classification": "slug:security,(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
           "security",
-          "audit"
+          "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
           "match_count": 2,
           "matched_signals": [
             "security",
-            "audit"
+            "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -20569,32 +19962,20 @@
     {
       "assignments": [],
       "category_id": "security-privacy-legal",
-      "classification": "slug:security,audit;metadata:frontmatter",
+      "classification": "outcome:(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "security",
-          "audit"
+          "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "security-privacy-legal",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "security",
-            "audit"
+            "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)"
           ],
           "priority": 115,
           "tie_detected": false
@@ -20611,23 +19992,19 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "description:analysis;metadata:frontmatter",
+      "category_id": "general-utilities",
+      "classification": "fallback;metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [
-          "analysis"
-        ],
-        "method": "description",
-        "resolution_status": "rule-match",
+        "matched_signals": [],
+        "method": "fallback",
+        "resolution_status": "fallback",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
-          "match_count": 1,
-          "matched_signals": [
-            "analysis"
-          ],
-          "priority": 95,
+          "category_id": "general-utilities",
+          "match_count": 0,
+          "matched_signals": [],
+          "priority": 0,
           "tie_detected": false
         }
       },
@@ -20656,7 +20033,7 @@
             "category_id": "ai-agents-orchestration",
             "match_count": 1,
             "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
+              "(?:^|-)skills(?:-|$)"
             ],
             "priority": 75,
             "tied_for_first": true
@@ -20684,22 +20061,20 @@
     {
       "assignments": [],
       "category_id": "apps-workflow-automation",
-      "classification": "slug:automation,slack;metadata:frontmatter",
+      "classification": "outcome:(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "automation",
-          "slack"
+          "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "apps-workflow-automation",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "automation",
-            "slack"
+            "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
           ],
           "priority": 70,
           "tie_detected": false
@@ -20747,36 +20122,34 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)agent(?:-|$),(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "category_id": "content-media-publishing",
+      "classification": "slug:slide;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)agent(?:-|$)",
-          "(?:^|-)skills?(?:-|$)"
+          "slide"
         ],
         "method": "slug",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "content-media-publishing",
+            "category_id": "ai-agents-orchestration",
             "match_count": 1,
             "matched_signals": [
-              "slide"
+              "(?:^|-)agent(?:-|$)"
             ],
-            "priority": 100,
-            "tied_for_first": false
+            "priority": 75,
+            "tied_for_first": true
           }
         ],
         "winner": {
-          "category_id": "ai-agents-orchestration",
-          "match_count": 2,
+          "category_id": "content-media-publishing",
+          "match_count": 1,
           "matched_signals": [
-            "(?:^|-)agent(?:-|$)",
-            "(?:^|-)skills?(?:-|$)"
+            "slide"
           ],
-          "priority": 75,
-          "tie_detected": false
+          "priority": 100,
+          "tie_detected": true
         }
       },
       "description": "Create, edit, theme, build, and export Slidev presentations using a script-first workflow with detailed local references. Use when working on Slidev decks, themes, layouts,…",
@@ -20916,34 +20289,36 @@
     },
     {
       "assignments": [],
-      "category_id": "product-design-ux",
-      "classification": "slug:design;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "slug:architecture,(?:^|-)(?:software|system)-architecture(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "design"
+          "architecture",
+          "(?:^|-)(?:software|system)-architecture(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "software-engineering",
+            "category_id": "product-design-ux",
             "match_count": 1,
             "matched_signals": [
-              "architecture"
+              "design"
             ],
-            "priority": 80,
-            "tied_for_first": true
+            "priority": 90,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "product-design-ux",
-          "match_count": 1,
+          "category_id": "software-engineering",
+          "match_count": 2,
           "matched_signals": [
-            "design"
+            "architecture",
+            "(?:^|-)(?:software|system)-architecture(?:-|$)"
           ],
-          "priority": 90,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "Designs system structure across monolith/microservices/serverless. Use when structuring systems, scaling, decomposing monoliths, or choosing patterns.",
@@ -20957,19 +20332,22 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:fallback",
+      "category_id": "data-analytics-research",
+      "classification": "override;metadata:fallback",
       "classification_details": {
+        "base_candidates": [],
+        "base_method": "fallback",
         "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "method": "override",
+        "rationale": "The opaque product name hides a Bing search and deep webpage extraction workflow whose primary output is structured research evidence.",
+        "resolution_status": "override",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
+          "category_id": "data-analytics-research",
           "match_count": 0,
           "matched_signals": [],
-          "priority": 0,
+          "priority": 95,
           "tie_detected": false
         }
       },
@@ -21047,19 +20425,23 @@
           "level": "required"
         }
       ],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:(?:async|flaky).{0,20}tests?;metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:async|flaky).{0,20}tests?"
+        ],
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "software-engineering",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:async|flaky).{0,20}tests?"
+          ],
+          "priority": 80,
           "tie_detected": false
         }
       },
@@ -21082,10 +20464,10 @@
         }
       ],
       "category_id": "data-analytics-research",
-      "classification": "description:data;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data"
+          "(?:^|-)data(?:-|$)|\\bdata\\b"
         ],
         "method": "description",
         "resolution_status": "rule-match",
@@ -21095,7 +20477,7 @@
           "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "data"
+            "(?:^|-)data(?:-|$)|\\bdata\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -21281,7 +20663,7 @@
             "category_id": "software-engineering",
             "match_count": 1,
             "matched_signals": [
-              "code"
+              "(?:^|-)code(?:-|$)|\\bcode\\b"
             ],
             "priority": 80,
             "tied_for_first": false
@@ -21383,19 +20765,23 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "slug:(?:^|-)simplification-cascades(?:-|$);metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)simplification-cascades(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "software-engineering",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)simplification-cascades(?:-|$)"
+          ],
+          "priority": 80,
           "tie_detected": false
         }
       },
@@ -21415,34 +20801,36 @@
           "level": "required"
         }
       ],
-      "category_id": "software-engineering",
-      "classification": "slug:development;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:subagent,(?:^|-)subagent-driven(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "development"
+          "subagent",
+          "(?:^|-)subagent-driven(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "ai-agents-orchestration",
+            "category_id": "software-engineering",
             "match_count": 1,
             "matched_signals": [
-              "subagent"
+              "development"
             ],
-            "priority": 75,
-            "tied_for_first": true
+            "priority": 80,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "software-engineering",
-          "match_count": 1,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 2,
           "matched_signals": [
-            "development"
+            "subagent",
+            "(?:^|-)subagent-driven(?:-|$)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Execute implementation plan by dispatching fresh subagent for each task, with code review between tasks",
@@ -21651,10 +21039,10 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "slug:(?:^|-)skills(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:^|-)skills(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -21664,7 +21052,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:^|-)skills(?:-|$)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -21774,10 +21162,10 @@
     {
       "assignments": [],
       "category_id": "finance-trading-markets",
-      "classification": "slug:defi;metadata:frontmatter",
+      "classification": "slug:(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "defi"
+          "(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -21787,7 +21175,7 @@
           "category_id": "finance-trading-markets",
           "match_count": 1,
           "matched_signals": [
-            "defi"
+            "(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b"
           ],
           "priority": 120,
           "tie_detected": false
@@ -22007,7 +21395,17 @@
         "method": "slug",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "data-analytics-research",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
+            ],
+            "priority": 95,
+            "tied_for_first": false
+          }
+        ],
         "winner": {
           "category_id": "business-operations-strategy",
           "match_count": 2,
@@ -22049,6 +21447,15 @@
               "financ"
             ],
             "priority": 120,
+            "tied_for_first": false
+          },
+          {
+            "category_id": "data-analytics-research",
+            "match_count": 1,
+            "matched_signals": [
+              "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)"
+            ],
+            "priority": 95,
             "tied_for_first": false
           }
         ],
@@ -22164,34 +21571,24 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "slug:analysis;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:\\b(?:static|source) code analysis\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "\\b(?:static|source) code analysis\\b"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "code"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "analysis"
+            "\\b(?:static|source) code analysis\\b"
           ],
-          "priority": 95,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "Implement static code analysis with linters, formatters, and security scanners to catch bugs early. Use when enforcing code standards, detecting security vulnerabilities, or…",
@@ -22206,12 +21603,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:orchestrat;metadata:frontmatter",
+      "classification": "outcome:(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "orchestrat"
+          "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -22219,7 +21616,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "orchestrat"
+            "(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -22366,34 +21763,36 @@
     },
     {
       "assignments": [],
-      "category_id": "software-engineering",
-      "classification": "slug:development;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:subagent,(?:^|-)subagent-driven(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "development"
+          "subagent",
+          "(?:^|-)subagent-driven(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "ai-agents-orchestration",
+            "category_id": "software-engineering",
             "match_count": 1,
             "matched_signals": [
-              "subagent"
+              "development"
             ],
-            "priority": 75,
-            "tied_for_first": true
+            "priority": 80,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "software-engineering",
-          "match_count": 1,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 2,
           "matched_signals": [
-            "development"
+            "subagent",
+            "(?:^|-)subagent-driven(?:-|$)"
           ],
-          "priority": 80,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Use when executing implementation plans with independent tasks in the current session",
@@ -22495,7 +21894,7 @@
             "category_id": "ai-agents-orchestration",
             "match_count": 1,
             "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
+              "(?:^|-)skills(?:-|$)"
             ],
             "priority": 75,
             "tied_for_first": true
@@ -22908,24 +22307,34 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:task;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:(?:^|-)task-(?:supervisor|dispatcher)(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "task"
+          "(?:^|-)task-(?:supervisor|dispatcher)(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "rule-match",
+        "resolution_status": "priority-tie",
         "review_state": "unreviewed",
-        "runner_ups": [],
+        "runner_ups": [
+          {
+            "category_id": "business-operations-strategy",
+            "match_count": 1,
+            "matched_signals": [
+              "task"
+            ],
+            "priority": 65,
+            "tied_for_first": true
+          }
+        ],
         "winner": {
-          "category_id": "business-operations-strategy",
+          "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "task"
+            "(?:^|-)task-(?:supervisor|dispatcher)(?:-|$)"
           ],
-          "priority": 65,
-          "tie_detected": false
+          "priority": 75,
+          "tie_detected": true
         }
       },
       "description": "定时巡检 agent 任务执行状态，识别卡住、abort、无产出等异常并触发催促或告警。",
@@ -23166,11 +22575,10 @@
     {
       "assignments": [],
       "category_id": "business-operations-strategy",
-      "classification": "slug:team,daily-;metadata:frontmatter",
+      "classification": "slug:team;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "team",
-          "daily-"
+          "team"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -23178,10 +22586,9 @@
         "runner_ups": [],
         "winner": {
           "category_id": "business-operations-strategy",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "team",
-            "daily-"
+            "team"
           ],
           "priority": 65,
           "tie_detected": false
@@ -23300,19 +22707,9 @@
           "technical-analysis"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "finance-trading-markets",
           "match_count": 1,
@@ -23320,7 +22717,7 @@
             "technical-analysis"
           ],
           "priority": 120,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Master of price action, chart patterns, and technical indicators - combining classical Wyckoff/Dow theory with modern quantitative validation for edge identificationUse when…",
@@ -23671,12 +23068,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -23684,7 +23081,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?"
           ],
           "priority": 75,
           "tie_detected": false
@@ -24695,23 +24092,25 @@
     },
     {
       "assignments": [],
-      "category_id": "business-operations-strategy",
-      "classification": "slug:thinking-;metadata:frontmatter",
+      "category_id": "finance-trading-markets",
+      "classification": "outcome:量化思维,大量小交易|投资组合|估值|交易风控;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "thinking-"
+          "量化思维",
+          "大量小交易|投资组合|估值|交易风控"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "business-operations-strategy",
-          "match_count": 1,
+          "category_id": "finance-trading-markets",
+          "match_count": 2,
           "matched_signals": [
-            "thinking-"
+            "量化思维",
+            "大量小交易|投资组合|估值|交易风控"
           ],
-          "priority": 65,
+          "priority": 120,
           "tie_detected": false
         }
       },
@@ -25195,10 +24594,10 @@
         }
       ],
       "category_id": "marketing-seo-growth",
-      "classification": "slug:traffic,acquisition;metadata:frontmatter",
+      "classification": "slug:(?:^|-)(?:traffic-(?:growth|acquisition|seo)|(?:web|site|organic|search|social|paid)-traffic)(?:-|$)|\\b(?:web|site|organic|search|social|paid) traffic\\b,acquisition;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "traffic",
+          "(?:^|-)(?:traffic-(?:growth|acquisition|seo)|(?:web|site|organic|search|social|paid)-traffic)(?:-|$)|\\b(?:web|site|organic|search|social|paid) traffic\\b",
           "acquisition"
         ],
         "method": "slug",
@@ -25209,7 +24608,7 @@
           "category_id": "marketing-seo-growth",
           "match_count": 2,
           "matched_signals": [
-            "traffic",
+            "(?:^|-)(?:traffic-(?:growth|acquisition|seo)|(?:web|site|organic|search|social|paid)-traffic)(?:-|$)|\\b(?:web|site|organic|search|social|paid) traffic\\b",
             "acquisition"
           ],
           "priority": 105,
@@ -25230,10 +24629,10 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:fallback",
+      "classification": "slug:(?:^|-)skills(?:-|$);metadata:fallback",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:^|-)skills(?:-|$)"
         ],
         "method": "slug",
         "resolution_status": "rule-match",
@@ -25243,7 +24642,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:^|-)skills(?:-|$)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -25261,22 +24660,20 @@
     {
       "assignments": [],
       "category_id": "apps-workflow-automation",
-      "classification": "slug:automation,trello;metadata:frontmatter",
+      "classification": "outcome:(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "automation",
-          "trello"
+          "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "apps-workflow-automation",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "automation",
-            "trello"
+            "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"
           ],
           "priority": 70,
           "tie_detected": false
@@ -25352,22 +24749,20 @@
     {
       "assignments": [],
       "category_id": "product-design-ux",
-      "classification": "slug:\\bux\\b,\\bui\\b;metadata:frontmatter",
+      "classification": "outcome:\\b(?:product|ux|ui|visual) (?:design|vision|strategy)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bux\\b",
-          "\\bui\\b"
+          "\\b(?:product|ux|ui|visual) (?:design|vision|strategy)\\b"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "product-design-ux",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "\\bux\\b",
-            "\\bui\\b"
+            "\\b(?:product|ux|ui|visual) (?:design|vision|strategy)\\b"
           ],
           "priority": 90,
           "tie_detected": false
@@ -25520,19 +24915,23 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:(?:^|-)using-superpowers(?:-|$);metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)using-superpowers(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)using-superpowers(?:-|$)"
+          ],
+          "priority": 75,
           "tie_detected": false
         }
       },
@@ -25578,34 +24977,24 @@
     },
     {
       "assignments": [],
-      "category_id": "ai-agents-orchestration",
-      "classification": "description:context;metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "outcome:\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "context"
+          "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "business-operations-strategy",
-            "match_count": 1,
-            "matched_signals": [
-              "priorit"
-            ],
-            "priority": 65,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "ai-agents-orchestration",
+          "category_id": "data-analytics-research",
           "match_count": 1,
           "matched_signals": [
-            "context"
+            "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b"
           ],
-          "priority": 75,
-          "tie_detected": true
+          "priority": 95,
+          "tie_detected": false
         }
       },
       "description": "Annotate VCF variants with VEP, ClinVar, gnomAD frequencies, and ancestry-aware context. Generates prioritised variant reports.",
@@ -25782,34 +25171,24 @@
     },
     {
       "assignments": [],
-      "category_id": "security-privacy-legal",
-      "classification": "slug:audit;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "slug:(?:^|-)code(?:-|$)|\\bcode\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "audit"
+          "(?:^|-)code(?:-|$)|\\bcode\\b"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "code"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "security-privacy-legal",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "audit"
+            "(?:^|-)code(?:-|$)|\\bcode\\b"
           ],
-          "priority": 115,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "Audit rapidly generated or AI-produced code for structural flaws, fragility, and production risks.",
@@ -25919,12 +25298,12 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "slug:video;metadata:frontmatter",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "video"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -25932,7 +25311,7 @@
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "video"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -26071,12 +25450,12 @@
     {
       "assignments": [],
       "category_id": "content-media-publishing",
-      "classification": "slug:video;metadata:frontmatter",
+      "classification": "outcome:(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "video"
+          "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -26084,7 +25463,7 @@
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "video"
+            "(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -26298,19 +25677,9 @@
           "video"
         ],
         "method": "description",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "data-analytics-research",
-            "match_count": 1,
-            "matched_signals": [
-              "analysis"
-            ],
-            "priority": 95,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "content-media-publishing",
           "match_count": 1,
@@ -26318,7 +25687,7 @@
             "video"
           ],
           "priority": 100,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Virtual singer MV script generator — audio analysis to video storyboard pipeline",
@@ -26333,32 +25702,20 @@
     {
       "assignments": [],
       "category_id": "software-engineering",
-      "classification": "description:testing,test-;metadata:frontmatter",
+      "classification": "outcome:(?:async|flaky).{0,20}tests?;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "testing",
-          "test-"
+          "(?:async|flaky).{0,20}tests?"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "writing"
-            ],
-            "priority": 100,
-            "tied_for_first": false
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "software-engineering",
-          "match_count": 2,
+          "match_count": 1,
           "matched_signals": [
-            "testing",
-            "test-"
+            "(?:async|flaky).{0,20}tests?"
           ],
           "priority": 80,
           "tie_detected": false
@@ -26375,19 +25732,23 @@
     },
     {
       "assignments": [],
-      "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "category_id": "business-operations-strategy",
+      "classification": "slug:(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$);metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$)"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
-          "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
-          "priority": 0,
+          "category_id": "business-operations-strategy",
+          "match_count": 1,
+          "matched_signals": [
+            "(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$)"
+          ],
+          "priority": 65,
           "tie_detected": false
         }
       },
@@ -27039,33 +26400,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:weixin;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "weixin"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "weixin"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "微信视频号助手网页版视频发布全流程。通过浏览器自动化操控 channels.weixin.qq.com 完成登录检测、扫码登录、上传视频、填写描述和短标题、截图确认后发布或保存草稿。触发场景：用户需要发布视频到视频号、视频号发布、视频号上传视频、发视频号。",
@@ -27284,34 +26635,24 @@
     },
     {
       "assignments": [],
-      "category_id": "data-analytics-research",
-      "classification": "description:analysis;metadata:frontmatter",
+      "category_id": "software-engineering",
+      "classification": "outcome:\\bcode (?:repository|review|testing|debugging)\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "analysis"
+          "\\bcode (?:repository|review|testing|debugging)\\b"
         ],
-        "method": "description",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "software-engineering",
-            "match_count": 1,
-            "matched_signals": [
-              "code"
-            ],
-            "priority": 80,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
-          "category_id": "data-analytics-research",
+          "category_id": "software-engineering",
           "match_count": 1,
           "matched_signals": [
-            "analysis"
+            "\\bcode (?:repository|review|testing|debugging)\\b"
           ],
-          "priority": 95,
-          "tie_detected": true
+          "priority": 80,
+          "tie_detected": false
         }
       },
       "description": "Answers questions about a code repository using source file analysis. Use when the user asks a question about how something works, wants to understand a component, or needs help…",
@@ -27326,12 +26667,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "slug:(?:^|-)skills?(?:-|$);metadata:frontmatter",
+      "classification": "outcome:(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "(?:^|-)skills?(?:-|$)"
+          "(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -27339,7 +26680,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "(?:^|-)skills?(?:-|$)"
+            "(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -27456,34 +26797,36 @@
           "level": "required"
         }
       ],
-      "category_id": "content-media-publishing",
-      "classification": "slug:writing;metadata:frontmatter",
+      "category_id": "ai-agents-orchestration",
+      "classification": "slug:(?:^|-)skills(?:-|$),(?:^|-)(?:creating|writing|authoring|testing)-skills(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "writing"
+          "(?:^|-)skills(?:-|$)",
+          "(?:^|-)(?:creating|writing|authoring|testing)-skills(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "ai-agents-orchestration",
+            "category_id": "content-media-publishing",
             "match_count": 1,
             "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
+              "writing"
             ],
-            "priority": 75,
-            "tied_for_first": true
+            "priority": 100,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "content-media-publishing",
-          "match_count": 1,
+          "category_id": "ai-agents-orchestration",
+          "match_count": 2,
           "matched_signals": [
-            "writing"
+            "(?:^|-)skills(?:-|$)",
+            "(?:^|-)(?:creating|writing|authoring|testing)-skills(?:-|$)"
           ],
-          "priority": 100,
-          "tie_detected": true
+          "priority": 75,
+          "tie_detected": false
         }
       },
       "description": "Use when creating new skills, editing existing skills, or verifying skills work before deployment",
@@ -27505,12 +26848,12 @@
         }
       ],
       "category_id": "content-media-publishing",
-      "classification": "slug:article;metadata:frontmatter",
+      "classification": "outcome:(?:publish|repurpose).{0,24}(?:article|video|content|media);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "article"
+          "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -27518,7 +26861,7 @@
           "category_id": "content-media-publishing",
           "match_count": 1,
           "matched_signals": [
-            "article"
+            "(?:publish|repurpose).{0,24}(?:article|video|content|media)"
           ],
           "priority": 100,
           "tie_detected": false
@@ -27590,33 +26933,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:xhs;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "xhs"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "content"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "xhs"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "Generate Xiaohongshu (小红书/RED) content optimized for the platform''s CES algorithm. Use when: (1) creating xiaohongshu/小红书 posts, (2) writing Chinese social media content for…",
@@ -27682,33 +27015,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:xhs;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "xhs"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "ai-agents-orchestration",
-            "match_count": 1,
-            "matched_signals": [
-              "(?:^|-)skills?(?:-|$)"
-            ],
-            "priority": 75,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "xhs"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "小红书（创作者中心）登录拿 cookies、发布笔记、导出数据的单一入口技能（浏览器交互委托 agent-browser-stealth）",
@@ -27723,33 +27046,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:xhs;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "xhs"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "xhs"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "小红书智能发布：内容适配→排版→Playwright自动发布/存草稿。覆盖标题公式(≤20字+emoji+数字)、正文排版(空行分段+emoji点缀)、标签策略(热门+长尾3-8个)、封面规格(3:4竖版1080×1440)、CES算法优化。支持图文笔记和轮播。触发：'发小红书'、'小红书发布'、'xhs",
@@ -27821,22 +27134,13 @@
             "category_id": "chinese-platform-workflows",
             "match_count": 1,
             "matched_signals": [
-              "xiaohongshu"
+              "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
             ],
             "priority": 130,
             "tied_for_first": true
-          },
-          {
-            "category_id": "marketing-seo-growth",
-            "match_count": 1,
-            "matched_signals": [
-              "growth"
-            ],
-            "priority": 105,
-            "tied_for_first": true
           }
         ],
-        "base_method": "slug",
+        "base_method": "outcome",
         "matched_signals": [],
         "method": "override",
         "rationale": "The platform-specific publishing and growth workflow belongs with Chinese platforms.",
@@ -27866,12 +27170,12 @@
     {
       "assignments": [],
       "category_id": "ai-agents-orchestration",
-      "classification": "description:openclaw;metadata:frontmatter",
+      "classification": "outcome:(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "openclaw"
+          "(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能)"
         ],
-        "method": "description",
+        "method": "outcome",
         "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
@@ -27879,7 +27183,7 @@
           "category_id": "ai-agents-orchestration",
           "match_count": 1,
           "matched_signals": [
-            "openclaw"
+            "(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能)"
           ],
           "priority": 75,
           "tie_detected": false
@@ -27897,11 +27201,11 @@
     {
       "assignments": [],
       "category_id": "data-analytics-research",
-      "classification": "description:data,analysis;metadata:frontmatter",
+      "classification": "description:(?:^|-)data(?:-|$)|\\bdata\\b,(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b;metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "data",
-          "analysis"
+          "(?:^|-)data(?:-|$)|\\bdata\\b",
+          "(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b"
         ],
         "method": "description",
         "resolution_status": "rule-match",
@@ -27921,8 +27225,8 @@
           "category_id": "data-analytics-research",
           "match_count": 2,
           "matched_signals": [
-            "data",
-            "analysis"
+            "(?:^|-)data(?:-|$)|\\bdata\\b",
+            "(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b"
           ],
           "priority": 95,
           "tie_detected": false
@@ -27940,17 +27244,21 @@
     {
       "assignments": [],
       "category_id": "general-utilities",
-      "classification": "fallback;metadata:frontmatter",
+      "classification": "outcome:\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜;metadata:frontmatter",
       "classification_details": {
-        "matched_signals": [],
-        "method": "fallback",
-        "resolution_status": "fallback",
+        "matched_signals": [
+          "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
+        ],
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [],
         "winner": {
           "category_id": "general-utilities",
-          "match_count": 0,
-          "matched_signals": [],
+          "match_count": 1,
+          "matched_signals": [
+            "\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜"
+          ],
           "priority": 0,
           "tie_detected": false
         }
@@ -28038,34 +27346,36 @@
     },
     {
       "assignments": [],
-      "category_id": "content-media-publishing",
-      "classification": "slug:youtube;metadata:frontmatter",
+      "category_id": "data-analytics-research",
+      "classification": "slug:knowledge,(?:^|-)knowledge-extract(?:or)?(?:-|$);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "youtube"
+          "knowledge",
+          "(?:^|-)knowledge-extract(?:or)?(?:-|$)"
         ],
         "method": "slug",
-        "resolution_status": "priority-tie",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "data-analytics-research",
+            "category_id": "content-media-publishing",
             "match_count": 1,
             "matched_signals": [
-              "knowledge"
+              "youtube"
             ],
-            "priority": 95,
-            "tied_for_first": true
+            "priority": 100,
+            "tied_for_first": false
           }
         ],
         "winner": {
-          "category_id": "content-media-publishing",
-          "match_count": 1,
+          "category_id": "data-analytics-research",
+          "match_count": 2,
           "matched_signals": [
-            "youtube"
+            "knowledge",
+            "(?:^|-)knowledge-extract(?:or)?(?:-|$)"
           ],
-          "priority": 100,
-          "tie_detected": true
+          "priority": 95,
+          "tie_detected": false
         }
       },
       "description": "This skill performs deep analysis of YouTube videos through **both information channels**",
@@ -28121,33 +27431,23 @@
     {
       "assignments": [],
       "category_id": "chinese-platform-workflows",
-      "classification": "slug:ziliu;metadata:frontmatter",
+      "classification": "outcome:(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "ziliu"
+          "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
         ],
-        "method": "slug",
-        "resolution_status": "priority-tie",
+        "method": "outcome",
+        "resolution_status": "rule-match",
         "review_state": "unreviewed",
-        "runner_ups": [
-          {
-            "category_id": "content-media-publishing",
-            "match_count": 1,
-            "matched_signals": [
-              "publish"
-            ],
-            "priority": 100,
-            "tied_for_first": true
-          }
-        ],
+        "runner_ups": [],
         "winner": {
           "category_id": "chinese-platform-workflows",
           "match_count": 1,
           "matched_signals": [
-            "ziliu"
+            "(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"
           ],
           "priority": 130,
-          "tie_detected": true
+          "tie_detected": false
         }
       },
       "description": "字流(Ziliu) - AI驱动的多平台内容分发工具。用于一次创作、智能适配排版、一键分发到16+平台（公众号/知乎/小红书/B站/抖音/微博/X等）。当用户需要多平台发布、内容排版、格式适配时使用。触发词：字流、ziliu、多平台发布、一键分发、内容分发、排版发布。",
@@ -28165,22 +27465,22 @@
     {
       "assignments": [],
       "category_id": "sales-crm-customer-success",
-      "classification": "slug:\\bcrm\\b;metadata:frontmatter",
+      "classification": "outcome:(?:manage|qualify|enrich|convert).{0,24}(?:leads?|prospects?|customers?|crm);metadata:frontmatter",
       "classification_details": {
         "matched_signals": [
-          "\\bcrm\\b"
+          "(?:manage|qualify|enrich|convert).{0,24}(?:leads?|prospects?|customers?|crm)"
         ],
-        "method": "slug",
+        "method": "outcome",
         "resolution_status": "priority-tie",
         "review_state": "unreviewed",
         "runner_ups": [
           {
-            "category_id": "apps-workflow-automation",
+            "category_id": "marketing-seo-growth",
             "match_count": 1,
             "matched_signals": [
-              "automation"
+              "(?:launch|manage).{0,20}(?:campaigns?|ads?)"
             ],
-            "priority": 70,
+            "priority": 105,
             "tied_for_first": true
           }
         ],
@@ -28188,7 +27488,7 @@
           "category_id": "sales-crm-customer-success",
           "match_count": 1,
           "matched_signals": [
-            "\\bcrm\\b"
+            "(?:manage|qualify|enrich|convert).{0,24}(?:leads?|prospects?|customers?|crm)"
           ],
           "priority": 110,
           "tie_detected": true

--- a/catalog/skill-taxonomy-evaluation.json
+++ b/catalog/skill-taxonomy-evaluation.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "../config/skill-taxonomy-evaluation.schema.json",
+  "annotationMode": "independent-agent-manual-review",
+  "categoryCount": 14,
+  "errors": [
+    {
+      "expected_category": "apps-workflow-automation",
+      "predicted_category": "data-analytics-research",
+      "skill_id": "documents",
+      "split": "validation"
+    },
+    {
+      "expected_category": "business-operations-strategy",
+      "predicted_category": "apps-workflow-automation",
+      "skill_id": "hr-automation",
+      "split": "validation"
+    },
+    {
+      "expected_category": "data-analytics-research",
+      "predicted_category": "content-media-publishing",
+      "skill_id": "image-scraper",
+      "split": "validation"
+    },
+    {
+      "expected_category": "finance-trading-markets",
+      "predicted_category": "general-utilities",
+      "skill_id": "polyclaw",
+      "split": "validation"
+    },
+    {
+      "expected_category": "product-design-ux",
+      "predicted_category": "business-operations-strategy",
+      "skill_id": "thinking-steve-jobs",
+      "split": "validation"
+    }
+  ],
+  "gates": {
+    "accuracyAtLeast80": true,
+    "allCategoriesRepresented": true,
+    "macroF1AtLeast80": true,
+    "passed": true,
+    "sampleAtLeast140": true,
+    "validationAccuracyAtLeast75": true,
+    "validationAllCategoriesRepresented": true,
+    "validationMacroF1AtLeast75": true
+  },
+  "goldSetSha256": "73dfedf806ba9b8a0c3b1b336209ad825312af6ede51c993ce03199352058933",
+  "humanApproved": false,
+  "metrics": {
+    "accuracy": 0.9642857142857143,
+    "accuracyWilsonLower95": 0.919123,
+    "correct": 135,
+    "macro_f1": 0.956325222396651,
+    "per_category": {
+      "ai-agents-orchestration": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 15,
+        "recall": 1.0,
+        "support": 15
+      },
+      "apps-workflow-automation": {
+        "f1": 0.9,
+        "precision": 0.9,
+        "predicted": 10,
+        "recall": 0.9,
+        "support": 10
+      },
+      "business-operations-strategy": {
+        "f1": 0.875,
+        "precision": 0.875,
+        "predicted": 8,
+        "recall": 0.875,
+        "support": 8
+      },
+      "chinese-platform-workflows": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 10,
+        "recall": 1.0,
+        "support": 10
+      },
+      "cloud-devops-reliability": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 13,
+        "recall": 1.0,
+        "support": 13
+      },
+      "content-media-publishing": {
+        "f1": 0.952381,
+        "precision": 0.909091,
+        "predicted": 11,
+        "recall": 1.0,
+        "support": 10
+      },
+      "data-analytics-research": {
+        "f1": 0.928571,
+        "precision": 0.928571,
+        "predicted": 14,
+        "recall": 0.928571,
+        "support": 14
+      },
+      "finance-trading-markets": {
+        "f1": 0.952381,
+        "precision": 1.0,
+        "predicted": 10,
+        "recall": 0.909091,
+        "support": 11
+      },
+      "general-utilities": {
+        "f1": 0.923077,
+        "precision": 0.857143,
+        "predicted": 7,
+        "recall": 1.0,
+        "support": 6
+      },
+      "marketing-seo-growth": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 6,
+        "recall": 1.0,
+        "support": 6
+      },
+      "product-design-ux": {
+        "f1": 0.857143,
+        "precision": 1.0,
+        "predicted": 3,
+        "recall": 0.75,
+        "support": 4
+      },
+      "sales-crm-customer-success": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 13,
+        "recall": 1.0,
+        "support": 13
+      },
+      "security-privacy-legal": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 9,
+        "recall": 1.0,
+        "support": 9
+      },
+      "software-engineering": {
+        "f1": 1.0,
+        "precision": 1.0,
+        "predicted": 11,
+        "recall": 1.0,
+        "support": 11
+      }
+    },
+    "total": 140
+  },
+  "reviewedSetAgreementScore": 95,
+  "runtimeEvidenceIncluded": false,
+  "sampleSize": 140,
+  "schemaVersion": 1,
+  "scoreSemantics": "floored minimum of exact accuracy and macro-F1 on the fixed, manually reviewed Gold Set; not an inventory-wide confidence interval",
+  "splits": {
+    "development": {
+      "accuracy": 1.0,
+      "accuracyWilsonLower95": 0.966839,
+      "correct": 112,
+      "macro_f1": 1.0,
+      "per_category": {
+        "ai-agents-orchestration": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 11,
+          "recall": 1.0,
+          "support": 11
+        },
+        "apps-workflow-automation": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 9,
+          "recall": 1.0,
+          "support": 9
+        },
+        "business-operations-strategy": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 6,
+          "recall": 1.0,
+          "support": 6
+        },
+        "chinese-platform-workflows": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 8,
+          "recall": 1.0,
+          "support": 8
+        },
+        "cloud-devops-reliability": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 10,
+          "recall": 1.0,
+          "support": 10
+        },
+        "content-media-publishing": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 9,
+          "recall": 1.0,
+          "support": 9
+        },
+        "data-analytics-research": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 12,
+          "recall": 1.0,
+          "support": 12
+        },
+        "finance-trading-markets": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 8,
+          "recall": 1.0,
+          "support": 8
+        },
+        "general-utilities": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 5,
+          "recall": 1.0,
+          "support": 5
+        },
+        "marketing-seo-growth": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 4,
+          "recall": 1.0,
+          "support": 4
+        },
+        "product-design-ux": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 2
+        },
+        "sales-crm-customer-success": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 11,
+          "recall": 1.0,
+          "support": 11
+        },
+        "security-privacy-legal": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 8,
+          "recall": 1.0,
+          "support": 8
+        },
+        "software-engineering": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 9,
+          "recall": 1.0,
+          "support": 9
+        }
+      },
+      "total": 112
+    },
+    "validation": {
+      "accuracy": 0.8214285714285714,
+      "accuracyWilsonLower95": 0.644086,
+      "correct": 23,
+      "macro_f1": 0.7714285714285715,
+      "per_category": {
+        "ai-agents-orchestration": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 4,
+          "recall": 1.0,
+          "support": 4
+        },
+        "apps-workflow-automation": {
+          "f1": 0.0,
+          "precision": 0.0,
+          "predicted": 1,
+          "recall": 0.0,
+          "support": 1
+        },
+        "business-operations-strategy": {
+          "f1": 0.5,
+          "precision": 0.5,
+          "predicted": 2,
+          "recall": 0.5,
+          "support": 2
+        },
+        "chinese-platform-workflows": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 2
+        },
+        "cloud-devops-reliability": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 3,
+          "recall": 1.0,
+          "support": 3
+        },
+        "content-media-publishing": {
+          "f1": 0.666667,
+          "precision": 0.5,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 1
+        },
+        "data-analytics-research": {
+          "f1": 0.5,
+          "precision": 0.5,
+          "predicted": 2,
+          "recall": 0.5,
+          "support": 2
+        },
+        "finance-trading-markets": {
+          "f1": 0.8,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 0.666667,
+          "support": 3
+        },
+        "general-utilities": {
+          "f1": 0.666667,
+          "precision": 0.5,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 1
+        },
+        "marketing-seo-growth": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 2
+        },
+        "product-design-ux": {
+          "f1": 0.666667,
+          "precision": 1.0,
+          "predicted": 1,
+          "recall": 0.5,
+          "support": 2
+        },
+        "sales-crm-customer-success": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 2
+        },
+        "security-privacy-legal": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 1,
+          "recall": 1.0,
+          "support": 1
+        },
+        "software-engineering": {
+          "f1": 1.0,
+          "precision": 1.0,
+          "predicted": 2,
+          "recall": 1.0,
+          "support": 2
+        }
+      },
+      "total": 28
+    }
+  }
+}

--- a/config/repository-architecture.json
+++ b/config/repository-architecture.json
@@ -48,9 +48,9 @@
     {
       "id": "catalog-discovery",
       "title": "Skill taxonomy and discovery catalog",
-      "interface": "config/skill-taxonomy.json in; catalog/README.md and catalog/skill-index.json out.",
-      "implementations": ["scripts/build_skill_catalog.py", "config/skill-taxonomy.json", "catalog"],
-      "ownershipPrefixes": ["catalog", "config/skill-taxonomy.json", "config/skill-index.schema.json", "scripts/build_skill_catalog.py"],
+      "interface": "Taxonomy and reviewed Gold labels in; catalog indexes and semantic evaluation evidence out.",
+      "implementations": ["scripts/build_skill_catalog.py", "scripts/build_skill_taxonomy_evaluation.py", "config/skill-taxonomy.json", "config/skill-taxonomy-gold.json", "catalog"],
+      "ownershipPrefixes": ["catalog", "config/skill-taxonomy.json", "config/skill-taxonomy-gold.json", "config/skill-taxonomy-gold.schema.json", "config/skill-taxonomy-evaluation.schema.json", "config/skill-index.schema.json", "docs/skill-taxonomy-gold-set.md", "scripts/build_skill_catalog.py", "scripts/build_skill_taxonomy_evaluation.py"],
       "depth": "composed",
       "seams": ["skill-library", "public-navigation", "verification-evidence"],
       "leverage": "A single classification rule improves human browsing and machine discovery.",
@@ -128,10 +128,14 @@
     {"path": "agents", "role": "authored-source", "module": "team-composition", "authority": false},
     {"path": "assets", "role": "public-navigation", "module": "public-navigation", "authority": false},
     {"path": "catalog", "role": "generated-output", "module": "catalog-discovery", "authority": false, "generatedBy": "scripts/build_skill_catalog.py", "verify": "npm run check:skills"},
+    {"path": "catalog/skill-taxonomy-evaluation.json", "role": "generated-output", "module": "catalog-discovery", "authority": false, "generatedBy": "scripts/build_skill_taxonomy_evaluation.py", "verify": "npm run check:taxonomy-evaluation"},
     {"path": "catalog/skill-quality.json", "role": "generated-output", "module": "verification-evidence", "authority": false, "generatedBy": "scripts/audit_skill_quality.py", "verify": "npm run check:skill-quality"},
     {"path": "config", "role": "governance", "module": "governance-memory", "authority": false},
     {"path": "config/external-skill-sources.json", "role": "authored-authority", "module": "governance-memory", "authority": true},
     {"path": "config/skill-index.schema.json", "role": "authored-source", "module": "catalog-discovery", "authority": false},
+    {"path": "config/skill-taxonomy-evaluation.schema.json", "role": "authored-source", "module": "catalog-discovery", "authority": false},
+    {"path": "config/skill-taxonomy-gold.json", "role": "authored-authority", "module": "catalog-discovery", "authority": true},
+    {"path": "config/skill-taxonomy-gold.schema.json", "role": "authored-source", "module": "catalog-discovery", "authority": false},
     {"path": "config/repository-architecture.json", "role": "authored-authority", "module": "governance-memory", "authority": true},
     {"path": "config/skill-quality-baseline.json", "role": "authored-authority", "module": "verification-evidence", "authority": true},
     {"path": "config/skill-taxonomy.json", "role": "authored-authority", "module": "catalog-discovery", "authority": true},
@@ -139,6 +143,7 @@
     {"path": "cookbook", "role": "public-navigation", "module": "public-navigation", "authority": false},
     {"path": "design-qa.md", "role": "evidence", "module": "verification-evidence", "authority": false},
     {"path": "docs", "role": "public-navigation", "module": "public-navigation", "authority": false},
+    {"path": "docs/skill-taxonomy-gold-set.md", "role": "authored-source", "module": "catalog-discovery", "authority": false},
     {"path": "docs/adr", "role": "governance", "module": "governance-memory", "authority": false},
     {"path": "docs/assets/star-history.svg", "role": "generated-output", "module": "public-navigation", "authority": false, "generatedBy": "scripts/build_site_data.py", "verify": "npm run test:repository"},
     {"path": "docs/data/repo-stats.json", "role": "generated-output", "module": "public-navigation", "authority": false, "generatedBy": "scripts/build_site_data.py", "verify": "npm run test:repository"},
@@ -154,6 +159,7 @@
     {"path": "requirements-dev.txt", "role": "implementation", "module": "verification-evidence", "authority": false},
     {"path": "scripts", "role": "implementation", "module": "verification-evidence", "authority": false},
     {"path": "scripts/build_skill_catalog.py", "role": "implementation", "module": "catalog-discovery", "authority": false},
+    {"path": "scripts/build_skill_taxonomy_evaluation.py", "role": "implementation", "module": "catalog-discovery", "authority": false},
     {"path": "setup.md", "role": "public-navigation", "module": "safe-installation", "authority": false},
     {"path": "skills", "role": "authored-authority", "module": "skill-library", "authority": true},
     {"path": "starter-kits", "role": "authored-source", "module": "team-composition", "authority": false},
@@ -183,7 +189,8 @@
     "requiredDecisions": [
       "docs/adr/0001-canonical-inventory-and-generated-outputs.md",
       "docs/adr/0002-generic-workspace-and-curated-distributions.md",
-      "docs/adr/0003-structural-evidence-and-runtime-receipts.md"
+      "docs/adr/0003-structural-evidence-and-runtime-receipts.md",
+      "docs/adr/0004-reviewed-skill-taxonomy-evaluation.md"
     ]
   }
 }

--- a/config/skill-index.schema.json
+++ b/config/skill-index.schema.json
@@ -69,11 +69,11 @@
       "additionalProperties": false,
       "required": ["method", "winner", "matched_signals", "runner_ups", "resolution_status", "review_state"],
       "properties": {
-        "method": {"enum": ["slug", "description", "override", "fallback"]},
+        "method": {"enum": ["outcome", "slug", "description", "override", "fallback"]},
         "winner": {"$ref": "#/$defs/winner"},
         "matched_signals": {"type": "array", "uniqueItems": true, "items": {"type": "string"}},
         "runner_ups": {"type": "array", "items": {"$ref": "#/$defs/candidate"}},
-        "base_method": {"enum": ["slug", "description", "fallback"]},
+        "base_method": {"enum": ["outcome", "slug", "description", "fallback"]},
         "base_candidates": {"type": "array", "items": {"$ref": "#/$defs/candidate"}},
         "rationale": {"type": "string", "minLength": 20},
         "resolution_status": {"enum": ["rule-match", "priority-tie", "override", "fallback"]},
@@ -125,7 +125,7 @@
           }
         },
         {
-          "if": {"properties": {"method": {"enum": ["slug", "description"]}}, "required": ["method"]},
+          "if": {"properties": {"method": {"enum": ["outcome", "slug", "description"]}}, "required": ["method"]},
           "then": {
             "properties": {
               "resolution_status": {"enum": ["rule-match", "priority-tie"]},

--- a/config/skill-taxonomy-evaluation.schema.json
+++ b/config/skill-taxonomy-evaluation.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aaaaqwq.github.io/AGI-Super-Team/schemas/skill-taxonomy-evaluation.schema.json",
+  "title": "Generated Skill taxonomy reviewed-set agreement evaluation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "sampleSize", "categoryCount", "goldSetSha256", "annotationMode", "humanApproved", "metrics", "splits", "gates", "reviewedSetAgreementScore", "scoreSemantics", "runtimeEvidenceIncluded", "errors"],
+  "properties": {
+    "$schema": {"const": "../config/skill-taxonomy-evaluation.schema.json"},
+    "schemaVersion": {"const": 1},
+    "sampleSize": {"const": 140},
+    "categoryCount": {"const": 14},
+    "goldSetSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "annotationMode": {"const": "independent-agent-manual-review"},
+    "humanApproved": {"const": false},
+    "metrics": {"$ref": "#/$defs/metrics"},
+    "splits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["development", "validation"],
+      "properties": {
+        "development": {
+          "allOf": [
+            {"$ref": "#/$defs/splitMetrics"},
+            {"properties": {"total": {"const": 112}}}
+          ]
+        },
+        "validation": {
+          "allOf": [
+            {"$ref": "#/$defs/splitMetrics"},
+            {"properties": {"total": {"const": 28}}}
+          ]
+        }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sampleAtLeast140", "accuracyAtLeast80", "macroF1AtLeast80", "allCategoriesRepresented", "validationAccuracyAtLeast75", "validationMacroF1AtLeast75", "validationAllCategoriesRepresented", "passed"],
+      "properties": {
+        "sampleAtLeast140": {"type": "boolean"},
+        "accuracyAtLeast80": {"type": "boolean"},
+        "macroF1AtLeast80": {"type": "boolean"},
+        "allCategoriesRepresented": {"type": "boolean"},
+        "validationAccuracyAtLeast75": {"type": "boolean"},
+        "validationMacroF1AtLeast75": {"type": "boolean"},
+        "validationAllCategoriesRepresented": {"type": "boolean"},
+        "passed": {"type": "boolean"}
+      }
+    },
+    "reviewedSetAgreementScore": {"type": "integer", "minimum": 0, "maximum": 100},
+    "scoreSemantics": {"type": "string", "minLength": 30},
+    "runtimeEvidenceIncluded": {"const": false},
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["skill_id", "expected_category", "predicted_category", "split"],
+        "properties": {
+          "skill_id": {"type": "string"},
+          "expected_category": {"type": "string"},
+          "predicted_category": {"type": "string"}
+          ,"split": {"enum": ["development", "validation"]}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "categoryMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["precision", "recall", "f1", "support", "predicted"],
+      "properties": {
+        "precision": {"type": "number", "minimum": 0, "maximum": 1},
+        "recall": {"type": "number", "minimum": 0, "maximum": 1},
+        "f1": {"type": "number", "minimum": 0, "maximum": 1},
+        "support": {"type": "integer", "minimum": 0},
+        "predicted": {"type": "integer", "minimum": 0}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "correct", "accuracy", "macro_f1", "accuracyWilsonLower95", "per_category"],
+      "properties": {
+        "total": {"const": 140},
+        "correct": {"type": "integer", "minimum": 0},
+        "accuracy": {"type": "number", "minimum": 0, "maximum": 1},
+        "macro_f1": {"type": "number", "minimum": 0, "maximum": 1},
+        "accuracyWilsonLower95": {"type": "number", "minimum": 0, "maximum": 1},
+        "per_category": {
+          "type": "object",
+          "minProperties": 14,
+          "additionalProperties": {"$ref": "#/$defs/categoryMetrics"}
+        }
+      }
+    },
+    "splitMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "correct", "accuracy", "macro_f1", "accuracyWilsonLower95", "per_category"],
+      "properties": {
+        "total": {"type": "integer", "minimum": 1},
+        "correct": {"type": "integer", "minimum": 0},
+        "accuracy": {"type": "number", "minimum": 0, "maximum": 1},
+        "macro_f1": {"type": "number", "minimum": 0, "maximum": 1},
+        "accuracyWilsonLower95": {"type": "number", "minimum": 0, "maximum": 1},
+        "per_category": {
+          "type": "object",
+          "minProperties": 14,
+          "additionalProperties": {"$ref": "#/$defs/categoryMetrics"}
+        }
+      }
+    }
+  }
+}

--- a/config/skill-taxonomy-gold.json
+++ b/config/skill-taxonomy-gold.json
@@ -1,0 +1,2190 @@
+{
+  "$schema": "./skill-taxonomy-gold.schema.json",
+  "schemaVersion": 1,
+  "annotation": {
+    "mode": "independent-agent-manual-review",
+    "humanApproved": false,
+    "rubric": "../docs/skill-taxonomy-gold-set.md",
+    "labelSetSha256": "78e6b44843fc60d08d1a9cc3fb728fdfec2eccfc35b812064b53342559ba7da1"
+  },
+  "sampling": {
+    "method": "predicted-category-balanced-difficulty-first-stable-hash",
+    "seed": "semantic-gold-v1",
+    "perPredictedCategory": 10,
+    "baseCommit": "de505e1ea95d564f80541d7ad796883da5e9a350",
+    "baseCatalogSha256": "b3669c200fc349f792ad07d352f1f81f54a2c01b72c217da14f588a0bb2de0ee",
+    "candidateSetSha256": "7765f415e2be2d7b93341dc8192837a06bebb5a9c8fea17ab5c06d8326473267"
+  },
+  "labels": [
+    {
+      "skill_id": "agent-browser",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Its command loop navigates pages, fills forms, and drives repeatable browser workflows.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "04afeeb53a8b6ab953974311ec7ed60e0d66c532341ca21933625320f28b01c6"
+    },
+    {
+      "skill_id": "meta-cognition",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "核心产物是多 Agent 的路由、风险门控与闭环执行协议，而非一般企业战略建议。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "686412338738f1039ebafc5e9366856ed04c9b5806124062912931eef1d3ad8d"
+    },
+    {
+      "skill_id": "internal-comms",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Produces newsletters, status updates, FAQs, and other internal written artifacts.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "067b7587a344a928fc6534ef66b1bcd591fc7c26d207ea7ca3334aeb678d6475"
+    },
+    {
+      "skill_id": "agent-task-confirm",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "核心结果是确认已派发 Agent 的送达、活跃与超时状态，属于 Agent 调度闭环。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "146616e547f69b4076c306a6d4676f6038754afc558de7b7e15aac6662c010f7"
+    },
+    {
+      "skill_id": "vcf-annotator",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It annotates VCFs with VEP, ClinVar, and gnomAD, then produces ranked variant reports.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "3bbfb00254fbf4d46534f24133e7d7b029ddc84cd4d0b35cc9d0c1bc94520dc9"
+    },
+    {
+      "skill_id": "kanbanflow-skill",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "直接操作 KanbanFlow 这一具体 SaaS 的看板与任务，主要结果是应用工作流自动化。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "37fa362a68be4721887c97713cce6eb17526abf8ae9705c7715fe11a05104134"
+    },
+    {
+      "skill_id": "file-organizer",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Organizes local files, detects duplicates, and cleans folders as a general desktop utility.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a8b91952bab7f73511db68149c4a54672b40699903a8e35ed5044c3e3039ded5"
+    },
+    {
+      "skill_id": "dispatching-parallel-agents",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "override",
+      "split": "validation",
+      "rationale": "主要指导如何拆分独立任务并并发派发专业 Agent，再审查和整合结果。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "76806091c7f923ba2596546b19cccd98a08e57a68745df77c3a7b998fe838e2b"
+    },
+    {
+      "skill_id": "context-recovery",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It restores compacted agent context from channel history, session logs, and shared memory.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "13297b10889d57eeca467a4c16168081e3bf2a580adc66977591604204093f44"
+    },
+    {
+      "skill_id": "clawrouter",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "ai-agents-orchestration",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "按请求复杂度在多个 LLM 间路由并控制推理成本，属于模型编排与选择。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ac56e6c5625f557bdd0026928414a05da981708b1827343f15142e3db241a2a5"
+    },
+    {
+      "skill_id": "sp-subagent-driven-development",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Coordinates fresh subagents and review gates; orchestration defines the user workflow.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "33a23679d7a7353cb598f16ad86631dfe25b8800145d380573e9500c22956438"
+    },
+    {
+      "skill_id": "git-workflow",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "直接处理 Git 状态、提交、推送、冲突和分支，是典型开发者工具工作流。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f79b57a0359d63ebd29e55ecda73ceac5932bfd92aa68a8b121dc6dace3685b1"
+    },
+    {
+      "skill_id": "gitlab-automation",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It performs repeatable GitLab issue, merge-request, pipeline, and branch operations.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ee8116c37964ddb7f700a9e670e4179fefbb1da4dcfb5a891746d2f74540b254"
+    },
+    {
+      "skill_id": "liuyao-yijing",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "提供六爻起卦与传统易学解读，属于未设专类的垂直领域辅助工具。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "e7d94ceb4ed26c83c1bb245b2713137bc70749cbca4fe5c6aafecd1835058aeb"
+    },
+    {
+      "skill_id": "deepwork-tracker",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Tracks personal focus sessions and renders activity reports as a specialized local utility.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7ecb04afa361e0a4a5f8adb4a7b932d2991f5983e95f53e979a8b5110be06fcc"
+    },
+    {
+      "skill_id": "claude-code-runner",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "最终用户结果是以 PTY 执行代码审查、重构、修复和功能开发等编程任务。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "6fb465cf17f31e87b3df944aa6a399ff4834489d8d7005941d6f170d14fffd10"
+    },
+    {
+      "skill_id": "elite-github-skills-hub",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It discovers, compares, and installs capability packs for Claude, Codex, and other agents.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0dad782c259fbb20739a66005f012df4839547feb8231a650ea322e898b969cc"
+    },
+    {
+      "skill_id": "subagent-driven-development",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "核心方法是调度独立子 Agent 并组织两阶段审查，开发只是该编排协议的应用场景。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "081ad3869e55c80bf8f890b4768a90c0e8057daf94b1b6fadebfc85ea5b8304a"
+    },
+    {
+      "skill_id": "provider-key-manager",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Rotates and audits API credentials, making secret hygiene and key management the primary outcome.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "bd730395fd1673be4113e28914c5e60a4549b308751ff0d277962cca646772d3"
+    },
+    {
+      "skill_id": "codex-cc-guide",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "software-engineering",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "核心是通过 ACP sessions_spawn 创建、限制和管理 Claude Code 或 Codex 会话。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "9a83932498081fa6caf2c5c6033efec3d8c2309a5fd44803e82eb96494eec4aa"
+    },
+    {
+      "skill_id": "render-automation",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It lists Render services, triggers deployments, and monitors asynchronous deployment state.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d746d0e41d4a964bb0501e7153a89af24137f4e55d68744f41ffa70f2e8343fb"
+    },
+    {
+      "skill_id": "vercel-automation",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "管理 Vercel 部署、域名、DNS、环境变量和项目，直接服务云部署与运行维护。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "08c35e0fa4ca6b763842fcb48c7e55878c36a6e25fac9bda7f188c5e63170a9f"
+    },
+    {
+      "skill_id": "proxmox-ops-skill",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Operates Proxmox infrastructure, including VM control, monitoring, storage, backups, and recovery.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7b51fe23e4fd9459458ec21813b69ee4b93a5e4fcd2f829133258cd768761363"
+    },
+    {
+      "skill_id": "deployment-automation",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "交付 Docker、CI/CD、Kubernetes 和云平台部署方案，主要结果是基础设施发布。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "542d86db666473699645cd921ddc37f0e9927de839af0401968be0d0a254e9b4"
+    },
+    {
+      "skill_id": "ml-engineer",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Its core deliverable is production ML serving, deployment, monitoring, and MLOps infrastructure.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "cdd4ff5d9ed06a6f9db95c1be6a32eca303396644f51bf864ea9f85d13e469c2"
+    },
+    {
+      "skill_id": "model-usage-linux",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "解析会话数据并汇总模型 Token、成本和使用分布，主要用户结果是用量分析报告。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a432eaf5d392ce6c38f62524edc71a45d4765e403dc46cdbfcf59af174cb44de"
+    },
+    {
+      "skill_id": "sentry-automation",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Investigates production errors and manages alerts, releases, monitors, and observability workflows.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ed7f09932461c77f3542bd7acd9309fb8c71a666da616b936c861e9b2afd837b"
+    },
+    {
+      "skill_id": "kubernetes-deployment",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "rule-match",
+      "split": "validation",
+      "rationale": "完整流程围绕容器、Helm、服务网格、安全、可观测性和集群发布展开。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0adc0eb8df8a743470e5afc44447a9f19408a3f1d780d7e85c8d957946582f38"
+    },
+    {
+      "skill_id": "nginx-configuration",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It configures production reverse proxies, load balancing, TLS, caching, and API gateways.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "67357722522217369983a0376d0a59b1b5f5464c5ca7f62bf22ff8c16685e9a2"
+    },
+    {
+      "skill_id": "incident-response-incident-response",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "cloud-devops-reliability",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "覆盖事故分级、排障、缓解、恢复和复盘，是典型的 SRE 事故响应运行手册。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "75b23dfebf23c6f0e8d6f7ca59596a9bbc4642c2008e8023184822dd47459c73"
+    },
+    {
+      "skill_id": "startup-metrics-framework",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Calculates and interprets startup performance metrics, unit economics, and operating evidence.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "eaac30ac41b5effd1057bfc98b800816534c81fa74d29ff4ea926163f837f6c6"
+    },
+    {
+      "skill_id": "bio-orchestrator",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "虽然采用编排形式，最终产物是生物信息分析、研究报告和可复现证据包。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c5f118cbc042c61282238a39d1f4b314755679769466e643f6ff31bfcb000f58"
+    },
+    {
+      "skill_id": "datadog-automation",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It operates monitors, logs, traces, dashboards, events, and maintenance downtimes in Datadog.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "61c620482c80bff0969e9331f98f660002ce9a9088b069ab5a531a7d00421865"
+    },
+    {
+      "skill_id": "ai-radar",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "从公开数据源检索、过滤并综合最新 AI 资讯，核心是证据采集与研究简报。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "386bb5d95c228e9508c6b57fd77a44bbdbf247582a5c331ff7af4db469271ccc"
+    },
+    {
+      "skill_id": "documents",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "Retrieves, organizes, uploads, and sends documents through local storage, Drive, and email workflows.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "6c0a2beb4b3a19259a9af410778cb435c465f327f23f713f91719f6ac9406e87"
+    },
+    {
+      "skill_id": "wiki-qa",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "主要帮助开发者基于源码理解仓库组件、定位定义和导航代码，而非通用研究。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c0faf1c9819ce3dc080643294e5ce5173b2b84a10474c7d5ddba49594a6e7aed"
+    },
+    {
+      "skill_id": "business-intelligence",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It defines KPI contracts, metric trees, dashboards, and evidence-backed decision briefings.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "5cf7fac4dbfae89ea34000a733bb1d4de3677a529a1156e4d78c8c5283d07365"
+    },
+    {
+      "skill_id": "kpi-dashboard-design",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "指导 KPI 选择、计算、可视化和实时监测，主要结果是数据指标分析与沟通。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "68cbf33113de7767500c7420c25c47bf7d7542dc7426f688e16a9db49fde3c4e"
+    },
+    {
+      "skill_id": "static-code-analysis",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Configures developer tooling that detects code defects, security issues, and style violations.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "02c7a649fcbabdd57a8dfecc4b1b259fa2e6fe462f5519ebdcfae5d750cd723f"
+    },
+    {
+      "skill_id": "google-analytics-automation",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "data-analytics-research",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "主要结果是查询 GA4 指标、漏斗、透视表和关键事件并分析网站数据。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "9cfc4857f70887dd70827d8460af7e9479265649c385d3a19e95837671acdaa9"
+    },
+    {
+      "skill_id": "contract-and-proposal-writer",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It drafts jurisdiction-aware NDAs, MSAs, SOWs, contracts, and GDPR processing clauses.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0441fd90696398b503913a77b848e42e7c621f380820da7008305aa0267f9d62"
+    },
+    {
+      "skill_id": "performing-security-code-review",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "专门审查注入、XSS、认证缺陷和依赖风险，交付物是安全代码审计结论。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c0713ebfe3ae3d194f30f6292fed4269669c798da24e8050964654bf780f4243"
+    },
+    {
+      "skill_id": "vibe-code-auditor",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Reviews generated code for architecture, robustness, maintainability, and production readiness.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "78139c215eabc9c06181beac1bd61f2a9f2ee1c1ca31a3dc98cf012d6e3422c9"
+    },
+    {
+      "skill_id": "inference-optimizer",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "It audits token context and manages OpenClaw agent sessions; no cloud infrastructure is deployed or operated.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3",
+        "reviewer-root"
+      ],
+      "review_status": "adjudicated",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a2897e77cbdafa8518c4f36dbe211783a40524674a33f6ec5a66cbb2e547bb15"
+    },
+    {
+      "skill_id": "security-audit",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "override",
+      "split": "development",
+      "rationale": "It audits credentials, ports, permissions, Docker settings, and vulnerable configurations.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7ed4a7bd3811fbf405703886f4ce53c4953803af3f4e3705da95a8ae83e69dd5"
+    },
+    {
+      "skill_id": "skill-security-auditor",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "安装前扫描 Agent Skill 的恶意代码、提示注入与供应链风险，属于安全门禁。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d546d0edcd0fb0eafa3f81eb1f42a7fabb9994facda37e3a31009a8f9530eedf"
+    },
+    {
+      "skill_id": "china-contract-review",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "Reviews Chinese contracts for legal risk, compliance gaps, and safer clause revisions.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f46d5f73fc7c6270d47341f4bcc0020460788b33802d7ab07a00139f646bdb52"
+    },
+    {
+      "skill_id": "dependency-auditor",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "主要识别依赖漏洞、许可证冲突、供应链风险及合规问题并生成审计报告。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "008aa72387404d9be64a00ac3f289d1f44be71a6db472f985e0c260f6bb3815c"
+    },
+    {
+      "skill_id": "pci-compliance",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It implements PCI DSS controls for card data, encryption, access, auditing, and scope reduction.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "327d0197e57bdc1bfb7f546d2f5bcaa40693c9e5ec80b3af33dd75ed36a75f2e"
+    },
+    {
+      "skill_id": "auth-manager",
+      "expected_category": "security-privacy-legal",
+      "baseline_predicted_category": "security-privacy-legal",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "统一维护网页登录态、授权与会话有效性，核心责任是认证和访问状态管理。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "1cc404bd3fc158ffc6fd3975b06429bfd31bdd43493bd7c1d36b1037cd1370ce"
+    },
+    {
+      "skill_id": "prioritization-funnel",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Ranks strategic opportunities and allocates capital, people, and time through decision gates.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a6bbd634a825181803c604711a2f20a224c120627ce763383d1216d5b44a7ccb"
+    },
+    {
+      "skill_id": "roadmap-planning",
+      "expected_category": "product-design-ux",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "将客户问题、产品需求和优先级转化为结果导向的产品路线图与 Epic。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0c6d1cbcfadffc4befe7cfc22a0ca735172f24853605ac056282fb91a34ebff1"
+    },
+    {
+      "skill_id": "prd-development",
+      "expected_category": "product-design-ux",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It turns product problems, users, requirements, scope, and success criteria into a complete PRD.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "77e5ebabc9c917256ec91141365bddcd492c6f5aa6e12dbff22be0eb59337ff4"
+    },
+    {
+      "skill_id": "api-design-patterns",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "提供 REST、GraphQL、gRPC、版本化和认证的 API 工程设计模式，属于软件架构实践。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "1d89932bee15231fbf357ebc3573ea3eb877b01aa926a53f5b9c5dd5b53b7725"
+    },
+    {
+      "skill_id": "software-architecture-design",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Designs software system boundaries, architecture patterns, data strategy, and migration plans.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "bfd5c57076412707d800608b58995d05e06003fa4658520a8c211af24ec86a6f"
+    },
+    {
+      "skill_id": "figma-automation",
+      "expected_category": "product-design-ux",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "核心产物是 Figma 组件、设计令牌、样式、评论和视觉资产的设计操作。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "cb399ce260b15277e281267dac1384c8a4426d22404e3b37af828924ffbe8e22"
+    },
+    {
+      "skill_id": "cua-driver",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It drives native GUI applications through snapshot, click, type, scroll, and verification loops.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "22a3825ea5538b0cda07923d5d3e8123dd2da503f124976681c5969bf7d88a24"
+    },
+    {
+      "skill_id": "senior-architect",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "完成系统架构、技术栈、依赖、数据库和扩展性决策，主要服务软件系统设计。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "469ef270e5752425be0a1779ee42d683c43a342c196bc5f5fe1092bce93cb214"
+    },
+    {
+      "skill_id": "api-design",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "Defines production REST API contracts, pagination, errors, authentication, and versioning.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d2b090c4319e030fddb576950400724ff12ccb285083a540b6afb62431185d25"
+    },
+    {
+      "skill_id": "observability-designer",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "product-design-ux",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "明确设计 SLI/SLO、指标、日志、追踪、告警和运行手册以保障生产可靠性。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "bd68d04d7586a2bd8bc2dcc15594cf95d2e16b8a0f0ef6888a89fd646a250842"
+    },
+    {
+      "skill_id": "skill-amazon-ads",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It manages Amazon Sponsored Products campaigns, advertiser profiles, budgets, and performance.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "5d6deb377be8399e8227be1993d677d91a837b1b9acc0adf160fd0e67eef8b52"
+    },
+    {
+      "skill_id": "social-content",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "以品牌认知、获客、流量和互动为目标制定社媒内容与增长策略，重点是受众增长。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ee0181c7916d8f21ff5d778f8401f9e3686364af731eb30e06066f8197a4a146"
+    },
+    {
+      "skill_id": "microservices-patterns",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Operates production microservices with Istio, Kubernetes, resilience, traffic, and observability controls.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c2626388b336f11e208f8434d55ad832f0f1350ebd238d77fb1c7f518a69d1f7"
+    },
+    {
+      "skill_id": "seo-strategy",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "用户结果是通过关键词、内容、技术 SEO 和外链获取持续自然搜索流量。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f939c34d81e0bfe966c392217047bdc8ee45597330a05c932f60981e997ce422"
+    },
+    {
+      "skill_id": "activecampaign-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It manages CRM contacts, subscriptions, tags, follow-up tasks, and automation enrollment.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "79130c7386edc790f017466009d7de8a9940e932dc345296d8bf7c6cde1840f1"
+    },
+    {
+      "skill_id": "ai-marketing-videos",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "实际工作流生成镜头、旁白并合并为广告或演示视频；营销是用途，直接交付物是视频媒体资产。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1",
+        "reviewer-root"
+      ],
+      "review_status": "adjudicated",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ef3272d34fe7658c78bba4612223bfc93fda0e7761361f9c3e5920bd5a5b8896"
+    },
+    {
+      "skill_id": "geo-content-optimizer",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Optimizes content visibility and citations across AI answer engines and organic search surfaces.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "dd09dda1007965e1ed99b5ca161816b698c0e80caea8b6811e9010960909bb29"
+    },
+    {
+      "skill_id": "ai-viral-team-script-writing",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "主要交付短视频脚本、分镜、台词、镜头提示词和视频生成配置，属于内容生产。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "655e5fcd13f2efedfa80640af58679b2b5edaae70d6a915c2f640a285268d3bf"
+    },
+    {
+      "skill_id": "create-viral-content",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "It optimizes public content hooks, titles, thumbnails, and platform formats for audience reach.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0de78f1a54dd692f28cbdc5d5ee48bd70bf4efbd719300edc1129100681f45af"
+    },
+    {
+      "skill_id": "domain-name-brainstormer",
+      "expected_category": "marketing-seo-growth",
+      "baseline_predicted_category": "marketing-seo-growth",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "生成并筛选品牌域名、TLD 和竞争性命名方案，核心是品牌定位与市场识别。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "495707739b354f81d1e28c6188dd55b97fdf5c64ae3e3c182ba6f092b2ab782b"
+    },
+    {
+      "skill_id": "code-to-image",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Creates reusable image assets and publication covers by rendering coded visual compositions.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "20ea099cff9d2e524119929d1fe211e8b1abd64fedf10aebeb352362637898f4"
+    },
+    {
+      "skill_id": "mv-production-standard",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "定义从素材、分镜、剪辑、字幕、口型同步到最终 MV 交付的媒体制作流程。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "71c71993508da8d72ba4e1dc32532ab23d2820b9877f765e3727aa3221e03923"
+    },
+    {
+      "skill_id": "youtube-knowledge-extractor",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It extracts transcripts and frames, synchronizes evidence, and analyzes what a video teaches.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a91a82e5403c1e39419dde813e962ff97364b54e434e910f774cc7ad4b57d3df"
+    },
+    {
+      "skill_id": "writing-skills",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "创建、测试和优化供 Agent 触发执行的 Skill 契约，属于 Agent 能力与上下文工程。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d83a09d6a1c6976f6cc2f40addeae653a4a6eb5903097ebc365d90242e00e379"
+    },
+    {
+      "skill_id": "image-scraper",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "Collects image resources from web pages through scraping, extraction, and local download.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "5c4531484b2225d98fcb42d52ee12bf86b300fcf8b82b83aa94d94083edce129"
+    },
+    {
+      "skill_id": "heygen-avatar-lite",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "通过 HeyGen 生成多语言数字人视频，最终结果是可发布的视频媒体资产。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7e614c931d8302bd22bc8c81c99e022a00f3639c689cd2045a0ee29cb68d7cfd"
+    },
+    {
+      "skill_id": "evomap",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It connects agents to an A2A marketplace for shared capabilities, bounties, and swarm tasks.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "b8862b0fa6d8621f5fc42547fde4c14cfb6c1ac9e0e8fd4bb5caa614f7bfcc41"
+    },
+    {
+      "skill_id": "suno-skills",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "自动操作 Suno 生成歌曲、歌词和音频文件，主要产物是可下载的音乐内容。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "41b4466e1c452c659903ca726b85b4f3132cd0dc5d5e78cdda8756b33ecb8473"
+    },
+    {
+      "skill_id": "virtual-singer-mv-script",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Transforms audio and lyrics into synchronized video storyboards and production-ready MV scripts.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7d0fae36b001b0630b13014e66714ee1b32e36c21f8eb39edff7bbd944b1c68e"
+    },
+    {
+      "skill_id": "vectornode-image-gen",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "content-media-publishing",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "直接生成或编辑图片并保存视觉文件，主要结果是图像内容资产。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "51489c1cc1f52b170f1ede36aa15d652f4e630059f2c156e74271bbc75094106"
+    },
+    {
+      "skill_id": "watchers-run",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It monitors prospect and competitor sites, then emits lead and outreach-trigger alerts.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "290b10eaac2096b9d7980c2472113a98576233ab5054dbe9654a209baa553292"
+    },
+    {
+      "skill_id": "email-outreach-run",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "执行带审批、限速和 CRM 记录的邮件拓展活动，直接服务线索触达与销售转化。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f965f3efb31ab5b1291296b4d0637c58c58eebe46ae64b313b0913a715ed4cbb"
+    },
+    {
+      "skill_id": "pipedrive-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Runs Pipedrive deal, contact, activity, note, and sales-pipeline management workflows.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f594c20b259986a02a0937fca720b068ac6648e029bab75d5506cf7f62b0c6c5"
+    },
+    {
+      "skill_id": "close-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "围绕 Close 中的线索、联系人、电话、短信和跟进任务管理销售活动。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "298f9ed5af5eda1f9dcea34eb6ac9d68edf262c4eb601de340fe210ac714f504"
+    },
+    {
+      "skill_id": "cold-email-sequence-generator",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It builds personalized multi-touch outbound sequences for lead generation and sales replies.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "89082db5e31f995f969c332a425a33cbc85ae44f20848ff60bb2ee925cbd6583"
+    },
+    {
+      "skill_id": "zoho-crm-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "在 Zoho CRM 中检索联系人、管理线索并完成线索转化，属于销售 CRM 流程。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "6b305325a4c860dd0f8e0d233bf11a8c10d0b5d8d6b73c2d55a7c032bd996736"
+    },
+    {
+      "skill_id": "hubspot-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Runs HubSpot contact, company, deal, ticket, and CRM property management workflows.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "9574e7cf96e6424f86c995a3f9812b0db58039b7ac1210f28b611bd88963cac0"
+    },
+    {
+      "skill_id": "crm-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "主要完成线索捕获、评分、分配、成交阶段推进和多 CRM 销售管道同步。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "b3c9f124b28b87d90ea6471595e33941a6cf67d0043007f642562500abd4209a"
+    },
+    {
+      "skill_id": "zendesk-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "It manages support tickets, customer replies, users, organizations, and ticket lifecycles.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "91835c0b1beaa420365da18d5ad090c9b0e7b09e9051e6d02649e1d7b2b9b0aa"
+    },
+    {
+      "skill_id": "helpdesk-automation",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "sales-crm-customer-success",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "浏览和处理工单、视图、快捷回复及自定义字段，直接服务客户支持工作流。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d8a64a0a3a4d5e30db051f2b8ca481cae0446f0d52acb9301fd4a42df9a74a80"
+    },
+    {
+      "skill_id": "daily-portfolio",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "Tracks market prices, balances, prediction-market positions, returns, and portfolio actions.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "66065de257d80daa398d204cd4f41fdfefaf0d0cb84a6a57e8c863d46bcbffa8"
+    },
+    {
+      "skill_id": "quality-convergence-engine",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "它跨领域定义红线和验收标准，不产生某一垂直领域结果，符合通用审查工具。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "3d0ea290cb256d0027f2914110875042b7108be153665f982bcb48c285bf5f94"
+    },
+    {
+      "skill_id": "pine-visualizer",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It decomposes trading strategies into Pine indicators, entry rules, exits, and risk logic.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "edf60b330701efb2bd4785483ed130aa4d64f656ac28dd3d9d1817c25e969b9e"
+    },
+    {
+      "skill_id": "technical-analysis",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "使用价格行为、技术指标与图表形态识别交易机会，明确属于市场和交易分析。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "885764b2e375cfffeb38a48c016d9eb5d0d900a645def556f68567377fff0601"
+    },
+    {
+      "skill_id": "repro-enforcer",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Packages bioinformatics analyses into reproducible environments, pipelines, checksums, and instructions.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "6d260d38f624c6d71694e52d331e24d638552012fd6997196a99fd97b107d570"
+    },
+    {
+      "skill_id": "llm-stock-analyzer",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "采集股票行情、基本面和情绪，输出交易点位、风险纪律与历史回测评价。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "b0333c168cdfaba79c8dd0a89818ffb0da03ac28a06e7c98c1872b4580e766cf"
+    },
+    {
+      "skill_id": "setting-okrs-goals",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It aligns company and team objectives with measurable key results and operating systems.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ed39ed1153337573b64f70d5a8ea1576e1a3aaa2835df87959a2731674508aa9"
+    },
+    {
+      "skill_id": "startup-financial-modeling",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "建立收入、成本、现金流、烧钱速度和跑道预测，核心产物是创业财务模型。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "92f875c51cd3fbb3ebffecc9b20e33c1ff9f8c177f44edd418c77ff5c36b6f2a"
+    },
+    {
+      "skill_id": "billing-automation",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Implements subscription billing, payments, invoicing, taxes, renewals, and failed-payment recovery.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "08d64fa3e67c9c379d89a218278caa35125bbd2ba84f27a2c7c88feb124938a8"
+    },
+    {
+      "skill_id": "cost-optimization",
+      "expected_category": "cloud-devops-reliability",
+      "baseline_predicted_category": "finance-trading-markets",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "目标是通过云资源调整、标签、预留实例和存储策略优化基础设施成本。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d3cc6b5ad7d4bf6864ec21e6a2f9526afc99517037e0ad2e3597ac36117a39fa"
+    },
+    {
+      "skill_id": "company-analyzer",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It analyzes listed companies through fundamentals, valuation, technicals, and competitive position.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "5566a8b68e7dde9380bd4706b1198c2ca0e71b74603bf1f01c98a06483a0f511"
+    },
+    {
+      "skill_id": "todo-tracker",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "跨会话记录、排序和完成待办事项，主要结果是持续的任务计划与工作管理。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a8f163d2665037a5f12c22ed9cacf9e5c9598950c8a203ba3fa8654c3680649e"
+    },
+    {
+      "skill_id": "meeting-notes",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "validation",
+      "rationale": "Turns meetings into accountable decisions, action items, owners, risks, and operating records.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "3a23090aa07a7ce102eae2b389efd71a73eef6d9f052a85b32b7f5f8202fbf9b"
+    },
+    {
+      "skill_id": "daily-reflection",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "每日复盘账户 P&L、逐笔交易、胜率、仓位和风控，属于交易绩效审查。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "6e2a48daec8b18b94975574cadf900c5a5ac7e6ac886f11e0146313c1ea1ea9e"
+    },
+    {
+      "skill_id": "startup-business-analyst-business-case",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It creates investor-ready business cases spanning market, strategy, team, risks, and funding.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ea60f89ad32e1b95f2af0a14c6f3d32f8bc72bff1772816692752b94ee5852e9"
+    },
+    {
+      "skill_id": "cto-advisor",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "指导技术战略、团队扩张、技术债和工程指标，核心是 CTO 经营与组织决策。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "e8eeedffcb90f63c0a5635abe18fd5574e7bd7363791dcb4bcae69d40e4e9f5e"
+    },
+    {
+      "skill_id": "thinking-simon",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "Guides quantitative trading decisions through backtests, portfolio risk, and statistical edge.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "3bfe6bde4411a1b2261c5607c746379174f037c901f4beb2adb29c204ce4ab89"
+    },
+    {
+      "skill_id": "thinking-steve-jobs",
+      "expected_category": "product-design-ux",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "validation",
+      "rationale": "主要框架服务于产品取舍、极简设计、端到端体验和用户感受的决策。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a16f9741e6d475fe8043a9476a001b04b8fdb795a24fad859766414d30b233c0"
+    },
+    {
+      "skill_id": "business-analyst",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It turns business data into KPI models, dashboards, forecasts, experiments, and recommendations.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "99acef5c31762cddc2c8eb66652f520f3212606314b763861b902144aefbdcb0"
+    },
+    {
+      "skill_id": "task-supervisor",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "business-operations-strategy",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "巡检 Agent 会话、识别卡住或中止任务并触发催办，属于 Agent 运行编排与监督。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "51145f242a7e4f1bfe1329dda18b67a30516ad0fbe07c2eac13af8a525802da7"
+    },
+    {
+      "skill_id": "outbound-email-strategy",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Builds B2B prospecting sequences that generate replies, discovery calls, and sales opportunities.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "2f997ca27622384a107e740ec11be7797d75a1c61e16aa03d33b20b4d82c942f"
+    },
+    {
+      "skill_id": "doc-coauthoring",
+      "expected_category": "content-media-publishing",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "核心产物是技术文档、提案、规范和指南，并通过迭代改善写作质量。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "93ac256e2c9783b41aa2150bbbe4e4c8cda3ca8143af60fc891d9b316031dc44"
+    },
+    {
+      "skill_id": "hr-automation",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "It operates recruiting, onboarding, performance, time-off, and employee offboarding processes.",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "be0b35c34651d86bfa8b60abd38035dc6e0e602c54688cd5fbb05a5a616cdccf"
+    },
+    {
+      "skill_id": "microsoft-teams-automation",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "自动完成 Teams 消息、聊天、频道和会议操作，是具体协作应用的工作流自动化。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "24a40d2420982e6fa71c2b95ef16152be322299282962f9efa35bc713b67980f"
+    },
+    {
+      "skill_id": "github-automation",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "override",
+      "split": "development",
+      "rationale": "Automates repeatable GitHub repository, pull request, issue, branch, and release operations.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c0405d657014f40876e2c86149b169e23b7b9b47caed192360b70f35c28674f1"
+    },
+    {
+      "skill_id": "fabric-pattern",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "rule-match",
+      "split": "validation",
+      "rationale": "Selecting and applying Fabric system-prompt patterns is the core behavior; CLI retrieval only supports it.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3",
+        "reviewer-root"
+      ],
+      "review_status": "adjudicated",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "c8732e4757c2ca8634a25caba07080f006988350bcb0b4907419cd753aaaa9d5"
+    },
+    {
+      "skill_id": "docusign-automation",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "It selects DocuSign templates, sends envelopes, tracks status, and manages envelope lifecycles.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "0b4ebcf594b27bfe93143814f11914b82dd71e5ad01a726e231134aea907cb0d"
+    },
+    {
+      "skill_id": "linkedin-cdp",
+      "expected_category": "sales-crm-customer-success",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "完整闭环是搜索潜客、查看档案、发连接或消息，并强制把外联原文记录到 CRM。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1",
+        "reviewer-root"
+      ],
+      "review_status": "adjudicated",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "a05e5cc786bc12fbc64f407b9cb96fabed43907701f8efd2f7cf7c29b3f9a25d"
+    },
+    {
+      "skill_id": "email-read",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "Reads and searches Gmail folders and conversation threads through a repeatable app workflow.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "9383a484d1ec02fb9f9a5fd89c92e300ad43fd26a064e844770f1545c74410ef"
+    },
+    {
+      "skill_id": "outlook-automation",
+      "expected_category": "apps-workflow-automation",
+      "baseline_predicted_category": "apps-workflow-automation",
+      "baseline_resolution_status": "rule-match",
+      "split": "development",
+      "rationale": "通过 Outlook 外部应用接口自动化邮件、日历、联系人、文件夹和附件操作。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "42a8741a7780feb32a8f869be6a32cbb546ef1ecb3a2a858b0fd1ee4869df52d"
+    },
+    {
+      "skill_id": "juejin-publisher-custom",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Its planned outcome is formatting, tagging, and publishing Markdown articles on Juejin.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "73a6794fa1cce8a895f0c15f4c53e0ad22b1e4aa27e4bc964be2f34a5fbc3a03"
+    },
+    {
+      "skill_id": "wecom-cs-automation",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "围绕企业微信实现好友、问答和人工转接，是面向中国平台的专用客服工作流。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ce23d353314126f50cd8efef1c03a63485f8f0ba6afcc034dce9422f25d19a50"
+    },
+    {
+      "skill_id": "xhs-content-creator",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "validation",
+      "rationale": "Creates algorithm-aware, compliant posts specifically for Xiaohongshu's Chinese platform format.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "bbb5d4a9a05e195afdd46254989337de64a6eb1ba73c937881cfb33665e7a692"
+    },
+    {
+      "skill_id": "douyin-smart-publish",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "专门适配抖音创作者平台的素材、标题、话题、封面、草稿和发布流程。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "e10d44f35a986de24c5f789b72ca4371cbbd0a5a4a0619c5f2495809efa2708d"
+    },
+    {
+      "skill_id": "xhs-skill",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It logs into Xiaohongshu, validates posts, publishes notes, and exports creator data.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "daea5c04a1e6dc93b07772c0ba733f29cde137391d4a7b48d790031112624678"
+    },
+    {
+      "skill_id": "xhs-writing-coach",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "专门生成和优化小红书标题、正文、标签与互动结构，具有明确的平台专属性。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "f12e96eb4a59275a15a9a110352da3443c7b7f46f23e1e4dc41d3b89de3263e3"
+    },
+    {
+      "skill_id": "daily-douyin-content",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "Produces, validates, saves, and prepares daily short-form content specifically for Douyin.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "7bc007ccef91ac20bcdd64fcb2d098fe67bd0a18b0fe8cf8d23b760caf21ed55"
+    },
+    {
+      "skill_id": "zsxq-smart-publish",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "专门完成知识星球话题、问答、长文、文件和精华内容的管理与发布。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ffbf528c5e9caf119f76cf97b27fc20867c00c26aa3620867061ddeffe4607f4"
+    },
+    {
+      "skill_id": "weixin-channels-publish",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "It automates Weixin Channels login, video upload, metadata entry, review, and publishing.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "8b2842a34b7e00796e9baf4507a483d93a9f7f32ec135dfb96c688ceb246010a"
+    },
+    {
+      "skill_id": "douyin-video-analyst",
+      "expected_category": "chinese-platform-workflows",
+      "baseline_predicted_category": "chinese-platform-workflows",
+      "baseline_resolution_status": "priority-tie",
+      "split": "development",
+      "rationale": "采集抖音视频、提取文案并汇总账号内容，是抖音平台特定的分析工作流。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "2acc5381c0e825f26d6342392e1a7ba5a0310ba300f74058eac41b53ed8032e1"
+    },
+    {
+      "skill_id": "bazi-fortune",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "override",
+      "split": "development",
+      "rationale": "Provides a specialized Four Pillars fortune-analysis utility outside the repository's core domains.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "456fc7afe1564e5358b54d114b2eff1a1637d43a5dae9461b2fd8d8e9ae44f76"
+    },
+    {
+      "skill_id": "binance-trending",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "validation",
+      "rationale": "聚合币价、恐惧贪婪、新闻和热度并输出交易信号，结果直接服务加密交易。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "e324165ee84a4c969d1ed2272f1cb2b121dcdee93247cd72b1d9ae0f7141fe80"
+    },
+    {
+      "skill_id": "polyclaw",
+      "expected_category": "finance-trading-markets",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "validation",
+      "rationale": "It executes Polymarket CLOB strategies using order books, wallets, contracts, and positions.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "94551671cc898ad1ebb933dab6c1683c6cbac48c013d293ce25b73782d19f15f"
+    },
+    {
+      "skill_id": "soushen-hunter",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "执行 Bing 搜索、网页深度提取和结构化结果整理，核心结果是资料检索与研究。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "ef82f99cd93a9ac1e569452c343ad6284f43ddd8e2ac1f5314cb50be50367bef"
+    },
+    {
+      "skill_id": "market-intelligence",
+      "expected_category": "data-analytics-research",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "Collects and analyzes cross-platform market evidence to report trends, competitors, risks, and opportunities.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3",
+        "reviewer-2"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "8b8654d00298ccf04739274ffb0c88b1d63dd956492ee90889a49b7ee50a3d64"
+    },
+    {
+      "skill_id": "sp-simplification-cascades",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "针对重复实现、特殊分支和架构复杂度寻找统一抽象，主要用于代码重构。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "57417c2d46934c2214b3698823b7b1098c84fc2bcd5dea372ea2ba9fc00f4c32"
+    },
+    {
+      "skill_id": "sp-condition-based-waiting",
+      "expected_category": "software-engineering",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "It replaces fixed sleeps with condition polling to make asynchronous software tests reliable.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-1",
+        "reviewer-4"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "d6b45c913a6e3c2b175792e06a1ebec3e21bd4e6bd8e53eb2226b5704cd550b6"
+    },
+    {
+      "skill_id": "vp-cpo-readiness-advisor",
+      "expected_category": "business-operations-strategy",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "辅导 VP/CPO 的组织、战略、经营语言和高管协作，主要服务领导力与经营决策。",
+      "confidence": "medium",
+      "reviewers": [
+        "reviewer-2",
+        "reviewer-1"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "3cafc9255fc541726fe1e3870077e9ee5a67a337611444f05f7be6ae066001b5"
+    },
+    {
+      "skill_id": "timezone",
+      "expected_category": "general-utilities",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "Detects local time and performs reliable timezone conversion as a focused cross-functional utility.",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-3"
+      ],
+      "review_status": "primary",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "da3702d5758419004a8abb53065d172340feb458570a50aa5c7f7ba74c0e475c"
+    },
+    {
+      "skill_id": "using-superpowers",
+      "expected_category": "ai-agents-orchestration",
+      "baseline_predicted_category": "general-utilities",
+      "baseline_resolution_status": "fallback",
+      "split": "development",
+      "rationale": "规定 Agent 如何发现、调用和排序 Skills，是 Agent 工具协议与执行治理。",
+      "confidence": "high",
+      "reviewers": [
+        "reviewer-4",
+        "reviewer-3"
+      ],
+      "review_status": "cross-reviewed",
+      "reviewed_at": "2026-07-21",
+      "source_sha256": "07d73726944e38fac59b9c90d876e0f714e395308b357973ae77b1321fc75067"
+    }
+  ]
+}

--- a/config/skill-taxonomy-gold.schema.json
+++ b/config/skill-taxonomy-gold.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://aaaaqwq.github.io/AGI-Super-Team/schemas/skill-taxonomy-gold.schema.json",
+  "title": "Reviewed Skill taxonomy Gold Set",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "annotation", "sampling", "labels"],
+  "properties": {
+    "$schema": {"const": "./skill-taxonomy-gold.schema.json"},
+    "schemaVersion": {"const": 1},
+    "annotation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "humanApproved", "rubric", "labelSetSha256"],
+      "properties": {
+        "mode": {"const": "independent-agent-manual-review"},
+        "humanApproved": {"const": false},
+        "rubric": {"const": "../docs/skill-taxonomy-gold-set.md"},
+        "labelSetSha256": {"const": "78e6b44843fc60d08d1a9cc3fb728fdfec2eccfc35b812064b53342559ba7da1"}
+      }
+    },
+    "sampling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["method", "seed", "perPredictedCategory", "baseCommit", "baseCatalogSha256", "candidateSetSha256"],
+      "properties": {
+        "method": {"const": "predicted-category-balanced-difficulty-first-stable-hash"},
+        "seed": {"const": "semantic-gold-v1"},
+        "perPredictedCategory": {"const": 10},
+        "baseCommit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "baseCatalogSha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "candidateSetSha256": {"const": "7765f415e2be2d7b93341dc8192837a06bebb5a9c8fea17ab5c06d8326473267"}
+      }
+    },
+    "labels": {
+      "type": "array",
+      "minItems": 140,
+      "maxItems": 140,
+      "uniqueItems": true,
+      "items": {"$ref": "#/$defs/label"}
+    }
+  },
+  "$defs": {
+    "identifier": {"type": "string", "pattern": "^[a-z0-9]+(?:[-_][a-z0-9]+)*$"},
+    "category": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+    "label": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["skill_id", "expected_category", "baseline_predicted_category", "baseline_resolution_status", "split", "rationale", "confidence", "reviewers", "review_status", "reviewed_at", "source_sha256"],
+      "properties": {
+        "skill_id": {"$ref": "#/$defs/identifier"},
+        "expected_category": {"$ref": "#/$defs/category"},
+        "baseline_predicted_category": {"$ref": "#/$defs/category"},
+        "baseline_resolution_status": {"enum": ["rule-match", "priority-tie", "override", "fallback"]},
+        "split": {"enum": ["development", "validation"]},
+        "rationale": {"type": "string", "minLength": 20, "maxLength": 240},
+        "confidence": {"enum": ["high", "medium", "low"]},
+        "reviewers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^reviewer-[a-z0-9]+(?:-[a-z0-9]+)*$"}
+        },
+        "review_status": {"enum": ["primary", "cross-reviewed", "adjudicated"]},
+        "reviewed_at": {"type": "string", "format": "date"},
+        "source_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/config/skill-taxonomy.json
+++ b/config/skill-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./skill-taxonomy.schema.json",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "categories": [
     {
       "id": "ai-agents-orchestration",
@@ -8,7 +8,8 @@
       "title": "AI Agents & Orchestration",
       "description": "Coordinate agents, context, memory, models, prompts, and tool protocols.",
       "priority": 75,
-      "patterns": ["(?:^|-)agent(?:-|$)", "orchestrat", "multi-agent", "subagent", "dispatcher", "memory", "context", "prompt", "\\bllm\\b", "\\bmcp\\b", "claude", "codex", "(?:^|-)model(?:-|$)", "(?:^|-)skills?(?:-|$)", "ruflo", "openclaw", "clawrouter"]
+      "patterns": ["(?:^|-)agent(?:-|$)", "orchestrat", "multi-agent", "subagent", "dispatcher", "memory", "context", "prompt", "\\bllm\\b", "\\bmcp\\b", "claude", "codex", "(?:^|-)model(?:-|$)", "(?:^|-)skills(?:-|$)", "ruflo", "openclaw", "clawrouter", "(?:^|-)subagent-driven(?:-|$)", "(?:^|-)codex-(?:cc|cli|guide)(?:-|$)", "(?:^|-)task-(?:supervisor|dispatcher)(?:-|$)", "(?:^|-)(?:creating|writing|authoring|testing)-skills(?:-|$)", "(?:^|-)using-superpowers(?:-|$)", "(?:^|-)skills-(?:hub|repository|index|library)(?:-|$)", "(?:^|-)(?:skill-(?:authoring|creation|review|quality|evaluation|config|configuration)|work-to-skill)(?:-|$)", "\\bgep-a2a\\b", "\\ba2a protocol\\b", "collaborative evolution marketplace"],
+      "outcomePatterns": ["(?:dispatch|spawn|coordinate|orchestrate).{0,24}(?:agents?|subagents?)", "\\bsubagent-driven\\b", "(?:invoke|discover|install|author|write|create).{0,24}(?:agent )?skills?", "(?:evaluate|score|review|package|encapsulate).{0,24}(?:agent )?skills?", "(?:评估|评分|审查|封装|创建).{0,16}(?:Skill|技能)", "\\b(?:a2a|agent-to-agent) protocol\\b", "\\bfabric patterns?\\b", "(?:agent|model|inference|session).{0,24}(?:context|routing|orchestration|optimization)"]
     },
     {
       "id": "software-engineering",
@@ -16,7 +17,8 @@
       "title": "Software Engineering",
       "description": "Build, test, review, debug, and maintain applications and developer tooling.",
       "priority": 80,
-      "patterns": ["code", "developer", "development", "frontend", "backend", "react", "tailwind", "\\bcss\\b", "\\bapi\\b", "database", "postgres", "redis", "\\bsql\\b", "testing", "test-", "tdd", "debug", "architecture", "git-", "github", "gitlab", "commit", "(?:^|-)cli(?:-|$)|\\bcli\\b", "electron", "supabase", "webapp"]
+      "patterns": ["(?:^|-)code(?:-|$)|\\bcode\\b", "\\bcodebases?\\b", "developer", "development", "frontend", "backend", "react", "tailwind", "\\bcss\\b", "\\bapi\\b", "database", "postgres", "redis", "\\bsql\\b", "testing", "test-", "tdd", "debug", "architecture", "git-", "(?:^|-)github-(?:actions?|api|app|cli|integration|issues?|pr|pull-request|releases?|repos?|workflows?)(?:-|$)", "gitlab", "commit", "(?:^|-)cli(?:-|$)|\\bcli\\b", "electron", "supabase", "webapp", "(?:^|-)api-design(?:-|$)", "(?:^|-)(?:software|system)-architecture(?:-|$)", "(?:^|-)static-code(?:-|$)", "(?:^|-)condition-based-waiting(?:-|$)", "(?:^|-)simplification-cascades(?:-|$)", "(?:^|-)(?:senior-)?architect(?:-|$)", "code repository|source code"],
+      "outcomePatterns": ["\\b(?:api|rest|graphql|grpc) design\\b", "\\b(?:software|system) architecture\\b", "\\b(?:static|source) code analysis\\b", "\\bcode (?:repository|review|testing|debugging)\\b", "(?:async|flaky).{0,20}tests?", "(?:github )?issues?.{0,48}(?:implement fixes|fix bugs)", "open (?:pull requests?|prs?)"]
     },
     {
       "id": "cloud-devops-reliability",
@@ -24,7 +26,8 @@
       "title": "Cloud, DevOps & Reliability",
       "description": "Deploy, observe, troubleshoot, and operate cloud and local infrastructure.",
       "priority": 85,
-      "patterns": ["deploy", "devops", "cloud", "\\baws\\b", "kubernetes", "docker", "nginx", "observability", "monitoring", "healthcheck", "incident", "linux", "sysadmin", "sentry", "datadog", "grafana", "vercel", "cloudflare", "render-", "ssh", "tailscale", "proxmox", "distributed-tracing", "runbook"]
+      "patterns": ["deploy", "devops", "cloud", "\\baws\\b", "kubernetes", "docker", "nginx", "observability", "monitoring", "healthcheck", "incident", "linux", "sysadmin", "sentry", "datadog", "grafana", "vercel", "cloudflare", "render-", "ssh", "tailscale", "proxmox", "distributed-tracing", "runbook", "(?:^|-)microservices?(?:-|$)", "(?:^|-)observability-(?:design|designer|strategy)(?:-|$)"],
+      "outcomePatterns": ["\\b(?:service mesh|observability|distributed tracing|sli|slo)\\b", "\\b(?:datadog|grafana|kubernetes|docker)\\b", "(?:cloud|infrastructure).{0,32}(?:cost|spend|expense|rightsizing|optimization)", "(?:incident|reliability).{0,24}(?:response|runbook|operations)"]
     },
     {
       "id": "data-analytics-research",
@@ -32,7 +35,8 @@
       "title": "Data, Analytics & Research",
       "description": "Collect evidence, search sources, analyze data, and communicate findings.",
       "priority": 95,
-      "patterns": ["research", "data", "analytics", "analysis", "search", "scrap", "crawl", "arxiv", "\\bcsv\\b", "\\betl\\b", "duckdb", "business-intelligence", "dashboard", "metrics", "rag", "vector", "knowledge", "news", "genome", "bio-", "synthesizer", "experiment"]
+      "patterns": ["research", "(?:^|-)data(?:-|$)|\\bdata\\b", "analytics", "(?:^|-)(?:data|statistical|cohort|source|evidence|market-sizing)-analysis(?:-|$)|\\b(?:data|statistical|cohort|source|evidence|market sizing) analysis\\b", "search", "scrap", "crawl", "arxiv", "\\bcsv\\b", "\\betl\\b", "duckdb", "business-intelligence", "dashboard", "metrics", "rag", "vector", "knowledge", "news", "genome", "bio-", "synthesizer", "experiment", "(?:^|-)business-(?:analyst|analytics|intelligence)(?:-|$)", "(?:^|-)(?:daily|today)-trending(?:-|$)|热榜|热搜", "(?:^|-)market-intelligence(?:-|$)", "(?:^|-)model-usage(?:-|$)", "(?:^|-)knowledge-extract(?:or)?(?:-|$)", "(?:^|-)vcf(?:-|$)|\\bvcf\\b"],
+      "outcomePatterns": ["\\b(?:business|market) intelligence\\b", "\\bresearch (?:a|any|the) topic\\b", "\\b(?:vcf|clinvar|gnomad|bioinformatics)\\b", "(?:scrape|extract|crawl|collect).{0,28}(?:data|images?|web|urls?|evidence)", "(?:analy[sz]e|measure).{0,24}(?:data|usage|metrics|evidence)"]
     },
     {
       "id": "security-privacy-legal",
@@ -40,7 +44,8 @@
       "title": "Security, Privacy & Legal",
       "description": "Review security, privacy, compliance, permissions, contracts, and legal risk.",
       "priority": 115,
-      "patterns": ["security", "privacy", "compliance", "gdpr", "legal", "contract", "auth-", "secret", "permission", "key-rotation", "audit", "pci", "customs", "employment-contract"]
+      "patterns": ["security", "privacy", "compliance", "gdpr", "legal", "contract", "auth-", "secret", "permission", "key-rotation", "(?:security|privacy|compliance|legal)-audit|audit-(?:security|privacy|compliance|legal)", "pci", "customs", "employment-contract", "(?:^|-)(?:provider|api)-key-(?:manager|rotation|sync)(?:-|$)", "(?:^|-)dependency-auditor(?:-|$)"],
+      "outcomePatterns": ["(?:audit|rotate|manage|sync).{0,24}(?:api keys?|credentials?|secrets?)", "(?:security|privacy|compliance|legal).{0,24}(?:audit|review|risk|assessment)", "\\b(?:gdpr|pci dss|threat model)\\b"]
     },
     {
       "id": "product-design-ux",
@@ -48,7 +53,8 @@
       "title": "Product, Design & UX",
       "description": "Shape product requirements, interfaces, design systems, and user experience.",
       "priority": 90,
-      "patterns": ["(?:^|-)product(?:-|$)|\\bproduct\\b", "\\bprd\\b", "design", "\\bux\\b", "\\bui\\b", "figma", "canvas", "roadmap", "user-story", "requirements", "prioritization", "feature-", "style-guide", "web-artifacts", "accessibility"]
+      "patterns": ["(?:^|-)product(?:-|$)|\\bproduct\\b", "\\bprd\\b", "design", "\\bux\\b", "\\bui\\b", "figma", "canvas", "roadmap", "user-story", "requirements", "prioritization", "feature-", "style-guide", "web-artifacts", "accessibility"],
+      "outcomePatterns": ["\\b(?:product|ux|ui|visual) (?:design|vision|strategy)\\b", "\\buser experience\\b", "(?:design|build).{0,24}(?:interface|design system|prototype)", "\\bfigma\\b|(?:audit|design|test).{0,20}(?:accessibility|wcag)", "\\bwcag\\b", "(?:wcag|accessibility).{0,28}(?:audit|testing|barrier|remediation|inclusive)"]
     },
     {
       "id": "marketing-seo-growth",
@@ -56,7 +62,8 @@
       "title": "Marketing, SEO & Growth",
       "description": "Acquire audiences through positioning, campaigns, search, ads, and social growth.",
       "priority": 105,
-      "patterns": ["marketing", "\\bseo\\b", "growth", "\\bads?\\b", "campaign", "social", "influencer", "traffic", "viral", "brand", "competitor", "competitive", "domain-name", "geo-content", "serp", "acquisition", "postbridge"]
+      "patterns": ["marketing", "\\bseo\\b", "growth", "\\bads?\\b", "(?:^|-)campaigns?(?:-|$)|\\bcampaigns?\\b", "social", "influencer", "(?:^|-)(?:traffic-(?:growth|acquisition|seo)|(?:web|site|organic|search|social|paid)-traffic)(?:-|$)|\\b(?:web|site|organic|search|social|paid) traffic\\b", "(?:^|-)viral-(?:content|campaign|growth)(?:-|$)|\\bviral (?:content|campaign|growth)\\b", "brand", "competitor", "competitive", "domain-name", "geo-content", "serp", "acquisition", "postbridge"],
+      "outcomePatterns": ["(?:optimize|grow|acquire).{0,24}(?:search traffic|audience|customers|conversions)", "\\b(?:seo|search acquisition|ad campaign|brand positioning)\\b", "(?:launch|manage).{0,20}(?:campaigns?|ads?)"]
     },
     {
       "id": "content-media-publishing",
@@ -64,7 +71,8 @@
       "title": "Content, Media & Publishing",
       "description": "Create, edit, repurpose, and publish writing, images, audio, and video.",
       "priority": 100,
-      "patterns": ["content", "writing", "writer", "article", "copywriting", "copy-edit", "video", "image", "media", "publish", "podcast", "slide", "pptx", "docx", "\\bpdf\\b", "youtube", "subtitle", "lyrics", "infographic", "typography", "ffmpeg", "suno"]
+      "patterns": ["content", "writing", "writer", "article", "copywriting", "copy-edit", "video", "image", "media", "publish", "podcast", "slide", "pptx", "docx", "\\bpdf\\b", "youtube", "subtitle", "lyrics", "infographic", "typography", "ffmpeg", "suno", "(?:^|-)(?:marketing-videos?|video-(?:ad|creative|production)|script-writing|video-script|storyboard|doc-coauthor(?:ing)?|internal-comms)(?:-|$)"],
+      "outcomePatterns": ["(?:write|create|produce|edit).{0,28}(?:video|script|storyboard|article|newsletter|content|media)", "(?:record|edit|transcode).{0,24}(?:audio|video|podcast)", "(?:publish|repurpose).{0,24}(?:article|video|content|media)"]
     },
     {
       "id": "sales-crm-customer-success",
@@ -72,7 +80,8 @@
       "title": "Sales, CRM & Customer Success",
       "description": "Find, win, onboard, support, and retain customers with accountable workflows.",
       "priority": 110,
-      "patterns": ["sales", "lead", "\\bcrm\\b", "customer", "account-executive", "outreach", "cold-email", "hubspot", "salesforce", "pipedrive", "close-automation", "intercom", "freshdesk", "freshservice", "zendesk", "spin-selling", "sandler", "negotiation", "after-sales", "helpdesk", "client-"]
+      "patterns": ["sales", "lead", "\\bcrm\\b", "customer", "account-executive", "outreach", "cold-email", "hubspot", "salesforce", "pipedrive", "close-automation", "intercom", "freshdesk", "freshservice", "zendesk", "spin-selling", "sandler", "negotiation", "after-sales", "helpdesk", "client-", "(?:^|-)activecampaign(?:-|$)", "(?:^|-)outbound-email(?:-|$)", "(?:^|-)linkedin-(?:cdp|outreach|lead|sales|connect)(?:-|$)"],
+      "outcomePatterns": ["(?:manage|qualify|enrich|convert).{0,24}(?:leads?|prospects?|customers?|crm)", "(?:cold|outbound).{0,16}(?:email|outreach|sales)", "\\b(?:sales pipeline|customer success|crm contacts?)\\b"]
     },
     {
       "id": "finance-trading-markets",
@@ -80,7 +89,8 @@
       "title": "Finance, Trading & Markets",
       "description": "Analyze markets, backtest strategies, track portfolios, and review financial risk.",
       "priority": 120,
-      "patterns": ["financ", "trading", "trade-", "crypto", "\\bbtc\\b", "fund", "stock", "portfolio", "backtest", "quant", "investment", "equity", "polymarket", "defi", "payment", "billing", "invoice", "bookkeeping", "expense", "stripe", "bankr", "alpha101", "options-flow", "whale", "market-movers", "market-price", "market-sentiment", "technical-analysis"]
+      "patterns": ["financ", "trading", "trade-", "crypto", "\\bbtc\\b", "fund", "stock", "portfolio", "backtest", "quant", "investment", "equity", "polymarket", "(?:^|-)binance(?:-|$)", "(?:^|-)(?:a-share|stock|equity)(?:-|$).{0,24}(?:analysis|screening)|A股|个股|选股", "(?:^|-)defi(?:-|$)|\\bdecentralized finance\\b", "payment", "billing", "invoice", "bookkeeping", "expense", "stripe", "bankr", "alpha101", "options-flow", "whale", "market-movers", "market-price", "market-sentiment", "technical-analysis", "(?:^|-)company-(?:analy[sz]er|valuation|fundamentals)(?:-|$)", "\\bp&l\\b|量化|交易|投资组合|风控"],
+      "outcomePatterns": ["(?:quantitative|algorithmic).{0,20}(?:trading|finance|investment)", "\\b(?:portfolio risk|company valuation)\\b", "(?:trade|execute|backtest|price|monitor).{0,24}(?:prediction markets?|binance|polymarket)", "量化思维", "大量小交易|投资组合|估值|交易风控"]
     },
     {
       "id": "business-operations-strategy",
@@ -88,7 +98,8 @@
       "title": "Business Operations & Strategy",
       "description": "Plan work, make decisions, manage teams, and improve operating systems.",
       "priority": 65,
-      "patterns": ["business", "strategy", "\\bceo\\b", "\\bokr\\b", "\\bkpi\\b", "project", "task", "planning", "priorit", "team", "company", "startup", "process", "operations", "delegat", "meeting", "daily-", "weekly-", "\\bhr\\b", "culture", "resume", "first-principles", "thinking-", "brainstorm", "decision", "scrum", "kanban"]
+      "patterns": ["business", "strategy", "\\bceo\\b", "\\bokr\\b", "\\bkpi\\b", "project", "task", "planning", "priorit", "team", "company", "startup", "process", "operations", "delegat", "meeting", "daily-(?:brief|planning|standup|operations|review)", "weekly-", "\\bhr\\b", "culture", "resume", "first-principles", "thinking-", "brainstorm", "decision", "scrum", "kanban", "(?:^|-)prioritization-funnel(?:-|$)", "(?:^|-)okrs?(?:-|$)", "(?:^|-)(?:vp|cpo|cto|coo|cfo|chro|cmo)-(?:readiness|advisor|operating)(?:-|$)"],
+      "outcomePatterns": ["\\bobjectives and key results\\b", "(?:recruiting|onboarding|employee management|offboarding)", "(?:prioritize|allocate).{0,24}(?:resources?|projects?|opportunities)", "(?:strategic|strategy).{0,24}(?:capability|skills?) gaps?", "战略.{0,20}能力.{0,12}(?:缺口|鸿沟)|能力.{0,12}(?:招聘|培训)", "(?:executive|leadership).{0,20}(?:operations|readiness|decision)"]
     },
     {
       "id": "apps-workflow-automation",
@@ -96,7 +107,8 @@
       "title": "Apps & Workflow Automation",
       "description": "Connect everyday apps, browsers, messaging systems, and repeatable workflows.",
       "priority": 70,
-      "patterns": ["automation", "workflow", "browser", "airtable", "asana", "basecamp", "box-", "calendly", "clickup", "coda", "confluence", "discord", "docusign", "dropbox", "gmail", "google-drive", "jira", "linear", "monday", "notion", "slack", "telegram", "trello", "whatsapp", "zoom", "make-automation", "email-", "calendar", "one-drive", "outlook"]
+      "patterns": ["automation", "workflow", "browser", "airtable", "asana", "basecamp", "box-", "calendly", "clickup", "coda", "confluence", "discord", "docusign", "dropbox", "gmail", "google-drive", "jira", "linear", "monday", "notion", "slack", "telegram", "trello", "whatsapp", "zoom", "make-automation", "email-", "calendar", "one-drive", "outlook", "(?:^|-)(?:agent-browser|browser-driver|computer-use|cua)(?:-|$)", "(?:^|-)(?:github|gitlab)-automation(?:-|$)", "(?:^|-)kanbanflow(?:-|$)"],
+      "outcomePatterns": ["(?:browser|web page).{0,28}(?:navigate|click|type|snapshot|fill forms?)", "(?:native gui|accessibility tree).{0,36}(?:snapshot|click|type|scroll)", "(?:manage|store|send).{0,36}(?:documents?|files?).{0,36}(?:google drive|locally|folders?)", "(?:operate|automate|update).{0,24}(?:jira|slack|notion|github|gitlab|trello)"]
     },
     {
       "id": "chinese-platform-workflows",
@@ -104,7 +116,8 @@
       "title": "Chinese Platform Workflows",
       "description": "Create, analyze, and publish for major Chinese-language platforms and channels.",
       "priority": 130,
-      "patterns": ["baidu", "douyin", "xhs", "xiaohongshu", "wechat", "weixin", "weibo", "juejin", "zsxq", "wemp", "wecom", "tianyancha", "feishu", "humanize-zh", "redbook", "binance-square", "baoyu-xhs", "md2wechat", "gzh", "ziliu"]
+      "patterns": ["baidu", "douyin", "xhs", "xiaohongshu", "wechat", "weixin", "weibo", "juejin", "zsxq", "wemp", "wecom", "tianyancha", "feishu", "humanize-zh", "redbook", "binance-square", "baoyu-xhs", "md2wechat", "gzh", "ziliu"],
+      "outcomePatterns": ["(?:\\b(?:douyin|xiaohongshu|wechat|weixin|weibo|juejin|feishu|zsxq|binance square)\\b|小红书|微信|微博|抖音|飞书|知识星球).{0,20}(?:publish|post|发布|运营|增长)"]
     },
     {
       "id": "general-utilities",
@@ -112,7 +125,8 @@
       "title": "Specialized Domains & Utilities",
       "description": "Domain-specific helpers and cross-functional tools that need a dedicated review path.",
       "priority": 0,
-      "patterns": [],
+      "patterns": ["(?:^|-)deep-?work(?:-|$)", "(?:^|-)file-(?:organizer|cleanup|deduplicator)(?:-|$)", "(?:^|-)quality-(?:convergence|acceptance)(?:-|$)|(?:^|-)acceptance-engine(?:-|$)"],
+      "outcomePatterns": ["\\b(?:yijing|liuyao|divination|fortune telling)\\b|易经|六爻|占卜", "(?:organize|deduplicate|clean up).{0,24}(?:local )?(?:files|folders)", "(?:deep work|focus sessions?)"],
       "fallback": true
     }
   ],
@@ -136,6 +150,7 @@
     "invoice-generator-agent": "finance-trading-markets",
     "security-audit": "security-privacy-legal",
     "seo-audit": "marketing-seo-growth",
+    "soushen-hunter": "data-analytics-research",
     "tdd-workflow": "software-engineering",
     "xiaohongshu-growth": "chinese-platform-workflows"
   },
@@ -159,6 +174,7 @@
     "invoice-generator-agent": "Invoice generation is a financial operations outcome despite the agent suffix.",
     "security-audit": "Security risk review is the explicit purpose and must outrank generic audit wording.",
     "seo-audit": "Search acquisition is the explicit outcome and must outrank generic audit wording.",
+    "soushen-hunter": "The opaque product name hides a Bing search and deep webpage extraction workflow whose primary output is structured research evidence.",
     "tdd-workflow": "The workflow exists to implement and verify software changes.",
     "xiaohongshu-growth": "The platform-specific publishing and growth workflow belongs with Chinese platforms."
   },
@@ -192,7 +208,7 @@
     {"skill": "tdd-workflow", "category": "software-engineering", "reason": "Drive implementation through a test-first loop."},
     {"skill": "deep-research", "category": "data-analytics-research", "reason": "Turn a question into an evidence-oriented research process."},
     {"skill": "seo-audit", "category": "marketing-seo-growth", "reason": "Review search discoverability with explicit checks."},
-    {"skill": "writing-skills", "category": "content-media-publishing", "reason": "Move from a bounded writing brief to a reviewable draft."},
+    {"skill": "writing-skills", "category": "ai-agents-orchestration", "reason": "Create and maintain reusable agent Skill instructions with a reviewable workflow."},
     {"skill": "security-audit", "category": "security-privacy-legal", "reason": "Inspect code and configuration for security risk."},
     {"skill": "backtest-expert", "category": "finance-trading-markets", "reason": "Review backtests without implying live-trading safety."},
     {"skill": "frontend-design-ultimate", "category": "product-design-ux", "reason": "Create a concrete interface direction and implementation."},

--- a/config/skill-taxonomy.schema.json
+++ b/config/skill-taxonomy.schema.json
@@ -7,14 +7,14 @@
   "required": ["schemaVersion", "categories", "overrides", "overrideRationales", "riskLabels", "riskOverrides", "featured"],
   "properties": {
     "$schema": {"type": "string"},
-    "schemaVersion": {"const": 1},
+    "schemaVersion": {"const": 2},
     "categories": {
       "type": "array",
       "minItems": 8,
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["id", "emoji", "title", "description", "priority", "patterns"],
+        "required": ["id", "emoji", "title", "description", "priority", "patterns", "outcomePatterns"],
         "properties": {
           "id": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
           "emoji": {"type": "string", "minLength": 1, "maxLength": 4},
@@ -22,6 +22,7 @@
           "description": {"type": "string", "minLength": 12},
           "priority": {"type": "integer", "minimum": 0},
           "patterns": {"type": "array", "items": {"type": "string"}},
+          "outcomePatterns": {"type": "array", "items": {"type": "string"}},
           "fallback": {"const": true}
         }
       }

--- a/docs/adr/0004-reviewed-skill-taxonomy-evaluation.md
+++ b/docs/adr/0004-reviewed-skill-taxonomy-evaluation.md
@@ -1,0 +1,24 @@
+# ADR-0004: Reviewed Skill taxonomy evaluation
+
+- Status: Accepted
+- Date: 2026-07-21
+
+## Context
+
+The generated catalog previously used broad, equal-weight regular expressions and category priority as a semantic tie-break. A deterministic result was reproducible, but it did not establish that the primary outcome category agreed with manual review. Substring matches such as `data` in Datadog and `defi` in “define” created systematic errors.
+
+## Decision
+
+Maintain a fixed, category-balanced Gold Set of 140 independently reviewed labels. Its exact membership, baseline routes, and published 112/28 development/validation split are protected by a candidate-set digest and fail-closed evaluator checks.
+
+Taxonomy schema v2 separates high-precision `outcomePatterns` from legacy keyword `patterns`. The classifier considers outcome phrases across the Skill ID and source description first, but a single conflicting phrase cannot replace an existing slug route; it requires agreement with that route or at least two outcome signals. Exact overrides remain bounded exceptions with written rationales.
+
+Publish a `reviewedSetAgreementScore` only when exact accuracy, macro-F1, category coverage, and the published-validation gate pass. The score is not called human-verified while `humanApproved` is false, and it is not an inventory-wide confidence interval or runtime-quality score.
+
+## Consequences
+
+- Category changes receive deterministic, inspectable evidence rather than priority-only justification.
+- Gold membership cannot be expanded or re-split to inflate the score without changing an explicit contract.
+- Changed `SKILL.md` entrypoints invalidate their labels until they are reviewed again.
+- The public validation slice is a regression check, not a permanently unseen benchmark.
+- Safety, portability, runtime behavior, and business value remain separate evidence domains.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,5 +5,6 @@ ADRs preserve why repository boundaries exist. New records are immutable after a
 - [ADR-0001: Canonical inventory and generated outputs](./0001-canonical-inventory-and-generated-outputs.md)
 - [ADR-0002: Generic workspace and curated distributions](./0002-generic-workspace-and-curated-distributions.md)
 - [ADR-0003: Structural evidence and runtime receipts](./0003-structural-evidence-and-runtime-receipts.md)
+- [ADR-0004: Reviewed Skill taxonomy evaluation](./0004-reviewed-skill-taxonomy-evaluation.md)
 
 Return to the [architecture map](../../ARCHITECTURE.md) or [repository context](../../CONTEXT.md).

--- a/docs/skill-taxonomy-gold-set.md
+++ b/docs/skill-taxonomy-gold-set.md
@@ -1,0 +1,50 @@
+# Skill taxonomy Gold Set
+
+The Gold Set is a versioned semantic-evaluation sample for the catalog's single primary outcome category. It measures classification agreement; it does not establish Skill safety, quality, portability, or runtime behavior.
+
+## Annotation source
+
+Version 1 is manually reviewed by independent repository agents and adjudicated by the maintaining root agent. It is explicitly marked `humanApproved: false`; no page may describe it as human-verified until a maintainer reviews and signs the labels.
+
+## Sampling
+
+- Base revision: the merged PR #10 classifier state.
+- Seed: `semantic-gold-v1`.
+- Size: 10 candidates from each of 14 predicted categories, 140 total.
+- Ranking: priority ties, overrides, fallbacks, and descriptions needing review are considered before ordinary rule matches; stable hashes choose within each stratum.
+- Labels are never changed merely to agree with classifier output. Taxonomy rules may change after errors are reviewed.
+- A stable secondary hash freezes two entries per predicted category as a published validation slice (28 total); the other 112 labels form the development slice.
+- The validation slice is public and therefore is not described as an unseen or private benchmark. It is a regression check, not permission to tune individual Skill IDs.
+- The exact 140-entry membership, baseline routes, and 112/28 split are covered by a fixed candidate-set digest. The evaluator rejects additions, removals, split changes, and baseline-label drift.
+- A separate fixed label-set digest covers expected categories, rationales, confidence, reviewers, review status, review date, and source digest. Relabeling reviewed answers without an explicit contract change fails closed.
+- The evaluator restores the recorded base catalog from Git, verifies its SHA-256, reruns the deterministic sampler, and requires exact membership, baseline routes, and splits.
+
+## Primary-outcome rubric
+
+1. Read the Skill entrypoint far enough to identify its promised user outcome, required inputs, and produced artifact or decision.
+2. Ignore its current predicted category until after choosing a label.
+3. Choose one category only. Prefer what the user receives over incidental tools, frameworks, or keywords.
+4. Use `apps-workflow-automation` when controlling an external application is the central outcome; use the domain category when automation only supports a more specific outcome.
+5. Use `chinese-platform-workflows` when operating a named Chinese platform is the defining workflow, not merely the audience language.
+6. Use `security-privacy-legal` for assurance, legal constraints, privacy, or risk review; use `software-engineering` when security is only one implementation concern.
+7. Use `finance-trading-markets` for valuation, trading, portfolios, market risk, or financial operations; do not collapse these into generic data analysis.
+8. Use `general-utilities` only when no more specific primary outcome fits.
+
+Record a concrete rationale, confidence, reviewer identifiers, source digest, and disagreement status. Low-confidence and cross-category cases must be cross-reviewed or adjudicated rather than silently omitted.
+
+## Metrics and release gate
+
+- Exact accuracy must be at least 0.80.
+- Macro-F1 across all 14 categories must be at least 0.80.
+- Every category must appear in Gold labels.
+- Published-validation exact accuracy must be at least 0.75.
+- Published-validation macro-F1 must be at least 0.75 and every category must remain represented.
+- The report publishes the 95% Wilson lower bound for reviewed-set agreement as uncertainty evidence. Because the sample deliberately overrepresents difficult routes, that bound is not an inventory-wide accuracy interval.
+- `reviewedSetAgreementScore` is the floored minimum of accuracy and macro-F1, multiplied by 100. A failed gate cannot be reported as 80+.
+
+Build or check the generated report:
+
+```bash
+npm run build:taxonomy-evaluation
+npm run check:taxonomy-evaluation
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Evidence-backed AI team packs with preview-first installation and repository contracts",
   "type": "module",
   "scripts": {
-    "test": "npm run test:repository && npm run test:installer && npm run check:skills && npm run check:skill-quality && npm run check:architecture",
+    "test": "npm run test:repository && npm run test:installer && npm run check:skills && npm run check:skill-quality && npm run check:taxonomy-evaluation && npm run check:architecture",
     "test:repository": "python3 -m unittest discover -s tests -p 'test_*.py'",
     "test:installer": "bash tests/installer/test_install.sh",
     "validate": "python3 scripts/validate_repository.py",
@@ -13,6 +13,8 @@
     "check:skills": "python3 scripts/build_skill_catalog.py --check",
     "build:skill-quality": "python3 scripts/audit_skill_quality.py",
     "check:skill-quality": "python3 scripts/audit_skill_quality.py --check",
+    "build:taxonomy-evaluation": "python3 scripts/build_skill_taxonomy_evaluation.py",
+    "check:taxonomy-evaluation": "python3 scripts/build_skill_taxonomy_evaluation.py --check",
     "check:architecture": "python3 scripts/audit_architecture.py --check"
   },
   "keywords": [

--- a/scripts/audit_architecture.py
+++ b/scripts/audit_architecture.py
@@ -40,14 +40,21 @@ HARD_REQUIRED_DECISIONS = {
     "docs/adr/0001-canonical-inventory-and-generated-outputs.md",
     "docs/adr/0002-generic-workspace-and-curated-distributions.md",
     "docs/adr/0003-structural-evidence-and-runtime-receipts.md",
+    "docs/adr/0004-reviewed-skill-taxonomy-evaluation.md",
 }
 CRITICAL_PATH_CONTRACTS: dict[str, dict[str, Any]] = {
     "skills": {"role": "authored-authority", "module": "skill-library", "authority": True},
     "config/team-manifest.json": {"role": "authored-authority", "module": "team-composition", "authority": True},
     "config/skill-taxonomy.json": {"role": "authored-authority", "module": "catalog-discovery", "authority": True},
+    "config/skill-taxonomy-gold.json": {"role": "authored-authority", "module": "catalog-discovery", "authority": True},
+    "config/skill-taxonomy-gold.schema.json": {"role": "authored-source", "module": "catalog-discovery", "authority": False},
+    "config/skill-taxonomy-evaluation.schema.json": {"role": "authored-source", "module": "catalog-discovery", "authority": False},
+    "docs/skill-taxonomy-gold-set.md": {"role": "authored-source", "module": "catalog-discovery", "authority": False},
+    "scripts/build_skill_taxonomy_evaluation.py": {"role": "implementation", "module": "catalog-discovery", "authority": False},
     "config/repository-architecture.json": {"role": "authored-authority", "module": "governance-memory", "authority": True},
     "install.sh": {"role": "implementation", "module": "safe-installation", "authority": False},
     "catalog": {"role": "generated-output", "module": "catalog-discovery", "authority": False, "generatedBy": "scripts/build_skill_catalog.py", "verify": "npm run check:skills"},
+    "catalog/skill-taxonomy-evaluation.json": {"role": "generated-output", "module": "catalog-discovery", "authority": False, "generatedBy": "scripts/build_skill_taxonomy_evaluation.py", "verify": "npm run check:taxonomy-evaluation"},
     "catalog/skill-quality.json": {"role": "generated-output", "module": "verification-evidence", "authority": False, "generatedBy": "scripts/audit_skill_quality.py", "verify": "npm run check:skill-quality"},
     "docs/data/repo-stats.json": {"role": "generated-output", "module": "public-navigation", "authority": False, "generatedBy": "scripts/build_site_data.py", "verify": "npm run test:repository"},
     "docs/data/star-history.json": {"role": "generated-output", "module": "public-navigation", "authority": False, "generatedBy": "scripts/build_site_data.py", "verify": "npm run test:repository"},
@@ -298,15 +305,24 @@ def taxonomy_metrics(root: Path) -> dict[str, Any]:
 
         source = classification_source.split(":", 1)[0]
         slug, combined = builder._classification_text(entry.skill_id, entry.description)
-        text = slug if source == "slug" else combined
+        text = (
+            slug
+            if source == "slug"
+            else entry.description.lower()
+            if source == "outcome"
+            else combined
+        )
+        pattern_field = "outcomePatterns" if source == "outcome" else "patterns"
         scores: list[tuple[int, int, str]] = []
         for category in taxonomy["categories"]:
-            if category.get("fallback"):
+            patterns = category.get(pattern_field, [])
+            if category.get("fallback") and not patterns:
                 continue
             matched = [
-                pattern for pattern in category["patterns"]
+                pattern for pattern in patterns
                 if not (
-                    source == "description"
+                    pattern_field == "patterns"
+                    and source == "description"
                     and pattern in builder.DESCRIPTION_EXCLUDED_PATTERNS
                 )
                 and re.search(pattern, text, re.IGNORECASE)

--- a/scripts/build_skill_catalog.py
+++ b/scripts/build_skill_catalog.py
@@ -27,6 +27,8 @@ DESCRIPTION_EXCLUDED_PATTERNS = {
     "(?:^|-)skills?(?:-|$)",
     "(?:^|-)model(?:-|$)",
     "team",
+    "permission",
+    "secret",
 }
 DESCRIPTION_REVIEW_PATTERN = re.compile(
     r"(?i)(?:\bnever lost\b|\bguaranteed\b|\bproduction[- ]ready\b|"
@@ -162,16 +164,25 @@ def _classification_text(skill_id: str, description: str) -> tuple[str, str]:
 
 
 def _rule_candidates(
-    source: str, text: str, taxonomy: dict[str, Any]
+    source: str,
+    text: str,
+    taxonomy: dict[str, Any],
+    *,
+    pattern_field: str = "patterns",
 ) -> list[tuple[int, int, str, list[str]]]:
     candidates: list[tuple[int, int, str, list[str]]] = []
     for category in taxonomy["categories"]:
-        if category.get("fallback"):
+        patterns = category.get(pattern_field, [])
+        if category.get("fallback") and not patterns:
             continue
         matched = [
             pattern
-            for pattern in category["patterns"]
-            if not (source == "description" and pattern in DESCRIPTION_EXCLUDED_PATTERNS)
+            for pattern in patterns
+            if not (
+                pattern_field == "patterns"
+                and source == "description"
+                and pattern in DESCRIPTION_EXCLUDED_PATTERNS
+            )
             and re.search(pattern, text, re.IGNORECASE)
         ]
         if matched:
@@ -204,8 +215,14 @@ def _classify(
         category_id = str(overrides[skill_id])
         base_source = "fallback"
         base_candidates: list[tuple[int, int, str, list[str]]] = []
-        for source, text in (("slug", slug), ("description", combined)):
-            base_candidates = _rule_candidates(source, text, taxonomy)
+        for source, text, pattern_field in (
+            ("outcome", description.lower(), "outcomePatterns"),
+            ("slug", slug, "patterns"),
+            ("description", combined, "patterns"),
+        ):
+            base_candidates = _rule_candidates(
+                source, text, taxonomy, pattern_field=pattern_field
+            )
             if base_candidates:
                 base_source = source
                 break
@@ -231,28 +248,50 @@ def _classify(
             "review_state": "unreviewed",
         }
 
-    for source, text in (("slug", slug), ("description", combined)):
-        candidates = _rule_candidates(source, text, taxonomy)
-        if candidates:
-            best_score, best_priority, best_category, best_patterns = candidates[0]
-            tied = any(item[0] == best_score for item in candidates[1:])
-            return best_category, f"{source}:" + ",".join(best_patterns), {
-                "method": source,
-                "winner": {
-                    "category_id": best_category,
-                    "match_count": best_score,
-                    "matched_signals": best_patterns,
-                    "priority": best_priority,
-                    "tie_detected": tied,
-                },
+    outcome_candidates = _rule_candidates(
+        "outcome",
+        description.lower(),
+        taxonomy,
+        pattern_field="outcomePatterns",
+    )
+    slug_candidates = _rule_candidates("slug", slug, taxonomy)
+    selected: tuple[str, list[tuple[int, int, str, list[str]]]] | None = None
+    if outcome_candidates and (
+        not slug_candidates
+        or outcome_candidates[0][2] == slug_candidates[0][2]
+        or outcome_candidates[0][0] >= 2
+    ):
+        selected = ("outcome", outcome_candidates)
+    elif slug_candidates:
+        selected = ("slug", slug_candidates)
+    else:
+        description_candidates = _rule_candidates(
+            "description", combined, taxonomy
+        )
+        if description_candidates:
+            selected = ("description", description_candidates)
+
+    if selected:
+        source, candidates = selected
+        best_score, best_priority, best_category, best_patterns = candidates[0]
+        tied = any(item[0] == best_score for item in candidates[1:])
+        return best_category, f"{source}:" + ",".join(best_patterns), {
+            "method": source,
+            "winner": {
+                "category_id": best_category,
+                "match_count": best_score,
                 "matched_signals": best_patterns,
-                "runner_ups": [
-                    _candidate_document(item, best_score)
-                    for item in candidates[1:]
-                ],
-                "resolution_status": "priority-tie" if tied else "rule-match",
-                "review_state": "unreviewed",
-            }
+                "priority": best_priority,
+                "tie_detected": tied,
+            },
+            "matched_signals": best_patterns,
+            "runner_ups": [
+                _candidate_document(item, best_score)
+                for item in candidates[1:]
+            ],
+            "resolution_status": "priority-tie" if tied else "rule-match",
+            "review_state": "unreviewed",
+        }
     fallback = next(item["id"] for item in taxonomy["categories"] if item.get("fallback"))
     return fallback, "fallback", {
         "method": "fallback",
@@ -297,8 +336,8 @@ def _portability_class(levels: set[str]) -> str:
 def _validate_taxonomy(taxonomy: dict[str, Any], skill_names: set[str]) -> None:
     if taxonomy.get("$schema") != "./skill-taxonomy.schema.json":
         raise ValueError("taxonomy must reference ./skill-taxonomy.schema.json")
-    if taxonomy.get("schemaVersion") != 1:
-        raise ValueError("taxonomy schemaVersion must be 1")
+    if taxonomy.get("schemaVersion") != 2:
+        raise ValueError("taxonomy schemaVersion must be 2")
 
     categories = taxonomy.get("categories", [])
     category_ids = [item["id"] for item in categories]
@@ -310,7 +349,7 @@ def _validate_taxonomy(taxonomy: dict[str, Any], skill_names: set[str]) -> None:
     if sum(bool(item.get("fallback")) for item in categories) != 1:
         raise ValueError("taxonomy must define exactly one fallback category")
     for category in categories:
-        for pattern in category["patterns"]:
+        for pattern in category["patterns"] + category["outcomePatterns"]:
             if not pattern:
                 raise ValueError(f"empty pattern in category {category['id']}")
             re.compile(pattern)
@@ -431,6 +470,8 @@ def render_markdown(entries: list[SkillEntry], taxonomy: dict[str, Any]) -> str:
         "# 🧭 Skill catalog",
         "",
         "Find a skill by the outcome you need. This index is generated from tracked, physical `SKILL.md` entrypoints; catalog inclusion proves structure, not behavior or cross-harness compatibility.",
+        "",
+        "**Classification evidence:** inspect the fixed [Gold Set methodology](../docs/skill-taxonomy-gold-set.md) and the machine-readable [reviewed-set agreement report](./skill-taxonomy-evaluation.json). The score measures agreement on reviewed primary-outcome labels; it is not a Skill quality or runtime-success score.",
         "",
         "## 🚀 Suggested starting points",
         "",

--- a/scripts/build_skill_taxonomy_evaluation.py
+++ b/scripts/build_skill_taxonomy_evaluation.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""Build deterministic semantic evaluation evidence from reviewed Skill labels."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import subprocess
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+GOLD_PATH = Path("config/skill-taxonomy-gold.json")
+INDEX_PATH = Path("catalog/skill-index.json")
+TAXONOMY_PATH = Path("config/skill-taxonomy.json")
+REPORT_PATH = Path("catalog/skill-taxonomy-evaluation.json")
+
+
+def _stable_hash(seed: str, category_id: str, skill_id: str) -> str:
+    return hashlib.sha256(
+        f"{seed}\0{category_id}\0{skill_id}".encode("utf-8")
+    ).hexdigest()
+
+
+def select_candidates(
+    index: dict[str, Any], *, per_category: int, seed: str
+) -> list[dict[str, str]]:
+    """Select a deterministic, category-balanced, difficulty-aware review sample."""
+
+    if per_category < 1:
+        raise ValueError("per_category must be positive")
+    difficulty = {
+        "priority-tie": 0,
+        "override": 1,
+        "fallback": 2,
+        "rule-match": 4,
+    }
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for skill in index.get("skills", []):
+        grouped[skill["category_id"]].append(skill)
+
+    selected: list[dict[str, str]] = []
+    category_ids = [item["id"] for item in index.get("categories", [])]
+    for category_id in category_ids:
+        candidates = grouped.get(category_id, [])
+        if len(candidates) < per_category:
+            raise ValueError(
+                f"category {category_id} has only {len(candidates)} candidates"
+            )
+        ranked = sorted(
+            candidates,
+            key=lambda item: (
+                difficulty.get(
+                    item["classification_details"]["resolution_status"], 3
+                ),
+                0 if item.get("description_status") == "needs-review" else 1,
+                _stable_hash(seed, category_id, item["skill_id"]),
+            ),
+        )
+        chosen = ranked[:per_category]
+        validation_count = max(1, per_category // 5)
+        validation_ids = {
+            item["skill_id"]
+            for item in sorted(
+                chosen,
+                key=lambda item: _stable_hash(
+                    "semantic-gold-holdout-v1", category_id, item["skill_id"]
+                ),
+            )[:validation_count]
+        }
+        for item in chosen:
+            selected.append(
+                {
+                    "skill_id": item["skill_id"],
+                    "category_id": category_id,
+                    "resolution_status": item["classification_details"][
+                        "resolution_status"
+                    ],
+                    "description_status": item["description_status"],
+                    "split": (
+                        "validation"
+                        if item["skill_id"] in validation_ids
+                        else "development"
+                    ),
+                }
+            )
+    return selected
+
+
+def gold_candidate_set_sha256(labels: Iterable[dict[str, Any]]) -> str:
+    """Hash the frozen membership, baseline route, and published split."""
+
+    manifest = sorted(
+        (
+            {
+                "skill_id": item["skill_id"],
+                "baseline_predicted_category": item[
+                    "baseline_predicted_category"
+                ],
+                "baseline_resolution_status": item[
+                    "baseline_resolution_status"
+                ],
+                "split": item["split"],
+            }
+            for item in labels
+        ),
+        key=lambda item: item["skill_id"],
+    )
+    payload = json.dumps(
+        manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def gold_label_set_sha256(labels: Iterable[dict[str, Any]]) -> str:
+    """Hash the reviewed annotation evidence independently of sample routing."""
+
+    fields = (
+        "skill_id",
+        "expected_category",
+        "rationale",
+        "confidence",
+        "reviewers",
+        "review_status",
+        "reviewed_at",
+        "source_sha256",
+    )
+    annotations = sorted(
+        ({field: item[field] for field in fields} for item in labels),
+        key=lambda item: item["skill_id"],
+    )
+    payload = json.dumps(
+        annotations, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _load_frozen_baseline(root: Path, gold: dict[str, Any]) -> dict[str, Any]:
+    revision = gold["sampling"]["baseCommit"]
+    result = subprocess.run(
+        ["git", "show", f"{revision}:catalog/skill-index.json"],
+        cwd=root,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"Gold Set base commit is unavailable: {revision}")
+    actual_digest = hashlib.sha256(result.stdout).hexdigest()
+    if actual_digest != gold["sampling"]["baseCatalogSha256"]:
+        raise ValueError("Gold Set base catalog digest does not match")
+    return json.loads(result.stdout.decode("utf-8"))
+
+
+def _validate_gold_contract(
+    root: Path, gold: dict[str, Any], categories: list[str]
+) -> None:
+    labels = gold.get("labels", [])
+    if len(labels) != 140:
+        raise ValueError("Gold Set must contain exactly 140 labels")
+    skill_ids = [item["skill_id"] for item in labels]
+    if len(skill_ids) != len(set(skill_ids)):
+        raise ValueError("Gold Set skill IDs must be unique")
+
+    actual_digest = gold_candidate_set_sha256(labels)
+    expected_digest = gold.get("sampling", {}).get("candidateSetSha256")
+    if actual_digest != expected_digest:
+        raise ValueError("Gold Set candidate set digest does not match")
+    actual_label_digest = gold_label_set_sha256(labels)
+    expected_label_digest = gold.get("annotation", {}).get("labelSetSha256")
+    if actual_label_digest != expected_label_digest:
+        raise ValueError("Gold Set label set digest does not match")
+
+    baseline = _load_frozen_baseline(root, gold)
+    frozen_sample = select_candidates(
+        baseline,
+        per_category=gold["sampling"]["perPredictedCategory"],
+        seed=gold["sampling"]["seed"],
+    )
+    expected_candidates = {
+        item["skill_id"]: (
+            item["category_id"],
+            item["resolution_status"],
+            item["split"],
+        )
+        for item in frozen_sample
+    }
+    actual_candidates = {
+        item["skill_id"]: (
+            item["baseline_predicted_category"],
+            item["baseline_resolution_status"],
+            item["split"],
+        )
+        for item in labels
+    }
+    if actual_candidates != expected_candidates:
+        raise ValueError("Gold Set candidates do not match the frozen baseline sample")
+
+    by_baseline_category: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for label in labels:
+        by_baseline_category[label["baseline_predicted_category"]].append(label)
+        reviewers = label["reviewers"]
+        status = label["review_status"]
+        required_reviewers = {
+            "primary": 1,
+            "cross-reviewed": 2,
+            "adjudicated": 3,
+        }[status]
+        if len(reviewers) < required_reviewers:
+            raise ValueError(
+                f"Gold label lacks review evidence: {label['skill_id']}"
+            )
+        needs_cross_review = (
+            label["confidence"] != "high"
+            or label["expected_category"]
+            != label["baseline_predicted_category"]
+        )
+        if needs_cross_review and status == "primary":
+            raise ValueError(
+                f"Gold label requires cross-review: {label['skill_id']}"
+            )
+
+    if set(by_baseline_category) != set(categories):
+        raise ValueError("Gold Set baseline category coverage does not match taxonomy")
+    for category_id, category_labels in by_baseline_category.items():
+        split_counts = {
+            split: sum(item["split"] == split for item in category_labels)
+            for split in ("development", "validation")
+        }
+        if len(category_labels) != 10 or split_counts != {
+            "development": 8,
+            "validation": 2,
+        }:
+            raise ValueError(
+                "Gold Set requires 8 development and 2 validation labels "
+                f"for baseline category {category_id}"
+            )
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def classification_metrics(
+    *, expected: Iterable[str], predicted: Iterable[str], categories: Iterable[str]
+) -> dict[str, Any]:
+    expected_values = list(expected)
+    predicted_values = list(predicted)
+    category_values = list(categories)
+    if len(expected_values) != len(predicted_values):
+        raise ValueError("expected and predicted lengths differ")
+    if len(category_values) != len(set(category_values)):
+        raise ValueError("categories must be unique")
+
+    per_category: dict[str, dict[str, float | int]] = {}
+    f1_values: list[float] = []
+    for category_id in category_values:
+        true_positive = sum(
+            actual == category_id and guess == category_id
+            for actual, guess in zip(expected_values, predicted_values, strict=True)
+        )
+        false_positive = sum(
+            actual != category_id and guess == category_id
+            for actual, guess in zip(expected_values, predicted_values, strict=True)
+        )
+        false_negative = sum(
+            actual == category_id and guess != category_id
+            for actual, guess in zip(expected_values, predicted_values, strict=True)
+        )
+        precision = _safe_ratio(true_positive, true_positive + false_positive)
+        recall = _safe_ratio(true_positive, true_positive + false_negative)
+        f1 = _safe_ratio(2 * precision * recall, precision + recall)
+        f1_values.append(f1)
+        per_category[category_id] = {
+            "precision": round(precision, 6),
+            "recall": round(recall, 6),
+            "f1": round(f1, 6),
+            "support": sum(value == category_id for value in expected_values),
+            "predicted": sum(value == category_id for value in predicted_values),
+        }
+
+    correct = sum(
+        actual == guess
+        for actual, guess in zip(expected_values, predicted_values, strict=True)
+    )
+    accuracy = _safe_ratio(correct, len(expected_values))
+    macro_f1 = _safe_ratio(
+        sum(f1_values),
+        len(category_values),
+    )
+    return {
+        "total": len(expected_values),
+        "correct": correct,
+        "accuracy": accuracy,
+        "macro_f1": macro_f1,
+        "per_category": per_category,
+    }
+
+
+def wilson_lower_bound(successes: int, total: int, z: float = 1.959963984540054) -> float:
+    if total <= 0:
+        return 0.0
+    proportion = successes / total
+    denominator = 1 + z * z / total
+    centre = proportion + z * z / (2 * total)
+    margin = z * math.sqrt(
+        (proportion * (1 - proportion) + z * z / (4 * total)) / total
+    )
+    return (centre - margin) / denominator
+
+
+def skill_source_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def evaluate_gold_set(
+    root: Path,
+    gold: dict[str, Any],
+    index: dict[str, Any],
+    taxonomy: dict[str, Any],
+) -> dict[str, Any]:
+    root = root.resolve()
+    categories = [item["id"] for item in taxonomy["categories"]]
+    _validate_gold_contract(root, gold, categories)
+    known_categories = set(categories)
+    indexed = {item["skill_id"]: item for item in index["skills"]}
+    expected: list[str] = []
+    predicted: list[str] = []
+    split_values: list[str] = []
+    errors: list[dict[str, str]] = []
+
+    for label in gold["labels"]:
+        skill_id = label["skill_id"]
+        if skill_id not in indexed:
+            raise ValueError(f"gold label references missing skill: {skill_id}")
+        if label["expected_category"] not in known_categories:
+            raise ValueError(f"gold label references unknown category: {skill_id}")
+        current_digest = skill_source_digest(root / "skills" / skill_id / "SKILL.md")
+        if label["source_sha256"] != current_digest:
+            raise ValueError(f"gold label is stale: {skill_id}")
+        actual = label["expected_category"]
+        guess = indexed[skill_id]["category_id"]
+        expected.append(actual)
+        predicted.append(guess)
+        split_values.append(label["split"])
+        if actual != guess:
+            errors.append(
+                {
+                    "skill_id": skill_id,
+                    "expected_category": actual,
+                    "predicted_category": guess,
+                    "split": label["split"],
+                }
+            )
+
+    metrics = classification_metrics(
+        expected=expected,
+        predicted=predicted,
+        categories=categories,
+    )
+    split_metrics = {}
+    for split in ("development", "validation"):
+        positions = [
+            index for index, value in enumerate(split_values) if value == split
+        ]
+        split_result = classification_metrics(
+            expected=[expected[index] for index in positions],
+            predicted=[predicted[index] for index in positions],
+            categories=categories,
+        )
+        split_metrics[split] = {
+            **split_result,
+            "accuracyWilsonLower95": round(
+                wilson_lower_bound(
+                    split_result["correct"], split_result["total"]
+                ),
+                6,
+            ),
+        }
+    accuracy_gate = metrics["accuracy"] >= 0.80
+    macro_f1_gate = metrics["macro_f1"] >= 0.80
+    sample_gate = metrics["total"] >= 140
+    coverage_gate = all(
+        item["support"] > 0 for item in metrics["per_category"].values()
+    )
+    validation_gate = split_metrics["validation"]["accuracy"] >= 0.75
+    validation_macro_f1_gate = (
+        split_metrics["validation"]["macro_f1"] >= 0.75
+    )
+    validation_coverage_gate = all(
+        item["support"] > 0
+        for item in split_metrics["validation"]["per_category"].values()
+    )
+    raw_score = math.floor(
+        100 * min(float(metrics["accuracy"]), float(metrics["macro_f1"]))
+    )
+    passed = (
+        sample_gate
+        and accuracy_gate
+        and macro_f1_gate
+        and coverage_gate
+        and validation_gate
+        and validation_macro_f1_gate
+        and validation_coverage_gate
+    )
+    semantic_score = raw_score if passed else min(raw_score, 79)
+    gold_path = root / GOLD_PATH
+    return {
+        "$schema": "../config/skill-taxonomy-evaluation.schema.json",
+        "schemaVersion": 1,
+        "sampleSize": metrics["total"],
+        "categoryCount": len(categories),
+        "goldSetSha256": hashlib.sha256(gold_path.read_bytes()).hexdigest(),
+        "annotationMode": gold["annotation"]["mode"],
+        "humanApproved": gold["annotation"]["humanApproved"],
+        "metrics": {
+            **metrics,
+            "accuracyWilsonLower95": round(
+                wilson_lower_bound(metrics["correct"], metrics["total"]), 6
+            ),
+        },
+        "splits": split_metrics,
+        "gates": {
+            "sampleAtLeast140": sample_gate,
+            "accuracyAtLeast80": accuracy_gate,
+            "macroF1AtLeast80": macro_f1_gate,
+            "allCategoriesRepresented": coverage_gate,
+            "validationAccuracyAtLeast75": validation_gate,
+            "validationMacroF1AtLeast75": validation_macro_f1_gate,
+            "validationAllCategoriesRepresented": validation_coverage_gate,
+            "passed": passed,
+        },
+        "reviewedSetAgreementScore": semantic_score,
+        "scoreSemantics": "floored minimum of exact accuracy and macro-F1 on the fixed, manually reviewed Gold Set; not an inventory-wide confidence interval",
+        "runtimeEvidenceIncluded": False,
+        "errors": sorted(errors, key=lambda item: item["skill_id"]),
+    }
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.replace(temporary, path)
+    finally:
+        if temporary is not None and temporary.exists():
+            temporary.unlink()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--sample", action="store_true")
+    parser.add_argument("--shard", type=int, choices=range(1, 5))
+    arguments = parser.parse_args()
+    root = arguments.root.resolve()
+    index = json.loads((root / INDEX_PATH).read_text(encoding="utf-8"))
+    if arguments.sample:
+        candidates = select_candidates(
+            index, per_category=10, seed="semantic-gold-v1"
+        )
+        if arguments.shard:
+            candidates = [
+                item
+                for position, item in enumerate(candidates)
+                if position % 4 == arguments.shard - 1
+            ]
+        print(json.dumps(candidates, ensure_ascii=False, indent=2))
+        return 0
+
+    gold = json.loads((root / GOLD_PATH).read_text(encoding="utf-8"))
+    taxonomy = json.loads((root / TAXONOMY_PATH).read_text(encoding="utf-8"))
+    report = evaluate_gold_set(root, gold, index, taxonomy)
+    content = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    report_path = root / REPORT_PATH
+    if arguments.check:
+        if not report_path.is_file() or report_path.read_text(encoding="utf-8") != content:
+            print(f"STALE {report_path}")
+            return 1
+    else:
+        _write_atomic(report_path, content)
+        print(f"WROTE {report_path}")
+    return 0 if report["gates"]["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/README.md
+++ b/skills/README.md
@@ -60,7 +60,7 @@ The checked [debt baseline](../config/skill-quality-baseline.json) allows findin
 
 ## 📦 Inventory contract
 
-The canonical rules and active requirements live in [`config/team-manifest.json`](../config/team-manifest.json). Taxonomy rules live in [`config/skill-taxonomy.json`](../config/skill-taxonomy.json); generated counts are not maintained by hand.
+The canonical rules and active requirements live in [`config/team-manifest.json`](../config/team-manifest.json). Taxonomy rules live in [`config/skill-taxonomy.json`](../config/skill-taxonomy.json); generated counts are not maintained by hand. Primary-outcome classification is checked against a fixed [reviewed Gold Set](../docs/skill-taxonomy-gold-set.md) with a machine-readable [agreement report](../catalog/skill-taxonomy-evaluation.json). That score does not measure Skill quality, safety, or runtime success.
 
 The validator counts only skills that are tracked by Git, physical rather than symlinked, present in the working tree, and backed by a top-level `SKILL.md`.
 

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -60,6 +60,8 @@ class SkillCatalogTests(unittest.TestCase):
         for category in categories:
             for pattern in category["patterns"]:
                 re.compile(pattern)
+            for pattern in category["outcomePatterns"]:
+                re.compile(pattern)
         known_categories = set(identifiers)
         self.assertTrue(set(self.taxonomy["overrides"].values()) <= known_categories)
         self.assertEqual(
@@ -129,6 +131,39 @@ class SkillCatalogTests(unittest.TestCase):
             with self.subTest(skill=skill_id):
                 self.assertIn(signal, by_id[skill_id].review_signals)
 
+    def test_primary_outcome_routes_beat_incidental_tokens(self) -> None:
+        by_id = {entry.skill_id: entry for entry in self.entries}
+        expected_categories = {
+            "agent-browser": "apps-workflow-automation",
+            "ai-marketing-videos": "content-media-publishing",
+            "api-design-patterns": "software-engineering",
+            "business-analyst": "data-analytics-research",
+            "datadog-automation": "cloud-devops-reliability",
+            "deepwork-tracker": "general-utilities",
+            "evomap": "ai-agents-orchestration",
+            "file-organizer": "general-utilities",
+            "linkedin-cdp": "sales-crm-customer-success",
+            "microservices-patterns": "cloud-devops-reliability",
+            "provider-key-manager": "security-privacy-legal",
+            "quality-convergence-engine": "general-utilities",
+            "static-code-analysis": "software-engineering",
+            "subagent-driven-development": "ai-agents-orchestration",
+            "vcf-annotator": "data-analytics-research",
+        }
+        for skill_id, category_id in expected_categories.items():
+            with self.subTest(skill=skill_id):
+                self.assertEqual(by_id[skill_id].category_id, category_id)
+
+    def test_outcome_phrases_precede_weak_slug_tokens(self) -> None:
+        category_id, method, details = self.builder._classify(
+            "thinking-example",
+            "Apply quantitative trading and portfolio risk principles.",
+            self.taxonomy,
+        )
+        self.assertEqual(category_id, "finance-trading-markets")
+        self.assertTrue(method.startswith("outcome:"))
+        self.assertEqual(details["method"], "outcome")
+
     def test_generated_catalog_is_current_and_uses_portable_links(self) -> None:
         result = subprocess.run(
             [sys.executable, str(BUILDER_PATH), "--root", str(ROOT), "--check"],
@@ -176,7 +211,7 @@ class SkillCatalogTests(unittest.TestCase):
         for item in index["skills"]:
             decision = item["classification_details"]
             winner = decision["winner"]
-            self.assertIn(decision["method"], {"slug", "description", "override", "fallback"})
+            self.assertIn(decision["method"], {"outcome", "slug", "description", "override", "fallback"})
             self.assertIn(decision["resolution_status"], {"rule-match", "priority-tie", "override", "fallback"})
             self.assertEqual(decision["review_state"], "unreviewed")
             self.assertEqual(winner["category_id"], item["category_id"])
@@ -210,7 +245,7 @@ class SkillCatalogTests(unittest.TestCase):
                 self.assertFalse(winner["tie_detected"])
             if decision["method"] == "override":
                 self.assertGreaterEqual(len(decision["rationale"]), 20)
-                self.assertIn(decision["base_method"], {"slug", "description", "fallback"})
+                self.assertIn(decision["base_method"], {"outcome", "slug", "description", "fallback"})
                 self.assertIsInstance(decision["base_candidates"], list)
 
             assignments = {
@@ -233,12 +268,9 @@ class SkillCatalogTests(unittest.TestCase):
 
         by_id = {item["skill_id"]: item for item in index["skills"]}
         api_design = by_id["api-design"]["classification_details"]
-        self.assertEqual(api_design["resolution_status"], "priority-tie")
-        self.assertTrue(
-            any(
-                item["category_id"] == "software-engineering" and item["tied_for_first"]
-                for item in api_design["runner_ups"]
-            )
+        self.assertEqual(api_design["method"], "outcome")
+        self.assertEqual(
+            api_design["winner"]["category_id"], "software-engineering"
         )
         fallback = next(
             item for item in index["skills"]

--- a/tests/test_skill_taxonomy_evaluation.py
+++ b/tests/test_skill_taxonomy_evaluation.py
@@ -1,0 +1,220 @@
+import hashlib
+import json
+import sys
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from build_skill_taxonomy_evaluation import (  # noqa: E402
+    classification_metrics,
+    evaluate_gold_set,
+    gold_candidate_set_sha256,
+    gold_label_set_sha256,
+    select_candidates,
+    skill_source_digest,
+    wilson_lower_bound,
+)
+
+
+class SkillTaxonomyEvaluationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index = json.loads(
+            (ROOT / "catalog" / "skill-index.json").read_text(encoding="utf-8")
+        )
+        cls.taxonomy = json.loads(
+            (ROOT / "config" / "skill-taxonomy.json").read_text(encoding="utf-8")
+        )
+
+    def test_candidate_selection_is_deterministic_stratified_and_difficulty_aware(self) -> None:
+        selected = select_candidates(
+            self.index,
+            per_category=10,
+            seed="semantic-gold-v1",
+        )
+        reversed_index = {**self.index, "skills": list(reversed(self.index["skills"]))}
+        selected_again = select_candidates(
+            reversed_index,
+            per_category=10,
+            seed="semantic-gold-v1",
+        )
+        self.assertEqual(selected, selected_again)
+        self.assertEqual(len(selected), 140)
+        self.assertEqual(len(selected), len({item["skill_id"] for item in selected}))
+
+        counts = {}
+        for item in selected:
+            counts[item["category_id"]] = counts.get(item["category_id"], 0) + 1
+        self.assertEqual(set(counts), {item["id"] for item in self.taxonomy["categories"]})
+        self.assertTrue(all(count == 10 for count in counts.values()))
+        split_counts = {
+            split: sum(item["split"] == split for item in selected)
+            for split in ("development", "validation")
+        }
+        self.assertEqual(split_counts, {"development": 112, "validation": 28})
+        for category_id in counts:
+            category_items = [
+                item for item in selected if item["category_id"] == category_id
+            ]
+            self.assertEqual(
+                sum(item["split"] == "validation" for item in category_items), 2
+            )
+        hard = {
+            "priority-tie",
+            "override",
+            "fallback",
+        }
+        self.assertGreaterEqual(
+            sum(item["resolution_status"] in hard for item in selected),
+            50,
+        )
+
+    def test_metrics_and_wilson_bound_are_mathematically_stable(self) -> None:
+        metrics = classification_metrics(
+            expected=["a", "b", "b"],
+            predicted=["a", "a", "b"],
+            categories=["a", "b"],
+        )
+        self.assertAlmostEqual(metrics["accuracy"], 2 / 3)
+        self.assertAlmostEqual(metrics["macro_f1"], 2 / 3)
+        self.assertEqual(metrics["correct"], 2)
+        self.assertEqual(metrics["total"], 3)
+        self.assertAlmostEqual(wilson_lower_bound(80, 100), 0.7111708, places=6)
+        self.assertEqual(wilson_lower_bound(0, 0), 0.0)
+
+    def test_gold_set_and_generated_report_are_schema_valid_and_fresh(self) -> None:
+        gold_path = ROOT / "config" / "skill-taxonomy-gold.json"
+        gold_schema_path = ROOT / "config" / "skill-taxonomy-gold.schema.json"
+        report_path = ROOT / "catalog" / "skill-taxonomy-evaluation.json"
+        report_schema_path = ROOT / "config" / "skill-taxonomy-evaluation.schema.json"
+
+        gold = json.loads(gold_path.read_text(encoding="utf-8"))
+        gold_schema = json.loads(gold_schema_path.read_text(encoding="utf-8"))
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        report_schema = json.loads(report_schema_path.read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(gold_schema)
+        Draft202012Validator(
+            gold_schema, format_checker=FormatChecker()
+        ).validate(gold)
+        Draft202012Validator.check_schema(report_schema)
+        Draft202012Validator(report_schema).validate(report)
+
+        self.assertGreaterEqual(len(gold["labels"]), 140)
+        self.assertEqual(
+            len(gold["labels"]),
+            len({item["skill_id"] for item in gold["labels"]}),
+        )
+        known_categories = {item["id"] for item in self.taxonomy["categories"]}
+        gold_categories = {item["expected_category"] for item in gold["labels"]}
+        self.assertEqual(gold_categories, known_categories)
+        self.assertEqual(len(gold["labels"]), 140)
+        self.assertEqual(
+            sum(item["split"] == "development" for item in gold["labels"]),
+            112,
+        )
+        self.assertEqual(
+            sum(item["split"] == "validation" for item in gold["labels"]),
+            28,
+        )
+        self.assertEqual(
+            gold["sampling"]["candidateSetSha256"],
+            gold_candidate_set_sha256(gold["labels"]),
+        )
+        self.assertEqual(
+            gold["annotation"]["labelSetSha256"],
+            gold_label_set_sha256(gold["labels"]),
+        )
+        self.assertTrue(
+            all(len(item["rationale"].strip()) >= 20 for item in gold["labels"])
+        )
+        for item in gold["labels"]:
+            self.assertEqual(
+                item["source_sha256"],
+                skill_source_digest(ROOT / "skills" / item["skill_id"] / "SKILL.md"),
+            )
+
+        evaluated = evaluate_gold_set(ROOT, gold, self.index, self.taxonomy)
+        self.assertEqual(report, evaluated)
+        self.assertGreaterEqual(report["metrics"]["accuracy"], 0.80)
+        self.assertGreaterEqual(report["metrics"]["macro_f1"], 0.80)
+        self.assertGreaterEqual(report["splits"]["validation"]["accuracy"], 0.75)
+        self.assertTrue(report["gates"]["validationAccuracyAtLeast75"])
+        self.assertTrue(report["gates"]["validationMacroF1AtLeast75"])
+        self.assertTrue(
+            report["gates"]["validationAllCategoriesRepresented"]
+        )
+        self.assertGreaterEqual(report["reviewedSetAgreementScore"], 80)
+        self.assertFalse(report["runtimeEvidenceIncluded"])
+        self.assertGreater(
+            report["splits"]["validation"]["accuracyWilsonLower95"], 0
+        )
+        self.assertEqual(
+            report["goldSetSha256"],
+            hashlib.sha256(gold_path.read_bytes()).hexdigest(),
+        )
+
+    def test_gold_contract_rejects_sample_growth_split_changes_and_label_drift(self) -> None:
+        gold = json.loads(
+            (ROOT / "config" / "skill-taxonomy-gold.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        expanded = deepcopy(gold)
+        expanded["labels"].append(deepcopy(expanded["labels"][0]))
+        expanded["labels"][-1]["skill_id"] = "not-a-real-gold-skill"
+        with self.assertRaisesRegex(ValueError, "exactly 140"):
+            evaluate_gold_set(ROOT, expanded, self.index, self.taxonomy)
+
+        moved = deepcopy(gold)
+        moved["labels"][0]["split"] = "validation"
+        with self.assertRaisesRegex(ValueError, "candidate set digest"):
+            evaluate_gold_set(ROOT, moved, self.index, self.taxonomy)
+
+        relabeled_baseline = deepcopy(gold)
+        relabeled_baseline["labels"][0]["baseline_predicted_category"] = (
+            "general-utilities"
+        )
+        with self.assertRaisesRegex(ValueError, "candidate set digest"):
+            evaluate_gold_set(
+                ROOT, relabeled_baseline, self.index, self.taxonomy
+            )
+
+        relabeled_gold = deepcopy(gold)
+        relabeled_gold["labels"][0]["expected_category"] = "general-utilities"
+        with self.assertRaisesRegex(ValueError, "label set digest"):
+            evaluate_gold_set(ROOT, relabeled_gold, self.index, self.taxonomy)
+
+    def test_failed_validation_gate_caps_the_public_score(self) -> None:
+        gold = json.loads(
+            (ROOT / "config" / "skill-taxonomy-gold.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        validation_ids = {
+            item["skill_id"]
+            for item in gold["labels"]
+            if item["split"] == "validation"
+        }
+        degraded_index = deepcopy(self.index)
+        for item in degraded_index["skills"]:
+            if item["skill_id"] in validation_ids:
+                item["category_id"] = "general-utilities"
+        report = evaluate_gold_set(
+            ROOT, gold, degraded_index, self.taxonomy
+        )
+        self.assertFalse(report["gates"]["passed"])
+        self.assertFalse(report["gates"]["validationAccuracyAtLeast75"])
+        self.assertLessEqual(report["reviewedSetAgreementScore"], 79)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a fixed, category-balanced 140-label Skill taxonomy Gold Set with independent primary review, cross-review, and adjudication metadata
- add taxonomy schema v2 so high-precision outcome phrases are evaluated before weaker slug and description keywords
- add a deterministic evaluation report, schemas, CI freshness checks, architecture ownership, and ADR documentation
- harden the benchmark with exact 140-entry membership, fixed 112/28 development/validation slices, candidate and label digests, source freshness, and reconstruction from the recorded base commit
- expose the methodology and generated report from the English/Chinese README, skills overview, and generated catalog

## Results

- reviewed-set agreement score: **95**
- exact accuracy: **96.4%**
- macro-F1: **95.6%**
- accuracy Wilson lower 95%: **91.9%**
- published validation accuracy: **82.1%**
- published validation macro-F1: **77.1%**
- architecture classification contracts: **100/100**

The validation slice is public and is not presented as a private or unseen benchmark. `humanApproved` remains `false`; this is independent agent manual review, not a claim of human verification. The score measures agreement on primary-outcome labels, not Skill quality, safety, portability, or runtime success.

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 106 passed
- `bash tests/installer/test_install.sh` — 23 passed
- `npm run check:skills`
- `npm run check:skill-quality`
- `npm run check:taxonomy-evaluation`
- `npm run check:architecture` — 100/100
- `npm run validate:strict` — 0 errors, 0 warnings
- `git diff --check`

The unrelated local modification to `skills/a-fund-monitor/scripts/fund_monitor.py` is intentionally excluded.
