### PR TITLE
fix(readme): embed interactive star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,12 @@ AGI Super Team is not a model, autonomous orchestrator, or agent runtime. Instal
 
 ## ⭐ GitHub Stars
 
-GitHub does not provide an official embeddable Star History chart. To avoid presenting third-party or reconstructed data as authoritative, this README links directly to GitHub's own Stargazers page.
+Track AGI Super Team's public growth over time. The live visualization is provided by Star History; click the chart to inspect the interactive timeline.
 
 <p align="center">
-  <a href="https://github.com/aAAaqwq/AGI-Super-Team/stargazers"><strong>⭐ View official Stargazers on GitHub</strong></a>
+  <a href="https://www.star-history.com/?type=date&amp;legend=top-left&amp;repos=aAAaqwq%2FAGI-Super-Team">
+    <img src="https://api.star-history.com/svg?repos=aAAaqwq/AGI-Super-Team&amp;type=Date&amp;legend=top-left" alt="AGI Super Team Star History chart">
+  </a>
+  <br>
+  <sub>Live chart by Star History · <a href="https://github.com/aAAaqwq/AGI-Super-Team/stargazers">View Stargazers on GitHub</a></sub>
 </p>

--- a/README_CN.md
+++ b/README_CN.md
@@ -259,8 +259,12 @@ AGI Super Team 不是模型、自治编排器或 Agent 运行时。安装文件�
 
 ## ⭐ GitHub Stars
 
-GitHub 没有提供官方、可嵌入 README 的 Star History 图。为避免把第三方或重建数据包装成官方事实，这里只链接 GitHub 自己的 Stargazers 页面。
+查看 AGI Super Team 的公开增长趋势。动态图由 Star History 提供；点击图表可打开交互式时间线。
 
 <p align="center">
-  <a href="https://github.com/aAAaqwq/AGI-Super-Team/stargazers"><strong>⭐ 在 GitHub 查看官方 Stargazers</strong></a>
+  <a href="https://www.star-history.com/?type=date&amp;legend=top-left&amp;repos=aAAaqwq%2FAGI-Super-Team">
+    <img src="https://api.star-history.com/svg?repos=aAAaqwq/AGI-Super-Team&amp;type=Date&amp;legend=top-left" alt="AGI Super Team Star History chart">
+  </a>
+  <br>
+  <sub>动态图由 Star History 提供 · <a href="https://github.com/aAAaqwq/AGI-Super-Team/stargazers">在 GitHub 查看 Stargazers</a></sub>
 </p>

--- a/tests/test_official_stars_contract.py
+++ b/tests/test_official_stars_contract.py
@@ -6,16 +6,19 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class OfficialStarsContractTests(unittest.TestCase):
-    def test_readmes_link_to_github_instead_of_claiming_an_official_history(self) -> None:
+    def test_readmes_label_and_link_the_star_history_visualization(self) -> None:
         for readme_name in ("README.md", "README_CN.md"):
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
                 self.assertIn(
-                    "https://github.com/aAAaqwq/AGI-Super-Team/stargazers",
+                    'alt="AGI Super Team Star History chart"',
                     readme,
                 )
-                self.assertNotIn("docs/assets/star-history", readme)
-                self.assertNotIn("api.star-history.com", readme)
+                self.assertIn(
+                    "https://api.star-history.com/svg?repos=aAAaqwq/AGI-Super-Team&amp;type=Date&amp;legend=top-left",
+                    readme,
+                )
+                self.assertIn("https://github.com/aAAaqwq/AGI-Super-Team/stargazers", readme)
 
     def test_pages_workflow_does_not_write_star_charts_to_the_repository(self) -> None:
         workflow = (ROOT / ".github/workflows/pages.yml").read_text(

--- a/tests/test_readme_contracts.py
+++ b/tests/test_readme_contracts.py
@@ -153,16 +153,15 @@ class ReadmeContractTests(unittest.TestCase):
             site,
         )
 
-    def test_stars_link_to_github_without_an_unofficial_history_chart(self) -> None:
+    def test_readmes_embed_the_interactive_star_history_chart(self) -> None:
         for readme in (self.english, self.chinese):
             self.assertIn(
-                "https://github.com/aAAaqwq/AGI-Super-Team/stargazers",
+                "https://api.star-history.com/svg?repos=aAAaqwq/AGI-Super-Team&amp;type=Date&amp;legend=top-left",
                 readme,
             )
-            self.assertNotIn("docs/assets/star-history", readme)
-            self.assertNotIn(
-                "aaaaqwq.github.io/AGI-Super-Team/assets/star-history.svg",
-                readme.lower(),
+            self.assertIn(
+                "https://www.star-history.com/?type=date&amp;legend=top-left&amp;repos=aAAaqwq%2FAGI-Super-Team",
+                readme,
             )
 
 


### PR DESCRIPTION
## Summary
- replace the static Stargazers-only section with the requested Star History SVG in both READMEs
- link the chart to the interactive Date view with the legend in the top-left
- retain a direct GitHub Stargazers fallback
- update README contracts for the public embed

## Verification
- 109 repository tests passed
- 23 installer scenarios passed
- strict validation: 0 errors / 0 warnings
- skill, taxonomy, and architecture checks passed
- staged gitleaks scan passed

## External dependency
The Markdown contract is correct, but `api.star-history.com` currently returns HTTP 500 for this repository. The fallback Stargazers link remains visible.