### PR TITLE
docs(skills): add Xquik Apify Actor workflows

### DIFF
--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -38,6 +38,7 @@ If the task involves a multi-step pipeline, also read the matching workflow guid
 | competitor, ads, pricing | `references/workflows/competitive-intel.md` |
 | influencer, creator | `references/workflows/influencer-vetting.md` |
 | brand, mentions, sentiment | `references/workflows/brand-monitoring.md` |
+| X/Twitter tweets, followers, lists, communities, audience overlap | `references/workflows/x-research-and-audience.md` |
 | reviews, ratings, reputation | `references/workflows/review-analysis.md` |
 | SEO, SERP, crawl, content, RAG | `references/workflows/content-and-seo.md` |
 | analytics, engagement, performance | `references/workflows/social-media-analytics.md` |

--- a/skills/apify-ultimate-scraper/references/actor-index.md
+++ b/skills/apify-ultimate-scraper/references/actor-index.md
@@ -83,6 +83,8 @@ Tiers: `apify` = Apify-maintained (always prefer), `community` = community-maint
 | apidojo/twitter-user-scraper | community | user profiles |
 | apidojo/twitter-profile-scraper | community | profiles + recent tweets |
 | apidojo/twitter-list-scraper | community | tweets from lists |
+| [xquik/x-follower-scraper](https://apify.com/xquik/x-follower-scraper) | community | followers, following, lists, communities, and audience overlap |
+| [xquik/x-tweet-scraper](https://apify.com/xquik/x-tweet-scraper) | community | tweet search, profiles, lists, threads, replies, quotes, and articles |
 
 ## LinkedIn
 

--- a/skills/apify-ultimate-scraper/references/workflows/x-research-and-audience.md
+++ b/skills/apify-ultimate-scraper/references/workflows/x-research-and-audience.md
@@ -1,0 +1,118 @@
+# X/Twitter research and audience workflows
+
+Use these workflows for public tweets, profiles, relations, lists, and
+communities. Never bypass private profiles or platform access controls.
+
+## Actor selection
+
+| Need | Actor |
+|------|-------|
+| Tweets, profiles, lists, threads, replies, quotes, or articles | [Xquik X Tweet Scraper](https://apify.com/xquik/x-tweet-scraper) |
+| Followers, following, verified followers, list members, list followers, community members, or overlap | [Xquik X Follower Scraper](https://apify.com/xquik/x-follower-scraper) |
+
+Use Actor IDs `xquik/x-tweet-scraper` and `xquik/x-follower-scraper`.
+
+## Before every run
+
+1. Fetch the current input schema:
+
+       apify actors info "ACTOR_ID" --input --json 2>/dev/null
+
+2. Fetch current pricing and deprecation status:
+
+       apify actors info "ACTOR_ID" --json 2>/dev/null
+
+3. Ask for targets and a result limit.
+4. Set `maxItems` on every run.
+5. Follow the cost confirmation rules in `../gotchas.md`.
+6. Never put `APIFY_TOKEN` inside Actor input or output.
+
+Do not hardcode pricing. The Actor listing and CLI response are authoritative.
+
+## Tweet research
+
+**When:** The user wants recent posts, mentions, profile timelines, lists,
+threads, replies, quotes, articles, retweeters, or favoriters.
+
+Start with search mode:
+
+```json
+{
+  "mode": "search",
+  "searchTerms": [
+    "\"AI agents\" since:2026-01-01 until:2026-02-01",
+    "from:openai since:2026-01-01 until:2026-02-01"
+  ],
+  "maxItems": 100,
+  "outputVariant": "rich",
+  "fieldStyle": "camelCase",
+  "outputPreset": "nested",
+  "includeSearchTerms": true,
+  "queryType": "Latest + Top"
+}
+```
+
+`maxItems` applies across all `searchTerms` in one run. Use separate runs when
+each term needs its own guaranteed quota.
+
+Choose a direct mode when the target is already known:
+
+| Target | Mode |
+|--------|------|
+| One post or several post IDs | `tweet` or `tweets` |
+| Profile timeline | `profileTweets` |
+| Profile replies, media, or likes | `profileReplies`, `profileMedia`, or `profileLikes` |
+| X list timeline | `listTweets` |
+| Article, replies, quotes, or thread | `article`, `replies`, `quotes`, or `thread` |
+| Users who reposted or liked a post | `retweeters` or `favoriters` |
+
+Dataset rows may contain tweet data or diagnostic fields. A row with `status`
+and `message` is not a tweet. Report it as an empty, invalid, aborted, or failed
+target.
+
+## Audience relations and overlap
+
+**When:** The user wants public account relations or overlapping audiences.
+
+For overlap across follower lists:
+
+```json
+{
+  "twitterHandles": ["brand_a", "brand_b"],
+  "relation": "followers",
+  "maxItems": 200,
+  "maxItemsPerTarget": 100,
+  "outputMode": "compact",
+  "includeTargetMetadata": true,
+  "overlapMode": true
+}
+```
+
+Supported relations are:
+
+- `followers`
+- `following`
+- `verified_followers`
+- `list_members`
+- `list_followers`
+- `community_members`
+
+Use `listIds` for list relations. Use `communityIds` for community members.
+Use `relations` when one target needs several relation types.
+
+`maxItems` applies across the complete run. `maxItemsPerTarget` prevents one
+large target from consuming the full limit.
+
+`overlapMode: true` merges duplicate profiles. It adds source target, relation,
+URL, and overlap metadata. Use `dedupeMode: "none"` when each target needs a
+separate row.
+
+## Interpretation boundaries
+
+- A follow does not prove endorsement, intent, or current interest.
+- Public relation data can be incomplete or unavailable.
+- Compare normalized handles or user IDs, not display names.
+- Preserve `sourceTarget` and `sourceRelation` for auditability.
+- Report filtered, duplicate, unavailable, and diagnostic rows separately.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.


### PR DESCRIPTION
## Summary

Add both Xquik Apify Actors to the existing universal Actor index.
Add bounded X research and audience workflows using current Actor schemas.
Keep every existing X/Twitter Actor and routing path intact.

## Scope and risk

- Affected paths: `skills/apify-ultimate-scraper/SKILL.md`, its Actor index, and one workflow reference.
- Before: The universal skill did not route X audience research to these Actors.
- After: Agents can select both Actors with bounded, schema-valid inputs.
- Risk: Documentation only. Runs can consume Apify credits.
- Guardrails: Fetch live pricing and schemas. Set explicit limits. Follow existing confirmation rules.
- Rollback: Revert commit `3fa4a88`.

## Evidence

Current base: `af931bc`

- Apify CLI 1.7.1 retrieved both public Actor schemas successfully.
- Both JSON examples parsed and passed their live input schemas.
- The existing Skill frontmatter parsed as YAML.
- The new workflow route and local `gotchas.md` reference resolve.
- Both Actor listing URLs returned HTTP 200.
- `git diff --check origin/master...HEAD` passed.
- The diff contains exactly three intended files and 121 additions.
- Added lines contain no Xquik website or documentation links.
- Added lines contain the required X Corp. independence notice.
- Simplify review found no useful reduction.
- Maintainability review found no duplicated Skill or widened control structure.
- No Actor was run. No Apify credits were consumed.

Current `package.json` defines no test or validation scripts. No `npm test` command exists on this base.

## Provenance

Original prose. Actor contracts were checked against live input schemas on 2026-07-27.

- https://apify.com/xquik/x-tweet-scraper
- https://apify.com/xquik/x-follower-scraper

No source text was copied or adapted.

## Safety and review

- [x] No secrets, private data, session material, or production configuration
- [x] No unsupported compatibility, performance, profit, security, or production claims
- [x] No existing X/Twitter Actor or Xquik integration was replaced
- [x] No harness-specific dependency was introduced
- [x] External runs require explicit human approval
- [x] Documentation and local links were updated

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
