### PR TITLE
fix(site): make official GitHub stats visible

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -308,12 +308,17 @@ tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
 .community-links strong, .community-links small { display: block; }
 .community-links small { margin-top: 4px; color: var(--text-muted); }
 
-.star-history-chart { width: 100%; height: auto; border: 1px solid var(--line); border-radius: var(--radius); background: #070b18; }
-.history-figure { margin: 0; }
-.history-figure figcaption { margin-top: 14px; color: var(--text-muted); font-size: 0.86rem; }
-.history-details { margin-top: 20px; }
-.history-details summary { min-height: 44px; display: flex; align-items: center; color: var(--primary-strong); font-weight: 700; cursor: pointer; }
-.history-details table { min-width: 420px; }
+.repository-signal-grid { display: grid; grid-template-columns: 0.72fr 0.72fr 1.56fr; gap: 16px; margin-top: 48px; }
+.repository-metric-card, .repository-source-card { min-height: 230px; padding: 30px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface-soft); }
+.repository-metric-card { display: flex; flex-direction: column; }
+.repository-metric { margin-top: auto; color: var(--text); font-family: "JetBrains Mono", monospace; font-size: clamp(3.2rem, 7vw, 5.4rem); font-weight: 400; letter-spacing: -0.08em; line-height: 0.95; }
+.repository-metric-note { margin-top: 18px; color: var(--text-muted); font-size: 0.82rem; }
+.repository-source-card { display: grid; grid-template-columns: 32px 1fr 20px; gap: 18px; align-items: center; color: var(--text); text-decoration: none; background: linear-gradient(135deg, var(--surface), var(--surface-soft)); }
+.repository-source-card:hover { border-color: var(--primary); box-shadow: var(--shadow); transform: translateY(-2px); }
+.repository-source-card > img { opacity: 0.86; }
+.repository-source-card strong, .repository-source-card small { display: block; }
+.repository-source-card strong { margin-block: 8px; font-size: 1.35rem; line-height: 1.2; }
+.repository-source-card small { color: var(--text-muted); }
 .data-note { margin: 14px 0 0; font-size: 0.8rem; }
 .data-note a { color: var(--primary-strong); text-decoration: underline; text-underline-offset: 0.16em; }
 
@@ -355,6 +360,8 @@ tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
   .hero-copy { max-width: 760px; }
   .receipt-card { max-width: 720px; }
   .workflow-layout, .community-layout { grid-template-columns: 1fr; gap: 48px; }
+  .repository-signal-grid { grid-template-columns: 1fr 1fr; }
+  .repository-source-card { grid-column: 1 / -1; }
   .workflow .section-heading { position: static; }
 }
 
@@ -397,6 +404,8 @@ tbody tr:last-child th, tbody tr:last-child td { border-bottom: 0; }
   .evidence-grid article { min-height: auto; }
   .evidence-grid article > img { margin-bottom: 30px; }
   .evidence-grid p { min-height: auto; }
+  .repository-signal-grid { grid-template-columns: 1fr; }
+  .repository-source-card { grid-column: auto; }
   .final-cta-inner { grid-template-columns: 1fr; align-items: start; }
   .footer-inner { flex-direction: column; align-items: flex-start; }
   .guide-nav, .js .guide-nav { display: flex; position: static; order: 3; width: 100%; margin: 0; padding: 0; border: 0; box-shadow: none; background: none; flex-direction: row; flex-wrap: wrap; overflow: visible; }

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -6,7 +6,7 @@
   const menuButton = document.querySelector("[data-menu-button]");
   const primaryNav = document.querySelector("[data-primary-nav]");
   const themeButton = document.querySelector("[data-theme-button]");
-  const starCount = document.querySelector("[data-star-count]");
+  const starCounts = document.querySelectorAll("[data-star-count]");
   const statsState = document.querySelector("[data-stats-state]");
   const forksCount = document.querySelector("[data-forks-count]");
   const verificationStatus = document.querySelector("[data-verification-status]");
@@ -115,12 +115,12 @@
 
   function renderStats(stats, source) {
     if (!isRepositoryStats(stats)) return false;
-    if (starCount) {
+    starCounts.forEach((starCount) => {
       starCount.textContent = new Intl.NumberFormat().format(stats.stars);
       starCount.hidden = false;
-    }
+    });
     if (forksCount) {
-      forksCount.textContent = `${new Intl.NumberFormat().format(stats.forks)} forks.`;
+      forksCount.textContent = new Intl.NumberFormat().format(stats.forks);
     }
     if (statsState) {
       const age = Date.now() - Date.parse(stats.fetchedAt);
@@ -221,40 +221,6 @@
     }
   }
 
-  async function loadStarHistorySummary() {
-    try {
-      const history = await fetchJson("data/star-history.json");
-      const points = Array.isArray(history.points) ? history.points : [];
-      const summary = document.querySelector("[data-history-summary]");
-      if (!summary || !Number.isInteger(history.latestStars)) return;
-      if (points.length < 2) {
-        summary.textContent = `${history.latestStars} current stars. Historical values will appear after the authenticated Pages refresh.`;
-        return;
-      }
-      const first = points[0];
-      const last = points[points.length - 1];
-      summary.textContent = `${history.latestStars} current stars. The reconstructed series runs from ${first.date} to ${last.date}; unstars can revise earlier values.`;
-
-      const rows = document.querySelector("[data-history-rows]");
-      const details = document.querySelector("[data-history-details]");
-      if (!rows || !details) return;
-      points.slice(-5).forEach((point) => {
-        const row = document.createElement("tr");
-        const date = document.createElement("th");
-        const stars = document.createElement("td");
-        date.scope = "row";
-        date.textContent = point.date;
-        stars.textContent = new Intl.NumberFormat().format(point.stars);
-        row.append(date, stars);
-        rows.append(row);
-      });
-      details.hidden = false;
-    } catch (_error) {
-      // The visible pending explanation remains available without JavaScript data.
-    }
-  }
-
   loadRepositoryStats();
   loadVerificationReceipt();
-  loadStarHistorySummary();
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
   <meta name="twitter:image" content="https://aaaaqwq.github.io/AGI-Super-Team/assets/og-cover.png">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
-  <link rel="stylesheet" href="assets/site.css">
+  <link rel="stylesheet" href="assets/site.css?v=20260722">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -43,7 +43,7 @@
   }
   </script>
     <script src="assets/receipt-status.js" defer></script>
-    <script src="assets/site.js" defer></script>
+    <script src="assets/site.js?v=20260722" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -259,26 +259,36 @@ npm test &amp;&amp; npm run validate -- --warnings-as-errors</code></pre>
       </div>
     </section>
 
-    <section class="star-history-section section-rule" aria-labelledby="history-title">
+    <section class="repository-signal section-rule" aria-labelledby="repository-signal-title">
       <div class="shell">
         <div class="split-heading">
-          <div><h2 id="history-title">GitHub star history</h2></div>
-          <p><span data-stats-state role="status" aria-live="polite" aria-atomic="true">Cached data loads when available.</span> <span data-forks-count></span></p>
-        </div>
-        <figure class="history-figure">
-          <img class="star-history-chart" src="assets/star-history.svg" width="1200" height="420" alt="" loading="lazy">
-          <figcaption data-history-summary role="status" aria-live="polite" aria-atomic="true">Star history refresh pending. The current GitHub count appears above when available.</figcaption>
-        </figure>
-        <details class="history-details" data-history-details hidden>
-          <summary>View recent history values</summary>
-          <div class="compatibility-table">
-            <table>
-              <thead><tr><th scope="col">Date</th><th scope="col">Cumulative stars</th></tr></thead>
-              <tbody data-history-rows></tbody>
-            </table>
+          <div>
+            <p class="kicker">GitHub repository signal</p>
+            <h2 id="repository-signal-title">Current community signal.</h2>
           </div>
-        </details>
-        <p class="data-note">Built from GitHub’s current stargazer records. Unstars can revise earlier history. <a href="data/star-history.json">View JSON data</a>.</p>
+          <p>Current counts come from GitHub's repository API. No third-party or reconstructed Star History is presented as official.</p>
+        </div>
+        <div class="repository-signal-grid">
+          <article class="repository-metric-card">
+            <span class="card-label">Current stars</span>
+            <strong class="repository-metric" data-star-count aria-live="polite">...</strong>
+            <span class="repository-metric-note" data-stats-state role="status" aria-live="polite" aria-atomic="true">Loading current GitHub data.</span>
+          </article>
+          <article class="repository-metric-card">
+            <span class="card-label">Public forks</span>
+            <strong class="repository-metric" data-forks-count aria-live="polite">...</strong>
+            <span class="repository-metric-note">Current repository state</span>
+          </article>
+          <a class="repository-source-card" href="https://github.com/aAAaqwq/AGI-Super-Team/stargazers">
+            <img src="assets/icons/star.svg" width="28" height="28" alt="">
+            <span>
+              <small>Source of truth</small>
+              <strong>View Stargazers on GitHub</strong>
+              <small>Current GitHub records, no reconstructed timeline</small>
+            </span>
+            <img src="assets/icons/arrow-right.svg" width="20" height="20" alt="">
+          </a>
+        </div>
       </div>
     </section>
 

--- a/tests/test_official_stars_contract.py
+++ b/tests/test_official_stars_contract.py
@@ -26,6 +26,22 @@ class OfficialStarsContractTests(unittest.TestCase):
         self.assertIn("persist-credentials: false", workflow)
         self.assertNotIn("git push origin HEAD:main", workflow)
 
+    def test_homepage_shows_current_github_signal_instead_of_an_empty_history(self) -> None:
+        homepage = (ROOT / "docs/index.html").read_text(encoding="utf-8")
+        script = (ROOT / "docs/assets/site.js").read_text(encoding="utf-8")
+
+        self.assertIn("GitHub repository signal", homepage)
+        self.assertIn(
+            "https://github.com/aAAaqwq/AGI-Super-Team/stargazers",
+            homepage,
+        )
+        self.assertIn('data-star-count', homepage)
+        self.assertIn('querySelectorAll("[data-star-count]")', script)
+        self.assertRegex(homepage, r'assets/site\.css\?v=\d+')
+        self.assertRegex(homepage, r'assets/site\.js\?v=\d+')
+        self.assertNotIn("star-history-chart", homepage)
+        self.assertNotIn("data/star-history.json", script)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_site_contracts.py
+++ b/tests/test_site_contracts.py
@@ -100,7 +100,11 @@ class SiteContractTests(unittest.TestCase):
         script = (DOCS / "assets/site.js").read_text(encoding="utf-8")
         site_source = self.html + script
         self.assertIn("data/repo-stats.json", site_source)
-        self.assertIn("data/star-history.json", site_source)
+        self.assertNotIn("data/star-history.json", site_source)
+        self.assertIn(
+            "https://github.com/aAAaqwq/AGI-Super-Team/stargazers",
+            self.html,
+        )
         lowered = site_source.lower()
         self.assertNotIn("api.star-history.com", lowered)
         self.assertNotIn("blob/master", lowered)


### PR DESCRIPTION
## Problem

The changed page still looked blank because the public site retained an empty Star History frame. Browser verification also exposed a cache mismatch: new HTML could load with the old site.js, leaving the new count unresolved.

## Fix

- replace the empty history chart with visible current Stars and Forks cards
- use the existing GitHub repository stats cache and live API enhancement
- link directly to GitHub’s official Stargazers page
- remove the browser-side star-history SVG and JSON requests
- update all Star count surfaces rather than only the first matching node
- version site.css and site.js URLs to invalidate the old renderer cache
- add page-level regression contracts

## Real browser verification

Verified against the running Pages build:

- desktop light theme: 78 Stars, 18 Forks, and official CTA visible
- 390px mobile: values and CTA visible; no horizontal overflow
- mobile dark theme: values visible with correct contrast
- old star-history.svg and star-history.json requests absent after refresh
- versioned CSS and JavaScript requests return 200

## Automated verification

- 109 repository tests
- 23 installer scenarios
- strict validation: 0 errors / 0 warnings
- architecture classification: 100/100
- catalog, quality, and taxonomy gates passed
- gitleaks: no leaks

The existing local fund_monitor.py modification remains excluded.