### PR TITLE
fix(installer): restore Windows CLI support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Agent Markdown is content-addressed by config/agent-sources.lock.json.
+# Keep its bytes stable when the repository is checked out on Windows.
+agents/**/*.md text eol=lf

--- a/.github/workflows/validate-repository.yml
+++ b/.github/workflows/validate-repository.yml
@@ -43,3 +43,37 @@ jobs:
 
       - name: Enforce repository contracts
         run: npm run validate:strict
+
+  windows-packed-cli-smoke:
+    name: Test packed Windows CLI (Node ${{ matrix.node-version }})
+    runs-on: windows-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22", "24"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Pack and install CLI into an isolated prefix
+        id: packed-cli
+        shell: pwsh
+        run: |
+          $packOutput = npm pack --json --ignore-scripts | Out-String
+          if ($LASTEXITCODE -ne 0) { throw "npm pack failed with exit code $LASTEXITCODE" }
+          $pack = $packOutput | ConvertFrom-Json
+          $tarball = Join-Path $PWD $pack[0].filename
+          $prefix = Join-Path $env:RUNNER_TEMP "agi-super-team-prefix"
+          npm install --global --prefix $prefix --ignore-scripts $tarball
+          if ($LASTEXITCODE -ne 0) { throw "npm install failed with exit code $LASTEXITCODE" }
+          "shim=$(Join-Path $prefix 'agi-super-team.cmd')" >> $env:GITHUB_OUTPUT
+
+      - name: Run installed Windows CLI smoke
+        shell: pwsh
+        run: node tests/windows_cli_smoke.mjs "${{ steps.packed-cli.outputs.shim }}"

--- a/.github/workflows/validate-repository.yml
+++ b/.github/workflows/validate-repository.yml
@@ -45,13 +45,13 @@ jobs:
         run: npm run validate:strict
 
   windows-packed-cli-smoke:
-    name: Test packed Windows CLI (Node ${{ matrix.node-version }})
+    name: Test packed Windows CLI and primary harnesses (Node ${{ matrix.node-version }})
     runs-on: windows-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["22", "24"]
+        node-version: ["18", "20", "22", "24"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -76,4 +76,36 @@ jobs:
 
       - name: Run installed Windows CLI smoke
         shell: pwsh
+        run: node tests/windows_cli_smoke.mjs "${{ steps.packed-cli.outputs.shim }}"
+
+  unix-packed-cli-smoke:
+    name: Test packed ${{ matrix.os }} CLI and primary harnesses (Node ${{ matrix.node-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        node-version: ["18", "20", "22", "24"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Pack and install CLI into an isolated prefix
+        id: packed-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          tarball=$(node -e 'const fs=require("node:fs");const input=fs.readFileSync(0,"utf8");process.stdout.write(JSON.parse(input)[0].filename)' <<< "$(npm pack --json --ignore-scripts)")
+          prefix="${RUNNER_TEMP}/agi-super-team-prefix"
+          npm install --global --prefix "$prefix" --ignore-scripts "$PWD/$tarball"
+          echo "shim=$prefix/bin/agi-super-team" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke Claude Code, Codex, OpenClaw, and Hermes from packed CLI
+        shell: bash
         run: node tests/windows_cli_smoke.mjs "${{ steps.packed-cli.outputs.shim }}"

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -29,7 +29,7 @@ npx -y agi-super-team@latest --tool claude-code --install --connect
 npx -y agi-super-team@latest --tool claude-code --doctor
 ```
 
-Los comandos anteriores usan el paquete público de npm. Para automatizaciones reproducibles, sustituye `@latest` por una versión exacta, por ejemplo `@1.4.0`.
+Los comandos anteriores usan el paquete público de npm. Para automatizaciones reproducibles, sustituye `@latest` por una versión exacta, por ejemplo `@1.4.1`.
 
 La distribución npm mantiene accesibles los 817 puntos de entrada `SKILL.md` e incluye todos los archivos de cada Skill asignado por `config/team-manifest.json`. La colección [Skills originales de Daniel](./skills/original/) reúne el trabajo propio con procedencia revisada. Clona el repositorio si necesitas todos los recursos auxiliares de la biblioteca completa.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx -y agi-super-team@latest --tool claude-code --install --connect
 npx -y agi-super-team@latest --tool claude-code --doctor
 ```
 
-The commands above use the public npm package. For reproducible automation, replace `@latest` with an exact published version such as `@1.4.0`.
+The commands above use the public npm package. For reproducible automation, replace `@latest` with an exact published version such as `@1.4.1`.
 
 The npm distribution keeps all 817 `SKILL.md` entrypoints discoverable and includes the complete files for every Skill assigned by `config/team-manifest.json`. Browse the provenance-backed [Daniel's Original Skills](./skills/original/) collection for reviewed first-party work. Clone the repository when you need every auxiliary asset from the wider Skill library.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,7 +66,7 @@ npx -y agi-super-team@latest --tool claude-code --install --connect
 npx -y agi-super-team@latest --tool claude-code --doctor
 ```
 
-以上命令直接使用公开 npm 包。自动化场景建议把 `@latest` 换成明确版本，例如 `@1.4.0`，以获得可复现安装。
+以上命令直接使用公开 npm 包。自动化场景建议把 `@latest` 换成明确版本，例如 `@1.4.1`，以获得可复现安装。
 
 npm 发行包保留全部 817 个 `SKILL.md` 入口，并完整携带 `config/team-manifest.json` 实际分配的所有 Skills。经过来源审查的第一方作品可在 [Daniel 的原创 Skills](./skills/original/) 分类中查看；如果需要整个 Skill 库的全部辅助素材，请克隆仓库。
 

--- a/bin/adapters/openclaw.mjs
+++ b/bin/adapters/openclaw.mjs
@@ -5,6 +5,7 @@ import {
   statSync,
 } from "node:fs";
 import { isAbsolute, join, posix, resolve } from "node:path";
+import { isPhysicalStrictDescendant } from "../installer/path-safety.mjs";
 
 
 export const ADAPTER_ID = "openclaw";
@@ -51,7 +52,7 @@ function normalizeAgents(agents, allowEmpty = false) {
     const id = safeId(agent?.id, "agent id");
     if (seen.has(id)) throw new Error(`duplicate agent id: ${id}`);
     seen.add(id);
-    if (typeof agent.path !== "string" || !agent.path.startsWith("agents/")) throw new Error(`unsafe canonical agent path: ${agent.path}`);
+    if (agent.path !== `agents/${id}`) throw new Error(`unsafe canonical agent path: ${agent.path}`);
     return agent;
   });
   for (const required of ["ceo", "governor"]) {
@@ -70,7 +71,7 @@ function normalizeSpecialists(specialists, canonicalIds) {
     const runtimeId = `ast-${manager}-${id}`;
     if (seen.has(runtimeId)) throw new Error(`duplicate specialist id: ${runtimeId}`);
     seen.add(runtimeId);
-    if (typeof specialist.vendoredPath !== "string" || !specialist.vendoredPath.startsWith(`agents/${manager}/subagents/${id}/`)) {
+    if (specialist.vendoredPath !== `agents/${manager}/subagents/${id}/AGENTS.md`) {
       throw new Error(`unsafe specialist source: ${specialist.vendoredPath}`);
     }
     return specialist;
@@ -193,12 +194,13 @@ function renderAgentArtifacts(packageRoot, roots, agents, groups, specialists) {
   for (const agent of agents) {
     const sourceRoot = resolve(packageRoot, agent.path);
     const expectedRoot = resolve(packageRoot, "agents");
-    if (!sourceRoot.startsWith(`${expectedRoot}/`)) throw new Error(`unsafe canonical agent path: ${agent.path}`);
+    if (!isPhysicalStrictDescendant(expectedRoot, sourceRoot)) throw new Error(`unsafe canonical agent path: ${agent.path}`);
     const group = groups?.[agent.id];
     const targets = group ? managerTargets(agent.id, group, selected, canonicalIds) : [];
     for (const filename of ROLE_FILES) {
       const source = join(sourceRoot, filename);
       if (!existsSync(source)) continue;
+      if (!isPhysicalStrictDescendant(sourceRoot, source)) throw new Error(`unsafe role file: ${agent.path}/${filename}`);
       physicalFile(source, "role file");
       const original = readFileSync(source);
       const content = filename === "AGENTS.md" && group
@@ -214,7 +216,7 @@ function renderAgentArtifacts(packageRoot, roots, agents, groups, specialists) {
   for (const specialist of specialists) {
     const source = resolve(packageRoot, specialist.vendoredPath);
     const expectedRoot = resolve(packageRoot, "agents", specialist.manager, "subagents", specialist.id);
-    if (!source.startsWith(`${expectedRoot}/`)) throw new Error(`unsafe specialist source: ${specialist.vendoredPath}`);
+    if (!isPhysicalStrictDescendant(expectedRoot, source)) throw new Error(`unsafe specialist source: ${specialist.vendoredPath}`);
     physicalFile(source, "specialist role file");
     artifacts.push({
       relativePath: posix.join(roots.workspaceRoot, `ast-${specialist.manager}-${specialist.id}`, "AGENTS.md"),

--- a/bin/agi-super-team.mjs
+++ b/bin/agi-super-team.mjs
@@ -2,13 +2,18 @@
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmdirSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadCatalog, selectTools } from "./installer/catalog.mjs";
-import { applyPlan, buildPlan, doctor, safeRoot } from "./installer/core.mjs";
-import { connectHarness, writeHarnessReceipt } from "./installer/connect.mjs";
+import { applyPlanTransaction, buildPlan, doctor, safeRoot } from "./installer/core.mjs";
+import {
+  connectHarnessTransaction,
+  preflightHarnessConnection,
+  writeHarnessReceiptTransaction,
+} from "./installer/connect.mjs";
+import { spawnCli } from "./installer/process.mjs";
 
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -62,7 +67,8 @@ Content and actions:
   --doctor               Verify the selected installation (read-only)
   --install              Apply changes (default: preview)
   --connect              Connect installed Adapter state and write a pending receipt
-  --skip-plugin          Do not install/update the Codex plugin
+  --plugin               Explicitly install/update the Codex plugin (network side effect)
+  --skip-plugin          Compatibility alias that keeps plugin installation disabled
 
 Legacy Codex options remain supported:
   --team <id> --all-teams --all-agents --no-global-ceo
@@ -81,10 +87,10 @@ function parseArgs(argv) {
   );
   const options = {
     install: false, connect: false, doctor: false, listTools: false, listTeams: false,
-    tools: [], allTools: false, home: homedir(), projectDir: process.cwd(),
+    tools: [], allTools: false, home: homedir(), homeExplicit: false, projectDir: process.cwd(),
     includeAgents: true, includeSkills: true, teams: [], allTeams: true,
     allAgents: false, globalCeo: true, codexHome: process.env.CODEX_HOME || null,
-    plugin: true, legacy: false, includeCcoSpecialists: false, subagentManagers: [], allSubagents: false,
+    plugin: false, legacy: false, includeCcoSpecialists: false, subagentManagers: [], allSubagents: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
@@ -100,13 +106,14 @@ function parseArgs(argv) {
     else if (argument === "--all-teams") { options.allTeams = true; options.legacy = true; }
     else if (argument === "--all-agents") { options.allAgents = true; options.legacy = true; }
     else if (argument === "--no-global-ceo") { options.globalCeo = false; options.legacy = true; }
+    else if (argument === "--plugin") options.plugin = true;
     else if (argument === "--skip-plugin") options.plugin = false;
     else if (argument === "--list") { options.listTeams = true; options.legacy = true; }
     else if (argument === "--help" || argument === "-h") { usage(); process.exit(0); }
     else if (["--tool", "--home", "--project-dir", "--team", "--codex-home", "--with-subagents"].includes(argument)) {
       const value = requireValue(argv, index, argument);
       if (argument === "--tool") options.tools.push(value);
-      else if (argument === "--home") options.home = value;
+      else if (argument === "--home") { options.home = value; options.homeExplicit = true; }
       else if (argument === "--project-dir") options.projectDir = value;
       else if (argument === "--team") { options.teams.push(value); options.allTeams = false; options.legacy = true; }
       else if (argument === "--with-subagents") options.subagentManagers.push(value);
@@ -120,14 +127,14 @@ function parseArgs(argv) {
   if (options.install && options.doctor) throw new Error("choose either --install or --doctor");
   if (options.connect && !options.install) throw new Error("--connect requires --install");
   if (options.allTools && options.tools.length) throw new Error("choose --all-tools or --tool, not both");
-  if (options.legacy && options.tools.length && options.tools.some((id) => id !== "codex")) {
+  if (options.legacy && (options.allTools || options.tools.some((id) => id !== "codex"))) {
     throw new Error("legacy Team options only apply to the codex target");
   }
   if (!usesMultiTargetInterface) options.legacy = true;
   return options;
 }
 
-function resolveCodex() {
+function resolveCodex(environment) {
   const candidates = [
     process.env.CODEX_CLI,
     "codex",
@@ -135,24 +142,65 @@ function resolveCodex() {
     platform() === "darwin" ? "/Applications/ChatGPT.app/Contents/Resources/codex" : null,
   ].filter(Boolean);
   for (const candidate of candidates) {
-    const result = spawnSync(candidate, ["--version"], { encoding: "utf8" });
+    const result = spawnCli(candidate, ["--version"], { encoding: "utf8", env: environment });
     if (result.status === 0) return candidate;
   }
   throw new Error("Codex CLI not found; install Codex or pass --skip-plugin");
 }
 
-function installCodexPlugin(codexHome) {
-  const codex = resolveCodex();
+function installCodexPlugin(codexHome, packageVersion) {
   const environment = { ...process.env, CODEX_HOME: codexHome };
+  const codex = resolveCodex(environment);
+  const capabilities = [
+    ["plugin", "add", "--help"],
+    ["plugin", "marketplace", "add", "--help"],
+    ["plugin", "marketplace", "upgrade", "--help"],
+  ];
+  for (const arguments_ of capabilities) {
+    const result = spawnCli(codex, arguments_, { encoding: "utf8", env: environment });
+    if (result.status !== 0) {
+      throw new Error(`Codex CLI does not support required plugin command: ${arguments_.slice(0, -1).join(" ")}`);
+    }
+  }
   const commands = [
-    ["plugin", "marketplace", "add", "aAAaqwq/AGI-Super-Team", "--ref", "main"],
+    ["plugin", "marketplace", "add", "aAAaqwq/AGI-Super-Team", "--ref", `v${packageVersion}`],
     ["plugin", "marketplace", "upgrade", "agi-super-team"],
     ["plugin", "add", "agi-super-team-codex@agi-super-team"],
   ];
+  const completed = [];
   for (const arguments_ of commands) {
-    const result = spawnSync(codex, arguments_, { stdio: "inherit", env: environment });
-    if (result.status !== 0) throw new Error(`Codex plugin command failed: ${arguments_.join(" ")}`);
+    const result = spawnCli(codex, arguments_, { stdio: "inherit", env: environment });
+    if (result.status !== 0) {
+      const prior = completed.length
+        ? `; earlier explicit plugin steps completed (${completed.join(", ")}) and may require Codex plugin-manager cleanup`
+        : "";
+      throw new Error(`Codex plugin command failed: ${arguments_.join(" ")}${prior}`);
+    }
+    completed.push(arguments_.slice(0, -1).join(" "));
   }
+}
+
+function ensureDirectoryForExternalStage(path) {
+  const created = [];
+  let cursor = path;
+  while (!existsSync(cursor)) {
+    created.push(cursor);
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  mkdirSync(path, {recursive: true, mode: 0o700});
+  return () => {
+    for (const directory of created) {
+      try {
+        rmdirSync(directory);
+      } catch (error) {
+        if (error.code === "ENOENT") continue;
+        if (["ENOTEMPTY", "EEXIST"].includes(error.code)) break;
+        throw error;
+      }
+    }
+  };
 }
 
 function listTools(catalog) {
@@ -210,11 +258,29 @@ function configureLegacyCodex(tools, options) {
   };
 }
 
+function configureCodexRoot(tools, options, home) {
+  if (options.legacy || !options.codexHome || !tools.some((tool) => tool.id === "codex")) return tools;
+  const codexHome = safeRoot(options.codexHome, "Codex home");
+  const defaultCodexHome = safeRoot(join(home, ".codex"), "Codex home");
+  if (options.homeExplicit && relative(defaultCodexHome, codexHome) !== "") {
+    throw new Error(`--home conflicts with CODEX_HOME: ${codexHome}`);
+  }
+  if (codexHome === home) throw new Error(`refusing unsafe Codex home: ${codexHome}`);
+  return tools.map((tool) => tool.id === "codex" ? {
+    ...tool,
+    agentPaths: ["agents"],
+    connectionPath: join("agi-super-team", "connection.json"),
+    installationRoot: codexHome,
+  } : tool);
+}
+
 function printPlan(plan, options, tools) {
   const counts = Object.fromEntries(["add", "update", "unchanged"].map((status) => [status, plan.filter((item) => item.status === status).length]));
   console.log(`AGI Super Team — ${options.install ? "INSTALL" : "PREVIEW"}`);
   console.log(`Tools: ${tools.map((tool) => tool.id).join(", ")}`);
-  if (options.legacy) console.log(`Codex plugin: ${options.plugin ? "would install/update" : "skipped"}`);
+  if (tools.some((tool) => tool.id === "codex")) {
+    console.log(`Codex plugin: ${options.plugin ? "explicitly requested" : "disabled (add --plugin to opt in)"}`);
+  }
   console.log(`Files: add=${counts.add} update=${counts.update} unchanged=${counts.unchanged}`);
   for (const item of plan) if (item.status !== "unchanged") {
     console.log(`  ${item.status.padEnd(6)} ${item.tool.padEnd(14)} ${item.destination}`);
@@ -228,69 +294,152 @@ function main() {
     if (options.listTools) { listTools(catalog); return; }
     if (options.listTeams) { listTeams(catalog); return; }
     let tools = selectTools(catalog, options.tools, options.allTools);
+    if (options.connect) {
+      const unsupported = tools.filter((tool) => !tool.adapterModule);
+      if (unsupported.length) {
+        throw new Error(`${unsupported.map((tool) => tool.id).join(", ")} does not support --connect`);
+      }
+    }
     const configured = options.legacy
       ? configureLegacyCodex(tools, options)
       : { tools, home: safeRoot(options.home, "home") };
-    tools = configured.tools;
+    tools = configureCodexRoot(configured.tools, options, configured.home);
     const home = configured.home;
     const projectDir = options.projectDir ? safeRoot(options.projectDir, "project directory") : null;
     const legacyCodex = options.legacy && tools.length === 1 && tools[0].id === "codex";
-    const plan = buildPlan({
-      packageRoot: PACKAGE_ROOT,
-      catalog,
-      tools,
-      home,
-      projectDir,
-      includeAgents: options.includeAgents,
-      includeSkills: legacyCodex ? false : options.includeSkills,
-      agentIds: selectedAgentIds(catalog, options),
-      subagentManagers: selectedSubagentManagers(catalog, options),
-      includeCcoSpecialists: options.includeCcoSpecialists,
-      codexPayloadAll: options.allAgents,
+    const agentIds = selectedAgentIds(catalog, options);
+    const subagentManagers = selectedSubagentManagers(catalog, options);
+    if (agentIds) {
+      const missingManagers = [...subagentManagers].filter((id) => !agentIds.has(id));
+      if (missingManagers.length) {
+        throw new Error(`subagent manager is not in the selected Team: ${missingManagers.join(", ")}`);
+      }
+    }
+    const plan = tools.flatMap((tool) => {
+      const codexUsesCustomRoot = tool.id === "codex" && tool.installationRoot;
+      const common = {
+        packageRoot: PACKAGE_ROOT,
+        catalog,
+        tools: [tool],
+        projectDir,
+        agentIds,
+        subagentManagers,
+        includeCcoSpecialists: options.includeCcoSpecialists,
+        codexPayloadAll: options.allAgents,
+      };
+      const artifacts = buildPlan({
+        ...common,
+        home: tool.installationRoot || home,
+        includeAgents: options.includeAgents,
+        includeSkills: codexUsesCustomRoot ? false : legacyCodex ? false : options.includeSkills,
+      });
+      if (!codexUsesCustomRoot || !options.includeSkills) return artifacts;
+      const userSkills = buildPlan({
+        ...common,
+        home,
+        includeAgents: false,
+        includeSkills: true,
+      }).filter((item) => item.label !== "adapter:codex/connection");
+      return [...artifacts, ...userSkills];
     });
     if (options.doctor) {
       const result = doctor(plan, tools);
-      console.log(`AGI Super Team doctor: ${result.ok ? "HEALTHY" : "FAIL"} (${result.files} files, ${result.issues.length} issues)`);
+      console.log(`AGI Super Team doctor: ${result.ok ? "FILES_HEALTHY" : "FILES_FAIL"} (${result.files} files, ${result.issues.length} issues)`);
+      console.log("File checks only; connection/runtime status requires a receipt and harness canary.");
       for (const issue of result.issues.slice(0, 20)) console.log(`  ${issue}`);
       if (!result.ok) process.exitCode = 1;
       return;
     }
     printPlan(plan, options, tools);
     if (!options.install) { console.log("\nPreview only. Add --install to apply."); return; }
-    if (options.plugin && options.includeSkills && tools.some((tool) => tool.id === "codex")) {
-      const codexHome = options.codexHome ? resolve(options.codexHome) : join(home, ".codex");
-      mkdirSync(codexHome, {recursive: true, mode: 0o700});
-      installCodexPlugin(codexHome);
-    }
-    const backups = applyPlan(plan);
-    for (const backup of backups) console.log(`Backup: ${backup}`);
     if (options.connect) {
-      for (const tool of tools.filter((item) => item.adapterModule)) {
+      for (const tool of tools) {
         const item = plan.find((entry) => entry.label === `adapter:${tool.id}/connection`);
         if (!item) throw new Error(`missing generated connection spec for ${tool.id}`);
-        const connection = JSON.parse(item.content.toString("utf8"));
-        const connectionSha256 = createHash("sha256")
-          .update(item.content)
-          .digest("hex");
-        const receipt = {
-          ...connectHarness({
+        preflightHarnessConnection({
+          tool,
+          home: item.root,
+          connection: JSON.parse(item.content.toString("utf8")),
+        });
+      }
+    }
+    if (options.plugin && tools.some((tool) => tool.id === "codex")) {
+      const codexTool = tools.find((tool) => tool.id === "codex");
+      const codexHome = codexTool.installationRoot
+        || (options.codexHome ? resolve(options.codexHome) : join(home, ".codex"));
+      const cleanupEmptyDirectories = ensureDirectoryForExternalStage(codexHome);
+      const {version} = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8"));
+      try {
+        installCodexPlugin(codexHome, version);
+      } catch (error) {
+        try {
+          cleanupEmptyDirectories();
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [error, cleanupError],
+            `${error.message}; failed to clean the empty Codex plugin staging directory: ${cleanupError.message}`,
+          );
+        }
+        throw error;
+      }
+    }
+    const installation = applyPlanTransaction(plan);
+    const connections = [];
+    const receipts = [];
+    const connectedMessages = [];
+    try {
+      for (const backup of installation.backups) console.log(`Backup: ${backup}`);
+      if (options.connect) {
+        for (const tool of tools) {
+          const item = plan.find((entry) => entry.label === `adapter:${tool.id}/connection`);
+          if (!item) throw new Error(`missing generated connection spec for ${tool.id}`);
+          const connection = JSON.parse(item.content.toString("utf8"));
+          const connectionSha256 = createHash("sha256")
+            .update(item.content)
+            .digest("hex");
+          const transaction = connectHarnessTransaction({
             tool,
             home: item.root,
             connection,
-          }),
-          ...distributionMetadata(PACKAGE_ROOT),
-          connectionSha256,
-          generatedAt: new Date().toISOString(),
-        };
-        const receiptPath = writeHarnessReceipt({
-          root: item.root,
-          connectionPath: tool.connectionPath,
-          receipt,
-        });
-        console.log(`Connected: ${tool.id} (${receipt.status}); receipt: ${receiptPath}`);
+          });
+          connections.push(transaction);
+          const receipt = {
+            ...transaction.receipt,
+            ...distributionMetadata(PACKAGE_ROOT),
+            connectionSha256,
+            generatedAt: new Date().toISOString(),
+          };
+          const receiptTransaction = writeHarnessReceiptTransaction({
+            root: item.root,
+            connectionPath: tool.connectionPath,
+            receipt,
+          });
+          receipts.push(receiptTransaction);
+          connectedMessages.push(`Connected: ${tool.id} (${receipt.status}); receipt: ${receiptTransaction.path}`);
+        }
+      } else if (tools.some((tool) => tool.id === "openclaw")) {
+        console.log("OpenClaw note: artifacts were installed but workspaces were not registered; register them explicitly after review.");
       }
-    } else if (tools.some((tool) => tool.id === "openclaw")) {
-      console.log("OpenClaw note: artifacts were installed but workspaces were not registered; register them explicitly after review.");
+      for (const connection of connections) connection.commit();
+      for (const receipt of receipts) receipt.commit();
+      installation.commit();
+      for (const message of connectedMessages) console.log(message);
+    } catch (error) {
+      const rollbackErrors = [];
+      for (const receipt of [...receipts].reverse()) {
+        try { receipt.rollback(); } catch (rollbackError) { rollbackErrors.push(rollbackError); }
+      }
+      for (const connection of [...connections].reverse()) {
+        try { connection.rollback(); } catch (rollbackError) { rollbackErrors.push(rollbackError); }
+      }
+      try { installation.rollback(); } catch (rollbackError) { rollbackErrors.push(rollbackError); }
+      if (rollbackErrors.length) {
+        throw new AggregateError(
+          [error, ...rollbackErrors],
+          `${error.message}; rollback failed: ${rollbackErrors.map((item) => item.message).join("; ")}`,
+        );
+      }
+      throw error;
     }
     console.log("\nInstalled. Restart the selected CLI to load new Agents and Skills.");
   } catch (error) {

--- a/bin/installer/catalog.mjs
+++ b/bin/installer/catalog.mjs
@@ -1,6 +1,10 @@
 import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createHash } from "node:crypto";
+import { isPhysicalStrictDescendant } from "./path-safety.mjs";
+
+
+const SAFE_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 function regularFile(path, label) {
   if (!existsSync(path) || lstatSync(path).isSymbolicLink() || !statSync(path).isFile()) {
@@ -32,7 +36,7 @@ export function loadCatalog(packageRoot) {
   const ids = new Set();
   const priorityHarnesses = new Set(["claude-code", "codex", "openclaw", "hermes"]);
   for (const tool of adapters.tools) {
-    if (!tool.id || ids.has(tool.id) || !["global", "project"].includes(tool.scope)) {
+    if (!SAFE_ID.test(tool.id || "") || ids.has(tool.id) || !["global", "project"].includes(tool.scope)) {
       throw new Error(`invalid or duplicate CLI adapter: ${tool.id || "<missing>"}`);
     }
     if (!Array.isArray(tool.agentPaths) || !Array.isArray(tool.skillPaths)) {
@@ -48,32 +52,61 @@ export function loadCatalog(packageRoot) {
       ) {
         throw new Error(`priority harness ${tool.id} must declare the external Adapter contract`);
       }
-      regularFile(resolve(packageRoot, tool.adapterModule), `${tool.id} Adapter module`);
+      const adapterPath = resolve(packageRoot, tool.adapterModule);
+      const adapterRoot = resolve(packageRoot, "bin", "adapters");
+      if (
+        tool.adapterModule !== `bin/adapters/${tool.id}.mjs`
+        || !isPhysicalStrictDescendant(adapterRoot, adapterPath)
+      ) {
+        throw new Error(`unsafe ${tool.id} Adapter module: ${tool.adapterModule}`);
+      }
+      regularFile(adapterPath, `${tool.id} Adapter module`);
     }
     ids.add(tool.id);
   }
   if (!Array.isArray(manifest.agents) || manifest.agents.length !== 14) {
     throw new Error("team manifest must contain exactly 14 canonical agents");
   }
+  const agentsRoot = resolve(packageRoot, "agents");
   for (const agent of manifest.agents) {
     const expected = resolve(packageRoot, agent.path);
-    if (!expected.startsWith(`${resolve(packageRoot, "agents")}/`) || !statSync(expected).isDirectory()) {
+    if (
+      !SAFE_ID.test(agent.id || "")
+      || agent.path !== `agents/${agent.id}`
+      || !isPhysicalStrictDescendant(agentsRoot, expected)
+      || !lstatSync(expected).isDirectory()
+    ) {
       throw new Error(`invalid canonical Agent path: ${agent.path}`);
     }
   }
   if (hierarchy.requiredMaxDepth !== 2 || hierarchy.executionPolicy !== "wave" || !hierarchy.managers) {
     throw new Error("Agent hierarchy must define depth-2 wave execution");
   }
-  const sourceByRole = new Map(sourceLock.entries.map((entry) => [`${entry.manager}/${entry.id}`, entry]));
+  const sourceByRole = new Map(sourceLock.entries.map((entry) => {
+    if (
+      !SAFE_ID.test(entry.manager || "")
+      || !SAFE_ID.test(entry.id || "")
+      || entry.vendoredPath !== `agents/${entry.manager}/subagents/${entry.id}/AGENTS.md`
+    ) {
+      throw new Error(`invalid Agent source lock path: ${entry.vendoredPath}`);
+    }
+    return [`${entry.manager}/${entry.id}`, entry];
+  }));
   const specialistGroups = {};
   for (const [manager, settings] of Object.entries(hierarchy.managers)) {
+    if (!SAFE_ID.test(manager) || settings.routingFile !== `config/${manager}-specialists.json`) {
+      throw new Error(`invalid manager routing path: ${manager}`);
+    }
     const routePath = resolve(packageRoot, settings.routingFile);
-    if (!routePath.startsWith(`${resolve(packageRoot, "config")}/`)) throw new Error(`unsafe routing file: ${settings.routingFile}`);
+    if (!isPhysicalStrictDescendant(resolve(packageRoot, "config"), routePath)) {
+      throw new Error(`unsafe routing file: ${settings.routingFile}`);
+    }
     const registry = readJson(routePath, `${manager} specialist routing`);
     if (registry.parent !== manager || registry.requiredMaxDepth !== 2 || registry.maxConcurrentLeaves !== 2) {
       throw new Error(`invalid specialist routing contract: ${manager}`);
     }
     const ids = registry.specialists.map((item) => item.id);
+    if (ids.some((id) => !SAFE_ID.test(id || ""))) throw new Error(`invalid specialist id for manager: ${manager}`);
     if (new Set(ids).size !== ids.length || JSON.stringify(ids) !== JSON.stringify(settings.subagents)) {
       throw new Error(`hierarchy and routing order differ for manager: ${manager}`);
     }
@@ -82,7 +115,12 @@ export function loadCatalog(packageRoot) {
       if (!source || source.sourcePath !== specialist.sourcePath) throw new Error(`missing source lock: ${manager}/${specialist.id}`);
       const vendored = resolve(packageRoot, source.vendoredPath);
       const expectedRoot = resolve(packageRoot, "agents", manager, "subagents");
-      if (!vendored.startsWith(`${expectedRoot}/`)) throw new Error(`unsafe vendored path: ${source.vendoredPath}`);
+      if (
+        !isPhysicalStrictDescendant(agentsRoot, vendored)
+        || !isPhysicalStrictDescendant(expectedRoot, vendored)
+      ) {
+        throw new Error(`unsafe vendored path: ${source.vendoredPath}`);
+      }
       regularFile(vendored, "vendored subagent");
       const digest = createHash("sha256").update(readFileSync(vendored)).digest("hex");
       if (digest !== source.sha256) throw new Error(`vendored subagent drift: ${manager}/${specialist.id}`);

--- a/bin/installer/connect.mjs
+++ b/bin/installer/connect.mjs
@@ -1,17 +1,17 @@
-import { spawnSync } from "node:child_process";
 import {
   chmodSync,
   closeSync,
-  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
   openSync,
+  readFileSync,
   renameSync,
-  statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { spawnCli } from "./process.mjs";
 
 
 export function mergeManagedAgents(existing, managed) {
@@ -27,22 +27,36 @@ export function mergeManagedAgents(existing, managed) {
 }
 
 function run(command, args, {environment, input = undefined, allowMissingPath = false}) {
-  const result = spawnSync(command, args, {
+  const result = spawnCli(command, args, {
     encoding: "utf8",
     env: environment,
     input,
     maxBuffer: 16 * 1024 * 1024,
   });
   if (result.status !== 0 && !allowMissingPath) {
-    const detail = (result.stderr || result.stdout || "").trim();
-    throw new Error(`${command} ${args.join(" ")} failed${detail ? `: ${detail}` : ""}`);
+    throw commandFailure(command, args, result);
   }
   return result;
 }
 
-function parseJsonOutput(result, fallback) {
+function commandFailure(command, args, result) {
+  const detail = (
+    result.error?.message
+    || result.stderr
+    || result.stdout
+    || (result.signal ? `terminated by signal ${result.signal}` : "")
+  ).trim();
+  return new Error(`${command} ${args.join(" ")} failed${detail ? `: ${detail}` : ""}`);
+}
+
+function isMissingAgentsList(result) {
+  if (result.status === 0 || result.error || result.signal) return false;
+  const output = `${result.stderr || ""}\n${result.stdout || ""}`;
+  return /Config path not found:\s*agents\.list(?:[.\s]|$)/.test(output);
+}
+
+function parseJsonOutput(result) {
   const text = (result.stdout || "").trim();
-  if (!text || result.status !== 0) return fallback;
   try {
     return JSON.parse(text);
   } catch (error) {
@@ -50,23 +64,102 @@ function parseJsonOutput(result, fallback) {
   }
 }
 
-function backupOpenClawConfig(home) {
-  const stateRoot = join(home, ".openclaw");
-  const config = join(stateRoot, "openclaw.json");
-  if (!existsSync(config)) return null;
+function captureOpenClawConfig(home) {
+  const path = join(home, ".openclaw", "openclaw.json");
+  if (!existsSync(path)) {
+    return {path, exists: false, content: null, mode: null, device: null, inode: null};
+  }
+  const metadata = lstatSync(path);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(`refusing unsafe OpenClaw config: ${path}`);
+  }
+  return {
+    path,
+    exists: true,
+    content: readFileSync(path),
+    mode: metadata.mode & 0o777,
+    device: metadata.dev,
+    inode: metadata.ino,
+  };
+}
+
+function configMatches(snapshot) {
+  try {
+    if (!existsSync(snapshot.path)) return !snapshot.exists;
+    if (!snapshot.exists) return false;
+    const metadata = lstatSync(snapshot.path);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) return false;
+    return (
+      (metadata.mode & 0o777) === snapshot.mode
+      && metadata.dev === snapshot.device
+      && metadata.ino === snapshot.inode
+      && readFileSync(snapshot.path).equals(snapshot.content)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function backupOpenClawConfig(snapshot) {
+  if (!snapshot.exists) return null;
+  const stateRoot = dirname(snapshot.path);
+  const config = snapshot.path;
   const metadata = lstatSync(config);
-  if (metadata.isSymbolicLink() || !statSync(config).isFile()) {
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
     throw new Error(`refusing unsafe OpenClaw config: ${config}`);
   }
   const backupRoot = join(stateRoot, ".agi-super-team-backups");
-  mkdirSync(backupRoot, {recursive: true, mode: 0o700});
+  if (existsSync(backupRoot)) {
+    const backupMetadata = lstatSync(backupRoot);
+    if (backupMetadata.isSymbolicLink() || !backupMetadata.isDirectory()) {
+      throw new Error(`refusing unsafe OpenClaw backup directory: ${backupRoot}`);
+    }
+    chmodSync(backupRoot, 0o700);
+  } else {
+    mkdirSync(backupRoot, {recursive: true, mode: 0o700});
+  }
   const timestamp = new Date().toISOString().replaceAll(":", "").replaceAll(".", "");
-  const backup = join(backupRoot, `openclaw.json.${timestamp}.bak`);
-  copyFileSync(config, backup);
+  const backup = join(backupRoot, `openclaw.json.${timestamp}.${process.pid}.bak`);
+  const descriptor = openSync(backup, "wx", 0o600);
+  try {
+    writeFileSync(descriptor, snapshot.content);
+  } finally {
+    closeSync(descriptor);
+  }
+  chmodSync(backup, 0o600);
   return backup;
 }
 
-function connectOpenClaw({home, connection, environment}) {
+function restoreOpenClawConfig({original, expected, backup, failure}) {
+  if (!configMatches(expected)) {
+    const recovery = backup
+      ? `original backup preserved at ${backup}`
+      : "no original config existed; the current config was preserved";
+    throw new Error(
+      `${failure.message}; refusing automatic rollback because OpenClaw config changed concurrently; ${recovery}`,
+      {cause: failure},
+    );
+  }
+  if (!original.exists) {
+    if (existsSync(original.path)) unlinkSync(original.path);
+    return {status: "rolled-back", restored: "removed-new-config", backup};
+  }
+  const temporary = join(
+    dirname(original.path),
+    `.agi-super-team-openclaw-restore.${process.pid}.${Date.now()}.tmp`,
+  );
+  const descriptor = openSync(temporary, "wx", 0o600);
+  try {
+    writeFileSync(descriptor, original.content);
+  } finally {
+    closeSync(descriptor);
+  }
+  chmodSync(temporary, original.mode);
+  renameSync(temporary, original.path);
+  return {status: "rolled-back", restored: "original-config", backup};
+}
+
+function prepareOpenClawConnection({home, connection, environment}) {
   const command = environment.OPENCLAW_CLI || "openclaw";
   const stateRoot = join(home, ".openclaw");
   const env = {
@@ -74,12 +167,16 @@ function connectOpenClaw({home, connection, environment}) {
     OPENCLAW_STATE_DIR: stateRoot,
   };
   const version = run(command, ["--version"], {environment: env}).stdout.trim();
+  const originalConfig = captureOpenClawConfig(home);
   const currentResult = run(
     command,
     ["config", "get", "agents.list", "--json"],
     {environment: env, allowMissingPath: true},
   );
-  const existing = parseJsonOutput(currentResult, []);
+  if (currentResult.status !== 0 && !isMissingAgentsList(currentResult)) {
+    throw commandFailure(command, ["config", "get", "agents.list", "--json"], currentResult);
+  }
+  const existing = currentResult.status === 0 ? parseJsonOutput(currentResult) : [];
   if (!Array.isArray(existing)) throw new Error("OpenClaw agents.list must be an array");
   const managed = connection?.configPatch?.agents?.list;
   if (!Array.isArray(managed)) throw new Error("OpenClaw connection spec is missing configPatch.agents.list");
@@ -109,14 +206,71 @@ function connectOpenClaw({home, connection, environment}) {
     ],
     {environment: env, input},
   );
-  const backup = backupOpenClawConfig(home);
-  run(
-    command,
-    ["config", "patch", "--stdin", "--replace-path", "agents.list"],
-    {environment: env, input},
-  );
-  run(command, ["config", "validate", "--json"], {environment: env});
+  if (!configMatches(originalConfig)) {
+    throw new Error("OpenClaw config changed while preparing the connection; retry without concurrent edits");
+  }
   return {
+    command,
+    env,
+    version,
+    originalConfig,
+    existing,
+    managed,
+    input,
+  };
+}
+
+function connectOpenClawTransaction({home, connection, environment}) {
+  const prepared = prepareOpenClawConnection({home, connection, environment});
+  const {
+    command,
+    env,
+    version,
+    originalConfig,
+    existing,
+    managed,
+    input,
+  } = prepared;
+  const backup = backupOpenClawConfig(originalConfig);
+  if (!configMatches(originalConfig)) {
+    if (backup && existsSync(backup)) unlinkSync(backup);
+    throw new Error("OpenClaw config changed before applying the connection; retry without concurrent edits");
+  }
+  try {
+    run(
+      command,
+      ["config", "patch", "--stdin", "--replace-path", "agents.list"],
+      {environment: env, input},
+    );
+  } catch (failure) {
+    const failedPatchConfig = captureOpenClawConfig(home);
+    const rollback = restoreOpenClawConfig({
+      original: originalConfig,
+      expected: failedPatchConfig,
+      backup,
+      failure,
+    });
+    throw new Error(
+      `${failure.message}; OpenClaw config rollback completed (${rollback.restored})${backup ? `; backup preserved at ${backup}` : ""}`,
+      {cause: failure},
+    );
+  }
+  const appliedConfig = captureOpenClawConfig(home);
+  try {
+    run(command, ["config", "validate", "--json"], {environment: env});
+  } catch (failure) {
+    const rollback = restoreOpenClawConfig({
+      original: originalConfig,
+      expected: appliedConfig,
+      backup,
+      failure,
+    });
+    throw new Error(
+      `${failure.message}; OpenClaw config rollback completed (${rollback.restored})${backup ? `; backup preserved at ${backup}` : ""}`,
+      {cause: failure},
+    );
+  }
+  const receipt = {
     schemaVersion: 1,
     harness: "openclaw",
     status: "connected-structural",
@@ -139,9 +293,58 @@ function connectOpenClaw({home, connection, environment}) {
       "No inbound channel binding was created.",
     ],
   };
+  let state = "active";
+  return {
+    receipt,
+    rollback() {
+      if (state !== "active") return {status: "not-active", state, backup};
+      const rollback = restoreOpenClawConfig({
+        original: originalConfig,
+        expected: appliedConfig,
+        backup,
+        failure: new Error("OpenClaw connection rollback requested"),
+      });
+      state = "rolled-back";
+      return rollback;
+    },
+    commit() {
+      if (state === "committed") return {status: "committed", backup};
+      if (state !== "active") return {status: "not-active", state, backup};
+      state = "committed";
+      return {status: "committed", backup};
+    },
+  };
 }
 
-export function connectHarness({
+export function preflightHarnessConnection({
+  tool,
+  home,
+  connection,
+  environment = process.env,
+}) {
+  if (!tool?.id) throw new Error("preflightHarnessConnection requires a tool id");
+  if (!home) throw new Error("preflightHarnessConnection requires a home path");
+  if (tool.id !== "openclaw") {
+    return {
+      harness: tool.id,
+      status: "ready",
+      checks: ["adapter-artifacts-plan-ready"],
+    };
+  }
+  const prepared = prepareOpenClawConnection({home, connection, environment});
+  return {
+    harness: "openclaw",
+    status: "ready",
+    version: prepared.version,
+    managedAgents: prepared.managed.map((entry) => entry.id),
+    preservedAgents: prepared.existing
+      .filter((entry) => !prepared.managed.some((item) => item.id === entry.id))
+      .map((entry) => entry.id),
+    checks: ["cli-version", "config-get", "config-patch-dry-run"],
+  };
+}
+
+export function connectHarnessTransaction({
   tool,
   home,
   connection,
@@ -150,9 +353,9 @@ export function connectHarness({
   if (!tool?.id) throw new Error("connectHarness requires a tool id");
   if (!home) throw new Error("connectHarness requires a home path");
   if (tool.id === "openclaw") {
-    return connectOpenClaw({home, connection, environment});
+    return connectOpenClawTransaction({home, connection, environment});
   }
-  return {
+  const receipt = {
     schemaVersion: 1,
     harness: tool.id,
     status: "filesystem-connected",
@@ -162,6 +365,27 @@ export function connectHarness({
       "The harness client did not execute a model-backed trigger or delegation canary.",
     ],
   };
+  let state = "active";
+  return {
+    receipt,
+    rollback() {
+      if (state !== "active") return {status: "not-active", state, backup: null};
+      state = "rolled-back";
+      return {status: "not-required", backup: null};
+    },
+    commit() {
+      if (state === "committed") return {status: "committed", backup: null};
+      if (state !== "active") return {status: "not-active", state, backup: null};
+      state = "committed";
+      return {status: "committed", backup: null};
+    },
+  };
+}
+
+export function connectHarness(options) {
+  const transaction = connectHarnessTransaction(options);
+  transaction.commit();
+  return transaction.receipt;
 }
 
 function assertSafeReceiptPath(root, path) {
@@ -194,7 +418,52 @@ function assertSafeReceiptPath(root, path) {
   return resolvedPath;
 }
 
-export function writeHarnessReceipt({root, connectionPath, receipt}) {
+function captureReceipt(path) {
+  if (!existsSync(path)) {
+    return {path, exists: false, content: null, mode: null, device: null, inode: null};
+  }
+  const metadata = lstatSync(path);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) {
+    throw new Error(`refusing unsafe receipt destination: ${path}`);
+  }
+  return {
+    path,
+    exists: true,
+    content: readFileSync(path),
+    mode: metadata.mode & 0o777,
+    device: metadata.dev,
+    inode: metadata.ino,
+  };
+}
+
+function receiptMatches(snapshot) {
+  try {
+    if (!existsSync(snapshot.path)) return !snapshot.exists;
+    if (!snapshot.exists) return false;
+    const metadata = lstatSync(snapshot.path);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) return false;
+    return (
+      (metadata.mode & 0o777) === snapshot.mode
+      && metadata.dev === snapshot.device
+      && metadata.ino === snapshot.inode
+      && readFileSync(snapshot.path).equals(snapshot.content)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function writePrivateFile(path, content, mode = 0o600) {
+  const descriptor = openSync(path, "wx", mode);
+  try {
+    writeFileSync(descriptor, content);
+  } finally {
+    closeSync(descriptor);
+  }
+  chmodSync(path, mode);
+}
+
+export function writeHarnessReceiptTransaction({root, connectionPath, receipt}) {
   if (!root) throw new Error("writeHarnessReceipt requires a target root");
   if (
     typeof connectionPath !== "string"
@@ -209,17 +478,93 @@ export function writeHarnessReceipt({root, connectionPath, receipt}) {
     join(root, dirname(connectionPath), "receipt.json"),
   );
   mkdirSync(dirname(path), {recursive: true, mode: 0o700});
+  const original = captureReceipt(path);
+  const nonce = `${process.pid}.${Date.now()}`;
+  const backup = original.exists
+    ? join(dirname(path), `.agi-super-team-receipt-backup.${nonce}.tmp`)
+    : null;
+  if (backup) writePrivateFile(backup, original.content);
+  const backupSnapshot = backup ? captureReceipt(backup) : null;
   const temporary = join(
     dirname(path),
-    `.agi-super-team-receipt.${process.pid}.${Date.now()}.tmp`,
+    `.agi-super-team-receipt.${nonce}.tmp`,
   );
-  const descriptor = openSync(temporary, "wx", 0o600);
+  let temporarySnapshot = null;
   try {
-    writeFileSync(descriptor, `${JSON.stringify(receipt, null, 2)}\n`);
-  } finally {
-    closeSync(descriptor);
+    writePrivateFile(temporary, `${JSON.stringify(receipt, null, 2)}\n`);
+    temporarySnapshot = captureReceipt(temporary);
+    assertSafeReceiptPath(root, path);
+    if (!receiptMatches(original)) {
+      throw new Error(
+        "refusing receipt replacement because the destination changed concurrently before write",
+      );
+    }
+    renameSync(temporary, path);
+  } catch (error) {
+    const preserved = [];
+    for (const artifact of [temporarySnapshot, backupSnapshot]) {
+      if (!artifact) continue;
+      try {
+        if (receiptMatches(artifact)) unlinkSync(artifact.path);
+        else if (existsSync(artifact.path)) preserved.push(artifact.path);
+      } catch {
+        preserved.push(artifact.path);
+      }
+    }
+    if (preserved.length) {
+      throw new Error(
+        `${error.message}; transaction artifacts preserved for inspection at ${preserved.join(", ")}`,
+        {cause: error},
+      );
+    }
+    throw error;
   }
-  chmodSync(temporary, 0o600);
-  renameSync(temporary, path);
-  return path;
+  const applied = captureReceipt(path);
+  let state = "active";
+  let commitResult = null;
+  return {
+    path,
+    rollback() {
+      if (state !== "active") return {status: "not-active", state, backup};
+      if (!receiptMatches(applied)) {
+        const recovery = backup
+          ? `original receipt backup preserved at ${backup}`
+          : "no original receipt existed; the current receipt was preserved";
+        throw new Error(
+          `refusing automatic receipt rollback because the receipt changed concurrently; ${recovery}`,
+        );
+      }
+      if (original.exists) {
+        const restore = join(
+          dirname(path),
+          `.agi-super-team-receipt-restore.${process.pid}.${Date.now()}.tmp`,
+        );
+        writePrivateFile(restore, original.content, original.mode);
+        renameSync(restore, path);
+      } else if (existsSync(path)) {
+        unlinkSync(path);
+      }
+      if (backup && existsSync(backup)) unlinkSync(backup);
+      state = "rolled-back";
+      return {status: "rolled-back", backup: null};
+    },
+    commit() {
+      if (state === "committed") return commitResult;
+      if (state !== "active") return {status: "not-active", state, backup};
+      state = "committed";
+      try {
+        if (backup && existsSync(backup)) unlinkSync(backup);
+        commitResult = {status: "committed", backup: null};
+      } catch {
+        commitResult = {status: "committed", backup, backupPreserved: true};
+      }
+      return commitResult;
+    },
+  };
+}
+
+export function writeHarnessReceipt(options) {
+  const transaction = writeHarnessReceiptTransaction(options);
+  transaction.commit();
+  return transaction.path;
 }

--- a/bin/installer/core.mjs
+++ b/bin/installer/core.mjs
@@ -8,12 +8,15 @@ import {
   mkdtempSync,
   openSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import * as nativePath from "node:path";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { adapterFor } from "../adapters/index.mjs";
 import {
@@ -32,13 +35,24 @@ import {
   walkFiles,
 } from "./render.mjs";
 
-export function safeRoot(input, label) {
-  const path = resolve(input);
-  if (path === resolve("/") || !input) throw new Error(`refusing unsafe ${label}: ${path}`);
-  if (existsSync(path) && (lstatSync(path).isSymbolicLink() || !statSync(path).isDirectory())) {
-    throw new Error(`invalid ${label}: ${path}`);
+export function safeRoot(input, label, pathApi = nativePath) {
+  const path = pathApi.resolve(input);
+  if (!input || pathApi.parse(path).root === path) throw new Error(`refusing unsafe ${label}: ${path}`);
+  if (pathApi !== nativePath) return path;
+  if (existsSync(path)) {
+    if (lstatSync(path).isSymbolicLink() || !statSync(path).isDirectory()) {
+      throw new Error(`invalid ${label}: ${path}`);
+    }
+    return realpathSync.native(path);
   }
-  return path;
+  let ancestor = path;
+  while (!existsSync(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) throw new Error(`invalid ${label}: ${path}`);
+    ancestor = parent;
+  }
+  if (!statSync(ancestor).isDirectory()) throw new Error(`invalid ${label}: ${path}`);
+  return resolve(realpathSync.native(ancestor), relative(ancestor, path));
 }
 
 export function readSafe(path) {
@@ -46,6 +60,13 @@ export function readSafe(path) {
   const metadata = lstatSync(path);
   if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error(`refusing unsafe destination: ${path}`);
   return readFileSync(path);
+}
+
+export function modesEquivalent(actualMode, expectedMode, platform = process.platform) {
+  const actual = actualMode & 0o777;
+  const expected = expectedMode & 0o777;
+  if (platform === "win32") return Boolean(actual & 0o200) === Boolean(expected & 0o200);
+  return actual === expected;
 }
 
 function destination(root, configuredPath, child = "") {
@@ -57,7 +78,7 @@ function destination(root, configuredPath, child = "") {
 
 function assertSafeAncestors(root, path) {
   const rel = relative(root, path);
-  if (rel === ".." || rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
+  if (rel === "" || rel === ".." || rel.startsWith(`..${nativePath.sep}`) || isAbsolute(rel)) {
     throw new Error(`refusing destination outside target root: ${path}`);
   }
   let cursor = root;
@@ -72,9 +93,10 @@ function assertSafeAncestors(root, path) {
   }
 }
 
-function addFile(plan, tool, root, path, content, label) {
+function addFile(plan, tool, root, path, content, label, mode = 0o600) {
   assertSafeAncestors(root, path);
   const baseline = readSafe(path);
+  const baselineMode = baseline === null ? null : lstatSync(path).mode & 0o777;
   const rendered = Buffer.isBuffer(content) ? content : Buffer.from(content);
   plan.push({
     tool: tool.id,
@@ -82,8 +104,16 @@ function addFile(plan, tool, root, path, content, label) {
     destination: path,
     content: rendered,
     baseline,
+    baselineMode,
+    mode,
+    platform: tool.platform ?? process.platform,
     label,
-    status: baseline === null ? "add" : Buffer.compare(baseline, rendered) === 0 ? "unchanged" : "update",
+    status: baseline === null
+      ? "add"
+      : Buffer.compare(baseline, rendered) === 0
+        && modesEquivalent(baselineMode, mode, tool.platform)
+        ? "unchanged"
+        : "update",
   });
 }
 
@@ -116,13 +146,13 @@ function planSkills(plan, catalog, tool, root, assignedSkills) {
         }
         const sourceFiles = walkFiles(sourceRoot);
         const targetFiles = walkFiles(resolved);
-        const targetByPath = new Map(
-          targetFiles.map((file) => [file.relative, file.content]),
-        );
+        const targetByPath = new Map(targetFiles.map((file) => [file.relative, file]));
         const exact = sourceFiles.length === targetFiles.length
           && sourceFiles.every((file) => {
             const candidate = targetByPath.get(file.relative);
-            return candidate && Buffer.compare(file.content, candidate) === 0;
+            return candidate
+              && modesEquivalent(candidate.mode, file.mode, tool.platform)
+              && Buffer.compare(file.content, candidate.content) === 0;
           });
         if (!exact) {
           throw new Error(`refusing mismatched Skill symlink: ${targetRoot}`);
@@ -130,7 +160,7 @@ function planSkills(plan, catalog, tool, root, assignedSkills) {
         continue;
       }
       for (const file of walkFiles(sourceRoot)) {
-        addFile(plan, tool, root, destination(root, configured, join(skill, file.relative)), file.content, `skill:${skill}`);
+        addFile(plan, tool, root, destination(root, configured, join(skill, file.relative)), file.content, `skill:${skill}`, file.mode);
       }
     }
   }
@@ -151,7 +181,7 @@ function renderAgents(plan, packageRoot, catalog, tool, root, agents, codexPaylo
     if (codexPayloadAll) {
       const payload = join(packageRoot, "plugins", "agi-super-team-codex", "payload", "agents");
       for (const file of walkFiles(payload)) {
-        addFile(plan, tool, root, destination(root, tool.agentPaths[0], file.relative), file.content, `agent:${file.relative}`);
+        addFile(plan, tool, root, destination(root, tool.agentPaths[0], file.relative), file.content, `agent:${file.relative}`, file.mode);
       }
     } else {
       for (const agent of agents.filter((item) => item.id !== "ceo")) {
@@ -229,7 +259,7 @@ function renderSpecialists(plan, packageRoot, tool, root, specialists) {
   if (mode !== "combined-rules") throw new Error(`unsupported specialist mode for ${tool.id}: ${mode}`);
 }
 
-export function buildPlan({ packageRoot, catalog, tools, home, projectDir, includeAgents, includeSkills, agentIds, subagentManagers = new Set(), includeCcoSpecialists = false, codexPayloadAll = false }) {
+export function buildPlan({ packageRoot, catalog, tools, home, projectDir, includeAgents, includeSkills, agentIds, subagentManagers = new Set(), includeCcoSpecialists = false, codexPayloadAll = false, platform = process.platform }) {
   const plan = [];
   const selected = agentIds ? catalog.agents.filter((agent) => agentIds.has(agent.id)) : catalog.agents;
   const managers = new Set(subagentManagers);
@@ -237,7 +267,8 @@ export function buildPlan({ packageRoot, catalog, tools, home, projectDir, inclu
   const groups = Object.fromEntries([...managers].map((manager) => [manager, catalog.specialistGroups[manager]]));
   const specialists = Object.values(groups).flatMap((group) => group.specialists);
   const assignedSkills = selectedAssignedSkills(catalog, selected);
-  for (const tool of tools) {
+  for (const configuredTool of tools) {
+    const tool = { ...configuredTool, platform };
     const root = tool.scope === "project" ? projectDir : home;
     if (!root) throw new Error(`${tool.id} is project-scoped; pass --project-dir <path>`);
     if (tool.agentMode === "harness-adapter") {
@@ -320,64 +351,230 @@ export function buildPlan({ packageRoot, catalog, tools, home, projectDir, inclu
   return plan;
 }
 
-function atomicWrite(path, content) {
+function atomicWrite(path, content, mode = 0o600) {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   if (existsSync(path) && lstatSync(path).isSymbolicLink()) throw new Error(`refusing symlinked destination: ${path}`);
   const temporary = join(dirname(path), `.agi-super-team.${process.pid}.${Date.now()}.tmp`);
   const descriptor = openSync(temporary, "wx", 0o600);
   try { writeFileSync(descriptor, content); } finally { closeSync(descriptor); }
-  chmodSync(temporary, 0o600);
+  chmodSync(temporary, mode);
   renameSync(temporary, path);
 }
 
-export function applyPlan(plan) {
-  const changed = plan.filter((item) => item.status !== "unchanged");
-  if (!changed.length) return [];
-  const roots = [...new Set(changed.map((item) => item.root))];
+function baselineMatches(item, current) {
+  if (current === null || item.baseline === null) return current === null && item.baseline === null;
+  if (Buffer.compare(current, item.baseline) !== 0) return false;
+  return item.baselineMode === null
+    || item.baselineMode === undefined
+    || modesEquivalent(lstatSync(item.destination).mode, item.baselineMode, item.platform);
+}
+
+function releaseLocks(locks) {
+  for (const lock of locks) {
+    closeSync(lock.descriptor);
+    if (existsSync(lock.path)) unlinkSync(lock.path);
+  }
+}
+
+function acquireLocks(roots) {
   const locks = [];
-  const backups = [];
-  const written = [];
   try {
     for (const root of roots) {
-      mkdirSync(root, { recursive: true, mode: 0o700 });
       const lock = join(root, ".agi-super-team-installer.lock");
       locks.push({ path: lock, descriptor: openSync(lock, "wx", 0o600) });
     }
+    return locks;
+  } catch (error) {
+    releaseLocks(locks);
+    throw error;
+  }
+}
+
+function ensureDirectory(path, createdDirectories) {
+  const missing = [];
+  let cursor = resolve(path);
+  while (!existsSync(cursor)) {
+    missing.unshift(cursor);
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  for (const directory of missing) {
+    try {
+      mkdirSync(directory, { mode: 0o700 });
+      const metadata = lstatSync(directory);
+      createdDirectories.push({ path: directory, dev: metadata.dev, ino: metadata.ino });
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      const metadata = lstatSync(directory);
+      if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+        throw new Error(`refusing unsafe destination directory: ${directory}`);
+      }
+    }
+  }
+}
+
+function removeEmptyCreatedDirectories(createdDirectories) {
+  const byPath = new Map(createdDirectories.map((entry) => [entry.path, entry]));
+  const directories = [...byPath.values()].sort((left, right) => right.path.length - left.path.length);
+  for (const directory of directories) {
+    if (!existsSync(directory.path)) continue;
+    const metadata = lstatSync(directory.path);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) continue;
+    if (metadata.dev !== directory.dev || metadata.ino !== directory.ino) continue;
+    if (readdirSync(directory.path).length === 0) rmdirSync(directory.path);
+  }
+}
+
+function assertBackupsUnchanged(backupFiles) {
+  for (const backup of backupFiles) {
+    const current = readSafe(backup.path);
+    if (current === null
+      || Buffer.compare(current, backup.content) !== 0
+      || !modesEquivalent(lstatSync(backup.path).mode, backup.mode, backup.platform)) {
+      throw new Error(`backup changed after install; refusing rollback: ${backup.path}`);
+    }
+  }
+}
+
+function removeBackupFiles(backupFiles) {
+  for (const backup of [...backupFiles].reverse()) unlinkSync(backup.path);
+}
+
+function restoreWritten(written) {
+  for (const item of written) {
+    const current = readSafe(item.destination);
+    const currentMode = current === null ? null : lstatSync(item.destination).mode & 0o777;
+    if (current === null
+      || Buffer.compare(current, item.content) !== 0
+      || !modesEquivalent(currentMode, item.installedMode, item.platform)) {
+      throw new Error(`destination changed after install; refusing rollback: ${item.destination}`);
+    }
+  }
+  for (const item of [...written].reverse()) {
+    if (item.baseline === null) unlinkSync(item.destination);
+    else atomicWrite(item.destination, item.baseline, item.baselineMode);
+  }
+}
+
+function completedTransaction(backups, written, backupFiles = [], createdDirectories = []) {
+  let active = true;
+  return {
+    backups: backups.map((entry) => entry.path),
+    commit() {
+      active = false;
+    },
+    rollback() {
+      if (!active) throw new Error("installer transaction is no longer active");
+      const roots = [...new Set(written.map((item) => item.root))];
+      const locks = acquireLocks(roots);
+      let restored = false;
+      try {
+        assertBackupsUnchanged(backupFiles);
+        restoreWritten(written);
+        removeBackupFiles(backupFiles);
+        active = false;
+        restored = true;
+      } finally {
+        releaseLocks(locks);
+      }
+      if (restored) removeEmptyCreatedDirectories(createdDirectories);
+    },
+  };
+}
+
+export function applyPlanTransaction(plan) {
+  const changed = plan
+    .filter((item) => item.status !== "unchanged")
+    .map((item) => ({ ...item }));
+  if (!changed.length) return completedTransaction([], []);
+  const roots = [...new Set(changed.map((item) => item.root))];
+  let locks = [];
+  const backups = [];
+  const backupFiles = [];
+  const createdDirectories = [];
+  const written = [];
+  try {
+    for (const root of roots) {
+      const resolvedRoot = resolve(root);
+      if (safeRoot(root, "target root") !== resolvedRoot) {
+        throw new Error(`refusing unsafe target root: ${root}`);
+      }
+    }
+    for (const item of changed) {
+      assertSafeAncestors(item.root, item.destination);
+      const current = readSafe(item.destination);
+      if (!baselineMatches(item, current)) throw new Error(`destination changed after preview: ${item.destination}`);
+      item.mode ??= 0o600;
+      item.baselineMode ??= current === null ? null : lstatSync(item.destination).mode & 0o777;
+    }
+    for (const root of roots) {
+      ensureDirectory(root, createdDirectories);
+    }
+    locks = acquireLocks(roots);
     for (const root of roots) {
       if (changed.some((item) => item.root === root && item.baseline !== null)) {
         const backupRoot = join(root, ".agi-super-team-backups");
-        mkdirSync(backupRoot, { recursive: true, mode: 0o700 });
-        backups.push({ root, path: mkdtempSync(join(backupRoot, `${new Date().toISOString().replaceAll(":", "")}-`)) });
+        ensureDirectory(backupRoot, createdDirectories);
+        const backupPath = mkdtempSync(join(backupRoot, `${new Date().toISOString().replaceAll(":", "")}-`));
+        const backupMetadata = lstatSync(backupPath);
+        createdDirectories.push({ path: backupPath, dev: backupMetadata.dev, ino: backupMetadata.ino });
+        backups.push({ root, path: backupPath });
       }
     }
     for (const item of changed) {
       const current = readSafe(item.destination);
-      const stable = current === null ? item.baseline === null : item.baseline !== null && Buffer.compare(current, item.baseline) === 0;
-      if (!stable) throw new Error(`destination changed after preview: ${item.destination}`);
+      if (!baselineMatches(item, current)) throw new Error(`destination changed after preview: ${item.destination}`);
       if (item.baseline !== null) {
         const backup = backups.find((entry) => entry.root === item.root);
         const target = join(backup.path, relative(item.root, item.destination));
-        mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+        ensureDirectory(dirname(target), createdDirectories);
         copyFileSync(item.destination, target);
+        chmodSync(target, item.baselineMode);
+        backupFiles.push({
+          path: target,
+          content: item.baseline,
+          mode: lstatSync(target).mode & 0o777,
+          platform: item.platform,
+        });
       }
-      atomicWrite(item.destination, item.content);
-      written.push(item);
+      ensureDirectory(dirname(item.destination), createdDirectories);
+      atomicWrite(item.destination, item.content, item.mode ?? 0o600);
+      written.push({
+        ...item,
+        installedMode: lstatSync(item.destination).mode & 0o777,
+      });
     }
   } catch (error) {
-    for (const item of written.reverse()) {
-      const current = readSafe(item.destination);
-      if (current === null || Buffer.compare(current, item.content) !== 0) continue;
-      if (item.baseline === null) unlinkSync(item.destination);
-      else atomicWrite(item.destination, item.baseline);
+    let rollbackError = null;
+    try {
+      assertBackupsUnchanged(backupFiles);
+      restoreWritten(written);
+      removeBackupFiles(backupFiles);
+    } catch (caught) {
+      rollbackError = caught;
     }
+    releaseLocks(locks);
+    locks = [];
+    if (!rollbackError) {
+      try {
+        removeEmptyCreatedDirectories(createdDirectories);
+      } catch (caught) {
+        rollbackError = caught;
+      }
+    }
+    if (rollbackError) throw new AggregateError([error, rollbackError], "installation failed and rollback could not complete");
     throw error;
   } finally {
-    for (const lock of locks) {
-      closeSync(lock.descriptor);
-      if (existsSync(lock.path)) unlinkSync(lock.path);
-    }
+    releaseLocks(locks);
   }
-  return backups.map((entry) => entry.path);
+  return completedTransaction(backups, written, backupFiles, createdDirectories);
+}
+
+export function applyPlan(plan) {
+  const transaction = applyPlanTransaction(plan);
+  transaction.commit();
+  return transaction.backups;
 }
 
 export function doctor(plan, tools) {
@@ -387,6 +584,13 @@ export function doctor(plan, tools) {
       const current = readSafe(item.destination);
       if (current === null) issues.push(`missing: ${item.destination}`);
       else if (Buffer.compare(current, item.content) !== 0) issues.push(`drifted: ${item.destination}`);
+      else if (!modesEquivalent(
+        lstatSync(item.destination).mode,
+        item.mode ?? 0o600,
+        item.platform,
+      )) {
+        issues.push(`mode drifted: ${item.destination}`);
+      }
     } catch (error) { issues.push(error.message); }
   }
   return {

--- a/bin/installer/path-safety.mjs
+++ b/bin/installer/path-safety.mjs
@@ -1,0 +1,35 @@
+import * as nativePath from "node:path";
+import { lstatSync, realpathSync } from "node:fs";
+
+
+export function isStrictDescendant(root, candidate, pathApi = nativePath) {
+  const resolvedRoot = pathApi.resolve(root);
+  const resolvedCandidate = pathApi.resolve(candidate);
+  const relativePath = pathApi.relative(resolvedRoot, resolvedCandidate);
+  return relativePath !== ""
+    && relativePath !== ".."
+    && !relativePath.startsWith(`..${pathApi.sep}`)
+    && !pathApi.isAbsolute(relativePath);
+}
+
+export function isPhysicalStrictDescendant(root, candidate) {
+  if (!isStrictDescendant(root, candidate)) return false;
+  try {
+    const resolvedRoot = nativePath.resolve(root);
+    const resolvedCandidate = nativePath.resolve(candidate);
+    const rootMetadata = lstatSync(resolvedRoot);
+    if (rootMetadata.isSymbolicLink() || !rootMetadata.isDirectory()) return false;
+    let cursor = resolvedRoot;
+    for (const component of nativePath.relative(resolvedRoot, resolvedCandidate).split(nativePath.sep)) {
+      if (!component) continue;
+      cursor = nativePath.join(cursor, component);
+      if (lstatSync(cursor).isSymbolicLink()) return false;
+    }
+    return isStrictDescendant(
+      realpathSync.native(resolvedRoot),
+      realpathSync.native(resolvedCandidate),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/bin/installer/process.mjs
+++ b/bin/installer/process.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+
+
+const UNSAFE_CMD_COMMAND = /[\0\r\n"%!^&|<>]/u;
+const SAFE_CMD_ARGUMENT = /^[\p{L}\p{N}_./:@+=,\\-]+$/u;
+
+function windowsCommandLine(command, args) {
+  if (typeof command !== "string" || !command || UNSAFE_CMD_COMMAND.test(command)) {
+    throw new Error(`unsafe Windows CLI command: ${command || "<missing>"}`);
+  }
+  for (const argument of args) {
+    if (typeof argument !== "string" || !SAFE_CMD_ARGUMENT.test(argument)) {
+      throw new Error(`unsafe Windows CLI argument: ${String(argument)}`);
+    }
+  }
+  const suffix = args.length ? ` ${args.join(" ")}` : "";
+  return `""${command}"${suffix}"`;
+}
+
+export function spawnCli(command, args, options = {}) {
+  if (!Array.isArray(args)) throw new Error("CLI arguments must be an array");
+  const {
+    platform: targetPlatform = process.platform,
+    comspec,
+    ...spawnOptions
+  } = options;
+  if (targetPlatform !== "win32") return spawnSync(command, args, spawnOptions);
+
+  const commandProcessor = comspec
+    || spawnOptions.env?.ComSpec
+    || spawnOptions.env?.COMSPEC
+    || process.env.ComSpec
+    || process.env.COMSPEC
+    || "cmd.exe";
+  return spawnSync(
+    commandProcessor,
+    ["/d", "/s", "/c", windowsCommandLine(command, args)],
+    {...spawnOptions, windowsVerbatimArguments: true},
+  );
+}

--- a/bin/installer/process.mjs
+++ b/bin/installer/process.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 
 const UNSAFE_CMD_COMMAND = /[\0\r\n"%!^&|<>]/u;
 const SAFE_CMD_ARGUMENT = /^[\p{L}\p{N}_./:@+=,\\-]+$/u;
+const BARE_CMD_COMMAND = /^[\p{L}\p{N}_.@+=,-]+$/u;
 
 function windowsCommandLine(command, args) {
   if (typeof command !== "string" || !command || UNSAFE_CMD_COMMAND.test(command)) {
@@ -14,6 +15,11 @@ function windowsCommandLine(command, args) {
     }
   }
   const suffix = args.length ? ` ${args.join(" ")}` : "";
+  // A quoted PATH-resolved batch name without its .cmd suffix can make cmd.exe
+  // expand %~dp0 relative to the caller's working directory. Bare command names
+  // contain no shell metacharacters and do not need quoting; explicit paths stay
+  // quoted so spaces and parentheses remain literal.
+  if (BARE_CMD_COMMAND.test(command)) return `${command}${suffix}`;
   return `""${command}"${suffix}"`;
 }
 

--- a/bin/installer/render.mjs
+++ b/bin/installer/render.mjs
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
+import { isPhysicalStrictDescendant } from "./path-safety.mjs";
 
 const ROLE_FILES = ["IDENTITY.md", "SOUL.md", "AGENTS.md", "USER.md", "TOOLS.md", "MEMORY.md"];
 export const BEGIN_MARKER = "<!-- AGI-SUPER-TEAM:CEO:BEGIN -->";
@@ -26,10 +27,18 @@ function managerRoutingBody(group, runtimeName = (manager, id) => `${manager}/${
   return `## ${group.manager.toUpperCase()} 子 Agent 路由\n\n先判断工作对象、领域和交付阶段。默认只选一个主责；只有独立的下游交付物才增加一个协作角色。缺少关键输入或两个角色仍然冲突时先澄清，不要广播。只能调用以下已安装的直属叶子，最多两个并发，总深度不超过二；子 Agent 不得继续创建 Agent。\n\n${[...roleRoutes, ...specialistRoutes].join("\n")}\n\n真实登录、上传、发布、部署、改基础设施、付费和第三方联系必须经过人类批准。`;
 }
 
+function readRoleFile(root, name, encoding = null) {
+  const source = join(root, name);
+  if (!isPhysicalStrictDescendant(root, source)) throw new Error(`unsafe Agent role file: ${source}`);
+  const metadata = lstatSync(source);
+  if (metadata.isSymbolicLink() || !metadata.isFile()) throw new Error(`invalid Agent role file: ${source}`);
+  return encoding ? readFileSync(source, encoding) : readFileSync(source);
+}
+
 export function roleBody(packageRoot, agent, group = null, runtimeName, roleName) {
   const root = join(packageRoot, agent.path);
   const body = ROLE_FILES.filter((name) => existsSync(join(root, name)))
-    .map((name) => `## ${name.slice(0, -3)}\n\n${readFileSync(join(root, name), "utf8").trim()}`)
+    .map((name) => `## ${name.slice(0, -3)}\n\n${readRoleFile(root, name, "utf8").trim()}`)
     .join("\n\n");
   const routing = group ? managerRoutingBody(group, runtimeName, roleName) : "";
   return [body, routing].filter(Boolean).join("\n\n");
@@ -61,7 +70,12 @@ export function specialistBody(packageRoot, specialist) {
   const outputs = specialist.outputs.map((item) => `- ${item}`).join("\n");
   const acceptance = specialist.acceptance.map((item) => `- ${item}`).join("\n");
   const sourceRole = specialist.sourceRole ? `\n- 上游角色：${specialist.sourceRole}\n- 改编说明：${specialist.adaptation}` : "";
-  const upstream = readFileSync(join(packageRoot, specialist.vendoredPath), "utf8");
+  const specialistRoot = resolve(packageRoot, "agents", specialist.manager, "subagents", specialist.id);
+  const specialistSource = resolve(packageRoot, specialist.vendoredPath);
+  if (!isPhysicalStrictDescendant(specialistRoot, specialistSource)) {
+    throw new Error(`unsafe specialist source: ${specialist.vendoredPath}`);
+  }
+  const upstream = readFileSync(specialistSource, "utf8");
   return `${upstream}\n\n---\n\n# AGI Super Team 路由与安全信封\n\n你是 ${specialist.manager.toUpperCase()} 直属叶子 Agent，不得创建子 Agent。\n\n## 何时调用\n\n${specialist.trigger}\n\n## 不应调用\n\n${specialist.doNotUseWhen}\n\n## 必需输入\n\n${inputs}\n\n## 标准交付物\n\n${outputs}\n\n## 验收标准\n\n${acceptance}\n\n## 权限边界\n\n${specialist.boundary}\n\n只返回事实、假设、产物、检查、限制和下一步。禁止登录账号、使用凭证、自动发布、评论、私信、投放、付费或联系第三方；不得声称未执行的测试、部署或运行结果。动态平台、市场、法律、财务、税务、技术和标准结论必须注明需要当前一手来源验证。\n\n## 来源\n\n- jnMetaCode/agency-agents-zh：${specialist.sourcePath}${sourceRole}\n`;
 }
 
@@ -99,8 +113,8 @@ export function openClawFiles(packageRoot, agent, group = null) {
   return ROLE_FILES.filter((name) => existsSync(join(source, name))).map((name) => ({
     relative: join(`workspace-${agent.id}`, name),
     content: name === "AGENTS.md" && group
-      ? Buffer.from(`${readFileSync(join(source, name), "utf8").trim()}\n\n${managerRoutingBody(group, (manager, id) => `workspace-${manager}-${id}`, (id) => `workspace-${id}`)}\n`)
-      : readFileSync(join(source, name)),
+      ? Buffer.from(`${readRoleFile(source, name, "utf8").trim()}\n\n${managerRoutingBody(group, (manager, id) => `workspace-${manager}-${id}`, (id) => `workspace-${id}`)}\n`)
+      : readRoleFile(source, name),
   }));
 }
 

--- a/bin/installer/render.mjs
+++ b/bin/installer/render.mjs
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { isPhysicalStrictDescendant } from "./path-safety.mjs";
 
@@ -118,17 +118,33 @@ export function openClawFiles(packageRoot, agent, group = null) {
   }));
 }
 
-export function walkFiles(root, prefix = "") {
+function walkPhysicalFiles(root, prefix, physicalRoot) {
   const output = [];
   for (const name of readdirSync(root).sort()) {
     if (name === "__pycache__" || name.endsWith(".pyc")) continue;
     const source = join(root, name);
+    if (!isPhysicalStrictDescendant(physicalRoot, source)) {
+      throw new Error(`refusing source outside physical root: ${source}`);
+    }
     const metadata = lstatSync(source);
     if (metadata.isSymbolicLink()) throw new Error(`refusing symlinked source: ${source}`);
-    if (metadata.isDirectory()) output.push(...walkFiles(source, join(prefix, name)));
-    else if (metadata.isFile()) output.push({ source, relative: join(prefix, name), content: readFileSync(source) });
+    if (metadata.isDirectory()) output.push(...walkPhysicalFiles(source, join(prefix, name), physicalRoot));
+    else if (metadata.isFile()) output.push({
+      source,
+      relative: join(prefix, name),
+      content: readFileSync(source),
+      mode: metadata.mode & 0o100 ? 0o700 : 0o600,
+    });
   }
   return output;
+}
+
+export function walkFiles(root, prefix = "") {
+  const metadata = lstatSync(root);
+  if (metadata.isSymbolicLink()) throw new Error(`refusing symlinked source root: ${root}`);
+  if (!metadata.isDirectory()) throw new Error(`invalid source root: ${root}`);
+  const physicalRoot = realpathSync.native(root);
+  return walkPhysicalFiles(physicalRoot, prefix, physicalRoot);
 }
 
 export function renderManaged(existing, managed, begin = RULES_BEGIN, end = RULES_END) {
@@ -155,7 +171,11 @@ export function combinedRules(packageRoot, agents, skills, groups = {}) {
 }
 
 export function globalCeoPayload(packageRoot) {
-  const path = join(packageRoot, "plugins", "agi-super-team-codex", "payload", "global", "AGENTS.md");
+  const payloadRoot = join(packageRoot, "plugins", "agi-super-team-codex", "payload");
+  const path = join(payloadRoot, "global", "AGENTS.md");
+  if (!isPhysicalStrictDescendant(payloadRoot, path)) {
+    throw new Error(`unsafe global CEO payload: ${path}`);
+  }
   const content = readFileSync(path, "utf8").trim();
   if (content.split(BEGIN_MARKER).length !== 2 || content.split(END_MARKER).length !== 2) {
     throw new Error("global CEO payload has invalid managed markers");

--- a/config/repository-architecture.json
+++ b/config/repository-architecture.json
@@ -94,7 +94,7 @@
       "title": "Governance and decision memory",
       "interface": "CONTEXT.md, ARCHITECTURE.md, ADRs, contribution, security, and governance records.",
       "implementations": ["CONTEXT.md", "ARCHITECTURE.md", "docs/adr"],
-      "ownershipPrefixes": ["AGENTS.md", "ARCHITECTURE.md", "CLAUDE.md", "CODE_OF_CONDUCT.md", "CONTEXT.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md", ".gitignore", "config", "docs/adr"],
+      "ownershipPrefixes": ["AGENTS.md", "ARCHITECTURE.md", "CLAUDE.md", "CODE_OF_CONDUCT.md", "CONTEXT.md", "CONTRIBUTING.md", "LICENSE", "SECURITY.md", ".gitattributes", ".gitignore", "config", "docs/adr"],
       "depth": "foundational",
       "seams": ["public-navigation", "verification-evidence"],
       "leverage": "Recorded terminology and decisions reduce contradictory future edits.",
@@ -103,6 +103,7 @@
   ],
   "pathOwnership": [
     {"path": ".github", "role": "governance", "module": "verification-evidence", "authority": false},
+    {"path": ".gitattributes", "role": "governance", "module": "governance-memory", "authority": false},
     {"path": ".githooks", "role": "evidence", "module": "verification-evidence", "authority": false},
     {"path": ".gitignore", "role": "governance", "module": "governance-memory", "authority": false},
     {"path": ".npmignore", "role": "implementation", "module": "safe-installation", "authority": false},

--- a/docs/guides/codex-install.html
+++ b/docs/guides/codex-install.html
@@ -39,9 +39,9 @@
           <li><strong>Add the plugin</strong><span>Install the named package, then start a new task so Codex can discover the newly available skills.</span></li>
           <li><strong>Preview agent sync</strong><span>Invoke <code>$agi-super-team-sync</code> without applying. Review creates, updates, backups, and destination paths.</span></li>
         </ol>
-        <pre><code>codex plugin marketplace add aAAaqwq/AGI-Super-Team --ref main
+        <pre><code>codex plugin marketplace add aAAaqwq/AGI-Super-Team --ref v1.4.1
 codex plugin add agi-super-team-codex@agi-super-team</code></pre>
-        <p>For reproducibility, replace <code>main</code> with a reviewed tag or commit when your Codex version accepts that reference. Repository commands may evolve with the client; check <code>codex plugin --help</code> before scripting them.</p>
+        <p>The marketplace reference selects the release tag matching the npm and plugin version. A Git tag is not a cryptographic content pin: verify and record the tag's resolved commit before installation, and stop if it differs from the published release commit. Repository commands may evolve with the client; check <code>codex plugin --help</code> before scripting them.</p>
       </section>
       <section>
         <h2>What the package changes</h2>

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,7 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/aAAaqwq/AGI-Super-Team.git"
+REPO_REF="${AGI_SUPER_TEAM_REF:-v1.4.1}"
 OPENCLAW_DIR="${AGI_SUPER_TEAM_DESTINATION:-${HOME}/.openclaw}"
 SOURCE_DIR="${AGI_SUPER_TEAM_SOURCE:-}"
 APPLY=0
@@ -24,6 +25,18 @@ SELECTOR_KIND=""
 MANIFEST_PATH=""
 DEPLOY_ROOT=""
 INSTALL_STAGE=""
+INSTALL_LOCK=""
+TRANSACTION_ACTIVE=0
+TRANSACTION_SIGNAL=""
+TRANSACTION_ROOT_MOVE=0
+TRANSACTION_ROOT_TOKEN=""
+declare -a TRANSACTION_COMPONENTS=()
+declare -a TRANSACTION_ORIGINAL_PRESENT=()
+declare -a TRANSACTION_ORIGINAL_DIGESTS=()
+declare -a TRANSACTION_STAGED_DIGESTS=()
+SNAPSHOT_DESTINATION_PRESENT=0
+declare -a SNAPSHOT_COMPONENTS=()
+declare -a SNAPSHOT_DIGESTS=()
 
 # Colors
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
@@ -42,7 +55,29 @@ check_prereqs() {
 }
 
 # ── Clone or update repo ──────────────────────────────────────
+validate_repo_ref() {
+  [[ "$REPO_REF" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ \
+     && "$REPO_REF" != *..* && "$REPO_REF" != */./* \
+     && "$REPO_REF" != */. && "$REPO_REF" != *.lock ]] \
+    || err "Invalid repository ref: $REPO_REF"
+}
+
+checkout_pinned_ref() {
+  local repo_dir="$1" commit="$2" actual
+  if ! git -C "$repo_dir" checkout --detach --quiet "$commit"; then
+    err "Unable to check out pinned repository ref: $REPO_REF"
+  fi
+  if ! actual=$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null); then
+    err "Unable to verify checked-out repository ref: $REPO_REF"
+  fi
+  [[ "$actual" == "$commit" ]] \
+    || err "Checked-out repository does not match pinned ref: $REPO_REF"
+}
+
 ensure_repo() {
+  local clone_dir="${1:-${HOME}/.agi-super-team}"
+  local clone_parent clone_stage="" status commit
+
   if [[ -n "$SOURCE_DIR" ]]; then
     [[ -d "$SOURCE_DIR/agents" && -d "$SOURCE_DIR/skills" ]] \
       || err "Local source is not an AGI Super Team checkout: $SOURCE_DIR"
@@ -50,19 +85,59 @@ ensure_repo() {
     return
   fi
 
+  validate_repo_ref
   if [[ "$APPLY" -eq 0 ]]; then
-    info "[PREVIEW] Would clone or update ${REPO_URL} at ${HOME}/.agi-super-team"
+    info "[PREVIEW] Would resolve ${REPO_URL} at pinned ref ${REPO_REF} into ${HOME}/.agi-super-team"
     RETVAL_REPO=""
     return
   fi
 
-  local clone_dir="${1:-${HOME}/.agi-super-team}"
   if [[ -d "$clone_dir/.git" ]]; then
-    info "Updating existing repo at $clone_dir"
-    git -C "$clone_dir" pull --ff-only -q 2>/dev/null || warn "Git pull failed, using cached version"
+    info "Resolving pinned repository ref ${REPO_REF} in $clone_dir"
+    if ! status=$(git -C "$clone_dir" status --porcelain --untracked-files=all 2>/dev/null); then
+      err "Unable to inspect cached repository before switching refs: $clone_dir"
+    fi
+    [[ -z "$status" ]] \
+      || err "Cached repository has local changes; refusing to switch refs: $clone_dir"
+    if ! git -C "$clone_dir" fetch --depth 1 "$REPO_URL" "$REPO_REF"; then
+      err "Unable to fetch pinned repository ref: $REPO_REF"
+    fi
+    if ! commit=$(git -C "$clone_dir" rev-parse --verify 'FETCH_HEAD^{commit}' 2>/dev/null); then
+      err "Unable to resolve pinned repository ref: $REPO_REF"
+    fi
+    checkout_pinned_ref "$clone_dir" "$commit"
   else
-    info "Cloning AGI Super Team..."
-    git clone --depth 1 "$REPO_URL" "$clone_dir" -q
+    [[ ! -e "$clone_dir" && ! -L "$clone_dir" ]] \
+      || err "Repository cache path exists but is not a Git checkout: $clone_dir"
+    clone_parent=$(dirname "$clone_dir")
+    mkdir -p "$clone_parent"
+    clone_stage=$(mktemp -d "${clone_parent}/.agi-super-team-source.XXXXXX")
+    rmdir "$clone_stage"
+    info "Cloning AGI Super Team at pinned ref ${REPO_REF}..."
+    if ! git clone --no-checkout --depth 1 --branch "$REPO_REF" "$REPO_URL" "$clone_stage" -q; then
+      rm -rf -- "$clone_stage"
+      err "Unable to clone pinned repository ref: $REPO_REF"
+    fi
+    if ! commit=$(git -C "$clone_stage" rev-parse --verify "${REPO_REF}^{commit}" 2>/dev/null); then
+      rm -rf -- "$clone_stage"
+      err "Unable to resolve pinned repository ref: $REPO_REF"
+    fi
+    if ! git -C "$clone_stage" checkout --detach --quiet "$commit"; then
+      rm -rf -- "$clone_stage"
+      err "Unable to check out pinned repository ref: $REPO_REF"
+    fi
+    if ! status=$(git -C "$clone_stage" rev-parse --verify HEAD 2>/dev/null); then
+      rm -rf -- "$clone_stage"
+      err "Unable to verify checked-out repository ref: $REPO_REF"
+    fi
+    if [[ "$status" != "$commit" ]]; then
+      rm -rf -- "$clone_stage"
+      err "Checked-out repository does not match pinned ref: $REPO_REF"
+    fi
+    if ! mv "$clone_stage" "$clone_dir"; then
+      rm -rf -- "$clone_stage"
+      err "Unable to publish pinned repository checkout: $clone_dir"
+    fi
   fi
   RETVAL_REPO="$clone_dir"
 }
@@ -476,6 +551,224 @@ cleanup_stage() {
   fi
 }
 
+release_destination_lock() {
+  local owner=""
+  [[ -n "$INSTALL_LOCK" ]] || return 0
+  if [[ -d "$INSTALL_LOCK" && ! -L "$INSTALL_LOCK" ]]; then
+    if [[ -f "${INSTALL_LOCK}/pid" ]]; then
+      IFS= read -r owner < "${INSTALL_LOCK}/pid" || true
+    fi
+    if [[ "$owner" == "$$" ]]; then
+      rm -f -- "${INSTALL_LOCK}/pid" "${INSTALL_LOCK}/destination"
+      rmdir "$INSTALL_LOCK" 2>/dev/null || warn "Installer lock could not be removed: $INSTALL_LOCK"
+    else
+      warn "Installer lock ownership changed; left it in place: $INSTALL_LOCK"
+    fi
+  fi
+  INSTALL_LOCK=""
+}
+
+acquire_destination_lock() {
+  local destination_parent destination_name physical_parent
+  destination_parent=$(dirname "$OPENCLAW_DIR")
+  destination_name=$(basename "$OPENCLAW_DIR")
+  [[ -d "$destination_parent" && ! -L "$destination_parent" ]] \
+    || err "Destination parent must be an existing real directory: $destination_parent"
+  physical_parent=$(CDPATH= cd -- "$destination_parent" && pwd -P) \
+    || err "Unable to resolve destination parent: $destination_parent"
+  INSTALL_LOCK="${physical_parent}/.${destination_name}.agi-super-team-install.lock"
+  if ! mkdir "$INSTALL_LOCK" 2>/dev/null; then
+    INSTALL_LOCK=""
+    err "Another installation is active for destination: $OPENCLAW_DIR"
+  fi
+  printf '%s\n' "$$" > "${INSTALL_LOCK}/pid"
+  printf '%s\n' "$OPENCLAW_DIR" > "${INSTALL_LOCK}/destination"
+  trap transaction_on_exit EXIT
+  trap 'transaction_on_signal HUP' HUP
+  trap 'transaction_on_signal INT' INT
+  trap 'transaction_on_signal TERM' TERM
+}
+
+fingerprint_path() {
+  node - "$1" <<'NODE'
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const root = process.argv[2];
+const hash = crypto.createHash('sha256');
+const visit = (entry, relative = '') => {
+  const stat = fs.lstatSync(entry);
+  const kind = stat.isDirectory() ? 'd' : stat.isFile() ? 'f' : stat.isSymbolicLink() ? 'l' : 'o';
+  hash.update(`${kind}\0${relative}\0${stat.mode & 0o777}\0`);
+  if (stat.isDirectory()) {
+    for (const name of fs.readdirSync(entry).sort()) visit(path.join(entry, name), path.join(relative, name));
+  } else if (stat.isFile()) {
+    hash.update(fs.readFileSync(entry));
+  } else if (stat.isSymbolicLink()) {
+    hash.update(fs.readlinkSync(entry));
+  }
+};
+let rootStat;
+try {
+  rootStat = fs.lstatSync(root);
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error;
+}
+if (!rootStat) {
+  process.stdout.write('absent\n');
+} else {
+  visit(root);
+  process.stdout.write(`${hash.digest('hex')}\n`);
+}
+NODE
+}
+
+snapshot_destination_state() {
+  local agent_key component digest
+  local -a components=(agents)
+  for agent_key in "$@"; do
+    components+=("workspace-${agent_key}")
+  done
+  if [[ "$LAYOUT" == "coordinated" ]]; then
+    components+=(AGENTS.md START_HERE.md TEAM.md RUNBOOK.md team.lock.json)
+  fi
+
+  SNAPSHOT_DESTINATION_PRESENT=0
+  SNAPSHOT_COMPONENTS=()
+  SNAPSHOT_DIGESTS=()
+  if [[ -e "$OPENCLAW_DIR" || -L "$OPENCLAW_DIR" ]]; then
+    SNAPSHOT_DESTINATION_PRESENT=1
+  fi
+  for component in "${components[@]}"; do
+    digest=$(fingerprint_path "${OPENCLAW_DIR}/${component}") \
+      || err "Unable to snapshot destination component: ${OPENCLAW_DIR}/${component}"
+    SNAPSHOT_COMPONENTS+=("$component")
+    SNAPSHOT_DIGESTS+=("$digest")
+  done
+}
+
+verify_destination_snapshot() {
+  local index component expected actual destination_present=0
+  if [[ -e "$OPENCLAW_DIR" || -L "$OPENCLAW_DIR" ]]; then
+    destination_present=1
+  fi
+  if [[ "$destination_present" -ne "$SNAPSHOT_DESTINATION_PRESENT" ]]; then
+    err "Destination changed after staging began: $OPENCLAW_DIR"
+  fi
+  for ((index=0; index < ${#SNAPSHOT_COMPONENTS[@]}; index++)); do
+    component="${SNAPSHOT_COMPONENTS[$index]}"
+    expected="${SNAPSHOT_DIGESTS[$index]}"
+    actual=$(fingerprint_path "${OPENCLAW_DIR}/${component}") \
+      || err "Unable to verify destination component: ${OPENCLAW_DIR}/${component}"
+    if [[ "$actual" != "$expected" ]]; then
+      err "Destination changed after staging began: ${OPENCLAW_DIR}/${component}"
+    fi
+  done
+}
+
+rollback_transaction() {
+  local index component final_component backup_component original_present original_digest staged_digest current_digest marker recovery_destination
+  local restore_failed=0
+
+  if [[ "$TRANSACTION_ROOT_MOVE" -eq 1 ]]; then
+    marker="${OPENCLAW_DIR}/.agi-super-team-transaction"
+    if [[ -f "$marker" && ! -L "$marker" \
+       && "$(<"$marker")" == "$TRANSACTION_ROOT_TOKEN" ]]; then
+      recovery_destination="${INSTALL_STAGE}/recovery-destination"
+      if [[ ! -e "$recovery_destination" && ! -L "$recovery_destination" ]]; then
+        # A digest check cannot authorize recursive deletion: another writer
+        # can add data after the check. Quarantine the entire root atomically
+        # and require explicit recovery review instead.
+        mv "$OPENCLAW_DIR" "$recovery_destination" || true
+      fi
+      restore_failed=1
+    elif [[ -e "$OPENCLAW_DIR" || -L "$OPENCLAW_DIR" ]]; then
+      restore_failed=1
+    fi
+  fi
+
+  for ((index=${#TRANSACTION_COMPONENTS[@]} - 1; index >= 0; index--)); do
+    component="${TRANSACTION_COMPONENTS[$index]}"
+    original_present="${TRANSACTION_ORIGINAL_PRESENT[$index]}"
+    original_digest="${TRANSACTION_ORIGINAL_DIGESTS[$index]}"
+    staged_digest="${TRANSACTION_STAGED_DIGESTS[$index]}"
+    final_component="${OPENCLAW_DIR}/${component}"
+    backup_component="${INSTALL_STAGE}/backup/${component}"
+
+    if [[ "$original_present" -eq 1 ]]; then
+      if [[ -e "$backup_component" || -L "$backup_component" ]]; then
+        if [[ -e "$final_component" || -L "$final_component" ]]; then
+          current_digest=$(fingerprint_path "$final_component") || current_digest="unknown"
+          if [[ "$current_digest" != "$staged_digest" ]]; then
+            restore_failed=1
+            continue
+          fi
+          rm -rf -- "$final_component" || { restore_failed=1; continue; }
+        fi
+        mv "$backup_component" "$final_component" || restore_failed=1
+      else
+        current_digest=$(fingerprint_path "$final_component") || current_digest="unknown"
+        [[ "$current_digest" == "$original_digest" ]] || restore_failed=1
+      fi
+    elif [[ -e "$final_component" || -L "$final_component" ]]; then
+      current_digest=$(fingerprint_path "$final_component") || current_digest="unknown"
+      if [[ "$current_digest" == "$staged_digest" ]]; then
+        rm -rf -- "$final_component" || restore_failed=1
+      else
+        restore_failed=1
+      fi
+    fi
+  done
+
+  return "$restore_failed"
+}
+
+transaction_on_exit() {
+  local status="$?" recovery_path="" restored=1
+  trap - EXIT HUP INT TERM
+  if [[ "$TRANSACTION_ACTIVE" -eq 1 ]]; then
+    rollback_transaction || restored=0
+  fi
+  if [[ "$restored" -eq 1 ]]; then
+    cleanup_stage
+    if [[ -n "$TRANSACTION_SIGNAL" ]]; then
+      warn "Received ${TRANSACTION_SIGNAL}; restored the previous destination state"
+    elif [[ "$status" -ne 0 && "${#TRANSACTION_COMPONENTS[@]}" -gt 0 ]]; then
+      warn "Atomic publish failed; restored the previous destination state"
+    fi
+  else
+    recovery_path="$INSTALL_STAGE"
+    INSTALL_STAGE=""
+    warn "automatic restore is incomplete. Recovery transaction preserved at: $recovery_path"
+  fi
+  release_destination_lock
+  exit "$status"
+}
+
+transaction_on_signal() {
+  TRANSACTION_SIGNAL="$1"
+  case "$1" in
+    HUP) exit 129 ;;
+    INT) exit 130 ;;
+    TERM) exit 143 ;;
+  esac
+}
+
+move_transaction_path() {
+  local status=0
+  if mv "$@"; then
+    return 0
+  else
+    status=$?
+  fi
+  case "$status" in
+    129) TRANSACTION_SIGNAL=HUP; err "Atomic publish interrupted" ;;
+    130) TRANSACTION_SIGNAL=INT; err "Atomic publish interrupted" ;;
+    143) TRANSACTION_SIGNAL=TERM; err "Atomic publish interrupted" ;;
+    *) err "Atomic publish failed" ;;
+  esac
+}
+
 prepare_stage() {
   local destination_parent
   local agent_key final_workspace
@@ -487,7 +780,20 @@ prepare_stage() {
   INSTALL_STAGE=$(mktemp -d "${destination_parent}/.agi-super-team-stage.XXXXXX")
   DEPLOY_ROOT="${INSTALL_STAGE}/destination"
   mkdir -p "${DEPLOY_ROOT}/agents"
-  trap cleanup_stage EXIT HUP INT TERM
+  TRANSACTION_ACTIVE=1
+  TRANSACTION_SIGNAL=""
+  TRANSACTION_ROOT_MOVE=0
+  TRANSACTION_ROOT_TOKEN=""
+  TRANSACTION_COMPONENTS=()
+  TRANSACTION_ORIGINAL_PRESENT=()
+  TRANSACTION_ORIGINAL_DIGESTS=()
+  TRANSACTION_STAGED_DIGESTS=()
+  trap transaction_on_exit EXIT
+  trap 'transaction_on_signal HUP' HUP
+  trap 'transaction_on_signal INT' INT
+  trap 'transaction_on_signal TERM' TERM
+
+  snapshot_destination_state "$@"
 
   if [[ -d "$OPENCLAW_DIR" ]]; then
     if [[ -e "${OPENCLAW_DIR}/agents" || -L "${OPENCLAW_DIR}/agents" ]]; then
@@ -600,10 +906,7 @@ NODE
 publish_stage() {
   local agent_key component staged_component final_component backup_component
   local -a components=(agents)
-  local -a published=()
-  local index published_component published_final published_backup
-  local restore_failed=0 recovery_path
-  local restore_message="Atomic publish failed; restored the previous destination state"
+  local original_present original_digest staged_digest
   for agent_key in "$@"; do
     components+=("workspace-${agent_key}")
   done
@@ -611,10 +914,20 @@ publish_stage() {
     components+=(AGENTS.md START_HERE.md TEAM.md RUNBOOK.md team.lock.json)
   fi
 
+  verify_destination_snapshot
+
   if [[ ! -e "$OPENCLAW_DIR" && ! -L "$OPENCLAW_DIR" ]]; then
-    mv "${DEPLOY_ROOT}" "$OPENCLAW_DIR"
+    TRANSACTION_ROOT_TOKEN=$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('hex'))") \
+      || err "Unable to create a transaction identifier"
+    printf '%s\n' "$TRANSACTION_ROOT_TOKEN" > "${DEPLOY_ROOT}/.agi-super-team-transaction"
+    TRANSACTION_ROOT_MOVE=1
+    move_transaction_path "${DEPLOY_ROOT}" "$OPENCLAW_DIR"
+    rm -f -- "${OPENCLAW_DIR}/.agi-super-team-transaction"
+    TRANSACTION_ROOT_MOVE=0
+    TRANSACTION_ACTIVE=0
     rmdir "$INSTALL_STAGE"
     INSTALL_STAGE=""
+    release_destination_lock
     trap - EXIT HUP INT TERM
     return
   fi
@@ -624,60 +937,27 @@ publish_stage() {
     staged_component="${DEPLOY_ROOT}/${component}"
     final_component="${OPENCLAW_DIR}/${component}"
     backup_component="${INSTALL_STAGE}/backup/${component}"
+    original_present=0
     if [[ -e "$final_component" || -L "$final_component" ]]; then
-      if ! mv "$final_component" "$backup_component"; then
-        restore_failed=0
-        for ((index=${#published[@]} - 1; index >= 0; index--)); do
-          published_component="${published[$index]}"
-          published_final="${OPENCLAW_DIR}/${published_component}"
-          published_backup="${INSTALL_STAGE}/backup/${published_component}"
-          if ! rm -rf -- "$published_final"; then
-            restore_failed=1
-            continue
-          fi
-          if [[ -e "$published_backup" || -L "$published_backup" ]]; then
-            mv "$published_backup" "$published_final" || restore_failed=1
-          fi
-        done
-        if [[ "$restore_failed" -ne 0 ]]; then
-          recovery_path="$INSTALL_STAGE"
-          INSTALL_STAGE=""
-          trap - EXIT HUP INT TERM
-          err "Atomic publish failed; automatic restore is incomplete. Recovery transaction preserved at: $recovery_path"
-        fi
-        err "$restore_message"
-      fi
+      original_present=1
     fi
-    if ! mv "$staged_component" "$final_component"; then
-      restore_failed=0
-      if [[ -e "$backup_component" || -L "$backup_component" ]]; then
-        mv "$backup_component" "$final_component" || restore_failed=1
-      fi
-      for ((index=${#published[@]} - 1; index >= 0; index--)); do
-        published_component="${published[$index]}"
-        published_final="${OPENCLAW_DIR}/${published_component}"
-        published_backup="${INSTALL_STAGE}/backup/${published_component}"
-        if ! rm -rf -- "$published_final"; then
-          restore_failed=1
-          continue
-        fi
-        if [[ -e "$published_backup" || -L "$published_backup" ]]; then
-          mv "$published_backup" "$published_final" || restore_failed=1
-        fi
-      done
-      if [[ "$restore_failed" -ne 0 ]]; then
-        recovery_path="$INSTALL_STAGE"
-        INSTALL_STAGE=""
-        trap - EXIT HUP INT TERM
-        err "Atomic publish failed; automatic restore is incomplete. Recovery transaction preserved at: $recovery_path"
-      fi
-      err "$restore_message"
+    original_digest=$(fingerprint_path "$final_component") \
+      || err "Unable to fingerprint destination component: $final_component"
+    staged_digest=$(fingerprint_path "$staged_component") || err "Unable to fingerprint staged component: $staged_component"
+    TRANSACTION_COMPONENTS+=("$component")
+    TRANSACTION_ORIGINAL_PRESENT+=("$original_present")
+    TRANSACTION_ORIGINAL_DIGESTS+=("$original_digest")
+    TRANSACTION_STAGED_DIGESTS+=("$staged_digest")
+    if [[ -e "$final_component" || -L "$final_component" ]]; then
+      move_transaction_path "$final_component" "$backup_component"
     fi
-    published+=("$component")
+    move_transaction_path "$staged_component" "$final_component"
   done
 
+  TRANSACTION_ACTIVE=0
   cleanup_stage
   INSTALL_STAGE=""
+  release_destination_lock
   trap - EXIT HUP INT TERM
 }
 
@@ -782,12 +1062,14 @@ deploy_starter_kit() {
   info "Materializing selection: ${kit} (${#agents[@]} agent(s))"
 
   preflight_kit_entrypoint "$repo_dir" "$kit"
-  validate_install_paths "$repo_dir" "${agents[@]}"
   preflight_agents "$repo_dir" "${agents[@]}"
   report_recommended_external_skills "${agents[@]}"
   if [[ "$APPLY" -eq 1 ]]; then
+    acquire_destination_lock
+    validate_install_paths "$repo_dir" "${agents[@]}"
     prepare_stage "${agents[@]}"
   else
+    validate_install_paths "$repo_dir" "${agents[@]}"
     DEPLOY_ROOT="$OPENCLAW_DIR"
   fi
 
@@ -923,7 +1205,7 @@ main() {
     err "Unexpected extra arguments: ${positionals[*]:2}"
   fi
   if [[ -z "$SOURCE_DIR" && "$APPLY" -eq 0 ]]; then
-    err "Preview requires --source PATH so the canonical team manifest can be validated without cloning or inventing a plan."
+    err "Preview for pinned ref ${REPO_REF} requires --source PATH so the canonical team manifest can be validated without cloning or inventing a plan."
   fi
 
   echo ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agi-super-team",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Evidence-backed AI team packs with preview-first installation and repository contracts",
   "license": "MIT",
   "repository": {
@@ -225,6 +225,7 @@
     "prepublishOnly": "npm test && npm run validate:strict && git diff --check",
     "test": "npm run test:repository && npm run test:installer && npm run check:subagent-sources && npm run check:agent-indexes && npm run check:codex-team && npm run check:skills && npm run check:skill-quality && npm run check:taxonomy-evaluation && npm run check:architecture",
     "test:repository": "python3 -m unittest discover -s tests -p 'test_*.py'",
+    "test:windows-cli": "node tests/windows_cli_smoke.mjs",
     "test:installer": "bash tests/installer/test_install.sh",
     "validate": "python3 scripts/validate_repository.py",
     "validate:strict": "python3 scripts/validate_repository.py --warnings-as-errors",

--- a/plugins/agi-super-team-codex/.codex-plugin/plugin.json
+++ b/plugins/agi-super-team-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agi-super-team-codex",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Codex-native Musk CEO guidance, eight C-suite outcome teams, executive specialist pyramids, swarm orchestration, and project memory.",
   "author": {
     "name": "Daniel Li",

--- a/tests/installer/test_install.sh
+++ b/tests/installer/test_install.sh
@@ -876,6 +876,250 @@ test_publish_failure_restores_existing_components() {
 
 test_publish_failure_restores_existing_components
 
+test_publish_signal_restores_existing_components() {
+  local signal_name signal_status destination fake_bin counter output status lock_path
+
+  for signal_name in HUP INT TERM; do
+    case "$signal_name" in HUP) signal_status=129 ;; INT) signal_status=130 ;; TERM) signal_status=143 ;; esac
+    destination="${TEST_TMP}/publish-${signal_name}-destination"
+    fake_bin="${TEST_TMP}/publish-${signal_name}-bin"
+    counter="${TEST_TMP}/publish-${signal_name}-count"
+    lock_path="${TEST_TMP}/.publish-${signal_name}-destination.agi-super-team-install.lock"
+    status=0
+
+    mkdir -p "${destination}/agents" "${destination}/workspace-ceo" "$fake_bin"
+    printf 'old shared state\n' > "${destination}/agents/marker.txt"
+    printf 'old persona\n' > "${destination}/workspace-ceo/SOUL.md"
+    printf '0\n' > "$counter"
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      "counter='$counter'" \
+      "signal_status='$signal_status'" \
+      'count=$(($(cat "$counter") + 1))' \
+      'printf "%s\n" "$count" > "$counter"' \
+      'if [[ "$count" -eq 3 ]]; then' \
+      '  /bin/mv "$@" || exit $?' \
+      '  exit "$signal_status"' \
+      'fi' \
+      'exec /bin/mv "$@"' > "${fake_bin}/mv"
+    chmod +x "${fake_bin}/mv"
+
+    output=$(PATH="${fake_bin}:$PATH" bash "$INSTALLER" \
+      --source "$REPO_ROOT" --destination "$destination" --apply ceo 2>&1) || status=$?
+
+    if [[ "$status" -eq 0 || "$output" != *"Received ${signal_name}; restored the previous destination state"* \
+       || "$(<"${destination}/agents/marker.txt")" != "old shared state" \
+       || "$(<"${destination}/workspace-ceo/SOUL.md")" != "old persona" \
+       || -e "${destination}/workspace-ceo/skills" || -e "$lock_path" ]]; then
+      printf 'not ok - %s publish interruption did not restore state and release its lock\n%s\n' \
+        "$signal_name" "$output"
+      failures=$((failures + 1))
+      return
+    fi
+  done
+  printf 'ok - HUP, INT, and TERM publish interruptions restore state and release locks\n'
+}
+
+test_publish_signal_restores_existing_components
+
+test_new_destination_interruption_quarantines_the_tagged_publish() {
+  local destination="${TEST_TMP}/new-root-signal-destination"
+  local fake_bin="${TEST_TMP}/new-root-signal-bin"
+  local output status=0 recovery_path
+
+  mkdir -p "$fake_bin"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '/bin/mv "$@" || exit $?' \
+    'exit 143' > "${fake_bin}/mv"
+  chmod +x "${fake_bin}/mv"
+
+  output=$(PATH="${fake_bin}:$PATH" bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo 2>&1) || status=$?
+  recovery_path=$(printf '%s\n' "$output" | sed -n 's/.*Recovery transaction preserved at: //p' | tail -1)
+
+  if [[ "$status" -ne 0 && "$output" == *"automatic restore is incomplete"* \
+     && -n "$recovery_path" && -d "${recovery_path}/recovery-destination" \
+     && -f "${recovery_path}/recovery-destination/workspace-ceo/AGENTS.md" \
+     && ! -e "$destination" && ! -L "$destination" \
+     && ! -e "${TEST_TMP}/.new-root-signal-destination.agi-super-team-install.lock" ]]; then
+    printf 'ok - interrupted first install quarantines its tagged destination and releases its lock\n'
+  else
+    printf 'not ok - interrupted first install did not preserve a recovery destination\n%s\n' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_new_destination_interruption_quarantines_the_tagged_publish
+
+test_new_destination_drift_during_interruption_is_quarantined() {
+  local destination="${TEST_TMP}/new-root-drift-destination"
+  local fake_bin="${TEST_TMP}/new-root-drift-bin"
+  local counter="${TEST_TMP}/new-root-drift-count"
+  local output status=0 recovery_path
+
+  mkdir -p "$fake_bin"
+  printf '0\n' > "$counter"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "counter='$counter'" \
+    'count=$(($(cat "$counter") + 1))' \
+    'printf "%s\n" "$count" > "$counter"' \
+    'if [[ "$count" -eq 1 ]]; then' \
+    '  /bin/mv "$@" || exit $?' \
+    '  printf "user concurrent data\n" > "$2/user-concurrent.txt"' \
+    '  exit 143' \
+    'fi' \
+    'exec /bin/mv "$@"' > "${fake_bin}/mv"
+  chmod +x "${fake_bin}/mv"
+
+  output=$(PATH="${fake_bin}:$PATH" bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo 2>&1) || status=$?
+  recovery_path=$(printf '%s\n' "$output" | sed -n 's/.*Recovery transaction preserved at: //p' | tail -1)
+
+  if [[ "$status" -ne 0 && "$output" == *"automatic restore is incomplete"* \
+     && -n "$recovery_path" && -d "$recovery_path" \
+     && "$(<"${recovery_path}/recovery-destination/user-concurrent.txt")" == "user concurrent data" \
+     && ! -e "$destination" && ! -L "$destination" ]]; then
+    printf 'ok - concurrent data in an interrupted new destination is quarantined, not deleted\n'
+  else
+    printf 'not ok - interrupted new-destination drift was deleted or lost\n%s\n' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_new_destination_drift_during_interruption_is_quarantined
+
+test_new_destination_drift_survives_failed_quarantine() {
+  local destination="${TEST_TMP}/new-root-drift-stays-destination"
+  local fake_bin="${TEST_TMP}/new-root-drift-stays-bin"
+  local counter="${TEST_TMP}/new-root-drift-stays-count"
+  local output status=0 recovery_path
+
+  mkdir -p "$fake_bin"
+  printf '0\n' > "$counter"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "counter='$counter'" \
+    'count=$(($(cat "$counter") + 1))' \
+    'printf "%s\n" "$count" > "$counter"' \
+    'if [[ "$count" -eq 1 ]]; then' \
+    '  /bin/mv "$@" || exit $?' \
+    '  printf "user concurrent data\n" > "$2/user-concurrent.txt"' \
+    '  exit 143' \
+    'fi' \
+    'exit 77' > "${fake_bin}/mv"
+  chmod +x "${fake_bin}/mv"
+
+  output=$(PATH="${fake_bin}:$PATH" bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo 2>&1) || status=$?
+  recovery_path=$(printf '%s\n' "$output" | sed -n 's/.*Recovery transaction preserved at: //p' | tail -1)
+
+  if [[ "$status" -ne 0 && "$output" == *"automatic restore is incomplete"* \
+     && -n "$recovery_path" && -d "$recovery_path" \
+     && "$(<"${destination}/user-concurrent.txt")" == "user concurrent data" ]]; then
+    printf 'ok - failed quarantine leaves concurrent data in place and reports recovery state\n'
+  else
+    printf 'not ok - failed quarantine deleted concurrent destination data\n%s\n' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_new_destination_drift_survives_failed_quarantine
+
+test_destination_lock_blocks_a_second_installer() {
+  local destination="${TEST_TMP}/lock-destination"
+  local fake_bin="${TEST_TMP}/lock-bin"
+  local ready="${TEST_TMP}/lock-ready"
+  local release="${TEST_TMP}/lock-release"
+  local first_output="${TEST_TMP}/lock-first-output"
+  local second_output second_status=0 first_status=0 first_pid attempt
+
+  mkdir -p "$destination" "$fake_bin"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "ready='$ready'" \
+    "release='$release'" \
+    'if [[ ! -e "$ready" ]]; then' \
+    '  : > "$ready"' \
+    '  while [[ ! -e "$release" ]]; do sleep 0.02; done' \
+    'fi' \
+    'exec /bin/cp "$@"' > "${fake_bin}/cp"
+  chmod +x "${fake_bin}/cp"
+
+  PATH="${fake_bin}:$PATH" bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo > "$first_output" 2>&1 &
+  first_pid=$!
+  for attempt in $(seq 1 100); do
+    [[ -e "$ready" ]] && break
+    sleep 0.02
+  done
+
+  second_output=$(bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo 2>&1) || second_status=$?
+  : > "$release"
+  wait "$first_pid" || first_status=$?
+
+  if [[ "$first_status" -eq 0 && "$second_status" -ne 0 \
+     && "$second_output" == *"Another installation is active for destination"* \
+     && ! -e "${TEST_TMP}/.lock-destination.agi-super-team-install.lock" ]]; then
+    printf 'ok - destination lock blocks a second installer\n'
+  else
+    printf 'not ok - two installers could publish the same destination concurrently\nfirst:\n%s\nsecond:\n%s\n' \
+      "$(<"$first_output")" "$second_output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_destination_lock_blocks_a_second_installer
+
+test_destination_drift_aborts_before_publish() {
+  local destination="${TEST_TMP}/drift-destination"
+  local fake_bin="${TEST_TMP}/drift-bin"
+  local ready="${TEST_TMP}/drift-ready"
+  local release="${TEST_TMP}/drift-release"
+  local install_output="${TEST_TMP}/drift-output"
+  local install_status=0 install_pid attempt
+
+  mkdir -p "${destination}/agents" "${destination}/workspace-ceo" "$fake_bin"
+  printf 'old shared state\n' > "${destination}/agents/marker.txt"
+  printf 'old persona\n' > "${destination}/workspace-ceo/SOUL.md"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "ready='$ready'" \
+    "release='$release'" \
+    'if [[ ! -e "$ready" ]]; then' \
+    '  : > "$ready"' \
+    '  while [[ ! -e "$release" ]]; do sleep 0.02; done' \
+    'fi' \
+    'exec /bin/cp "$@"' > "${fake_bin}/cp"
+  chmod +x "${fake_bin}/cp"
+
+  PATH="${fake_bin}:$PATH" bash "$INSTALLER" --source "$REPO_ROOT" \
+    --destination "$destination" --apply ceo > "$install_output" 2>&1 &
+  install_pid=$!
+  for attempt in $(seq 1 100); do
+    [[ -e "$ready" ]] && break
+    sleep 0.02
+  done
+  printf 'user concurrent edit\n' > "${destination}/workspace-ceo/SOUL.md"
+  : > "$release"
+  wait "$install_pid" || install_status=$?
+
+  if [[ "$install_status" -ne 0 \
+     && "$(<"$install_output")" == *"Destination changed after staging began"* \
+     && "$(<"${destination}/workspace-ceo/SOUL.md")" == "user concurrent edit" \
+     && ! -e "${destination}/workspace-ceo/skills" \
+     && ! -e "${TEST_TMP}/.drift-destination.agi-super-team-install.lock" ]]; then
+    printf 'ok - destination drift aborts before publish and preserves the concurrent edit\n'
+  else
+    printf 'not ok - destination drift was overwritten or silently published\n%s\n' "$(<"$install_output")"
+    failures=$((failures + 1))
+  fi
+}
+
+test_destination_drift_aborts_before_publish
+
 test_restore_failure_preserves_recovery_transaction() {
   local destination="${TEST_TMP}/restore-failure-destination"
   local fake_bin="${TEST_TMP}/restore-failure-bin"
@@ -975,8 +1219,9 @@ test_remote_preview_fails_closed_without_a_manifest() {
 
   output=$(HOME="$fake_home" PATH="${fake_bin}:/usr/bin:/bin" bash "$INSTALLER" --destination "$destination" ceo 2>&1) || status=$?
   if [[ "$status" -ne 0 && ! -e "$git_marker" && ! -e "$fake_home" && ! -e "$destination" \
-     && "$output" == *"--source"* && "$output" == *"manifest"* ]]; then
-    printf 'ok - remote preview fails closed without cloning or inventing a manifest plan\n'
+     && "$output" == *"--source"* && "$output" == *"manifest"* \
+     && "$output" == *"v1.4.1"* ]]; then
+    printf 'ok - remote preview names the pinned ref and does not clone or invent a manifest plan\n'
   else
     printf 'not ok - remote preview invented a plan or touched local state\n%s\n' "$output"
     failures=$((failures + 1))
@@ -984,6 +1229,118 @@ test_remote_preview_fails_closed_without_a_manifest() {
 }
 
 test_remote_preview_fails_closed_without_a_manifest
+
+test_remote_ref_resolution_failure_does_not_publish() {
+  local fake_home="${TEST_TMP}/remote-ref-resolution-home"
+  local fake_bin="${TEST_TMP}/remote-ref-resolution-bin"
+  local destination="${TEST_TMP}/remote-ref-resolution-destination"
+  local output status=0
+
+  mkdir -p "${fake_home}/.agi-super-team/.git" "$fake_bin"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  *"status --porcelain"*) exit 0 ;;' \
+    '  *"fetch --depth 1"*) exit 0 ;;' \
+    '  *"rev-parse --verify"*) exit 77 ;;' \
+    'esac' \
+    'exit 0' > "${fake_bin}/git"
+  chmod +x "${fake_bin}/git"
+
+  output=$(HOME="$fake_home" PATH="${fake_bin}:/usr/bin:/bin" bash "$INSTALLER" \
+    --destination "$destination" --apply ceo 2>&1) || status=$?
+
+  if [[ "$status" -ne 0 && "$output" == *"Unable to resolve pinned repository ref: v1.4.1"* \
+     && ! -e "$destination" && ! -L "$destination" ]]; then
+    printf 'ok - unresolved remote ref performs zero destination writes\n'
+  else
+    printf 'not ok - unresolved remote ref continued with unknown source state\n%s\n' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_remote_ref_resolution_failure_does_not_publish
+
+test_remote_checkout_failure_does_not_publish() {
+  local fake_home="${TEST_TMP}/remote-checkout-home"
+  local fake_bin="${TEST_TMP}/remote-checkout-bin"
+  local destination="${TEST_TMP}/remote-checkout-destination"
+  local output status=0
+
+  mkdir -p "${fake_home}/.agi-super-team/.git" "$fake_bin"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'case "$*" in' \
+    '  *"status --porcelain"*) exit 0 ;;' \
+    '  *"fetch --depth 1"*) exit 0 ;;' \
+    '  *"rev-parse --verify"*) printf "%040d\n" 1; exit 0 ;;' \
+    '  *"checkout --detach"*) exit 77 ;;' \
+    'esac' \
+    'exit 0' > "${fake_bin}/git"
+  chmod +x "${fake_bin}/git"
+
+  output=$(HOME="$fake_home" PATH="${fake_bin}:/usr/bin:/bin" bash "$INSTALLER" \
+    --destination "$destination" --apply ceo 2>&1) || status=$?
+
+  if [[ "$status" -ne 0 && "$output" == *"Unable to check out pinned repository ref: v1.4.1"* \
+     && ! -e "$destination" && ! -L "$destination" ]]; then
+    printf 'ok - failed pinned checkout performs zero destination writes\n'
+  else
+    printf 'not ok - failed pinned checkout continued with cached source state\n%s\n' "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+test_remote_checkout_failure_does_not_publish
+
+test_remote_cached_checkout_uses_the_exact_pinned_ref() {
+  local fake_home="${TEST_TMP}/remote-pinned-success-home"
+  local source="${fake_home}/.agi-super-team"
+  local fake_bin="${TEST_TMP}/remote-pinned-success-bin"
+  local destination="${TEST_TMP}/remote-pinned-success-destination"
+  local git_log="${TEST_TMP}/remote-pinned-success-git.log"
+  local output skill
+
+  mkdir -p "${source}/.git" "${source}/agents/ceo" "${source}/skills" "$fake_bin"
+  write_shared_workspace_files "$source"
+  write_ceo_manifest "$source"
+  printf '# CEO\n' > "${source}/agents/ceo/SOUL.md"
+  for skill in team-coordinator context-manager healthcheck web-search project-planner; do
+    mkdir -p "${source}/skills/${skill}"
+    printf '# %s\n' "$skill" > "${source}/skills/${skill}/SKILL.md"
+  done
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "log='$git_log'" \
+    'printf "%s\n" "$*" >> "$log"' \
+    'case "$*" in' \
+    '  *"status --porcelain"*) exit 0 ;;' \
+    '  *"fetch --depth 1"*) exit 0 ;;' \
+    '  *"rev-parse --verify FETCH_HEAD"*) printf "%s\n" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; exit 0 ;;' \
+    '  *"checkout --detach --quiet"*) exit 0 ;;' \
+    '  *"rev-parse --verify HEAD"*) printf "%s\n" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; exit 0 ;;' \
+    'esac' \
+    'exit 77' > "${fake_bin}/git"
+  chmod +x "${fake_bin}/git"
+
+  if ! output=$(HOME="$fake_home" PATH="${fake_bin}:$PATH" bash "$INSTALLER" \
+    --destination "$destination" --apply ceo 2>&1); then
+    printf 'not ok - exact pinned cached checkout failed\n%s\n' "$output"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [[ -f "${destination}/workspace-ceo/SOUL.md" \
+     && "$(<"$git_log")" == *"fetch --depth 1 https://github.com/aAAaqwq/AGI-Super-Team.git v1.4.1"* \
+     && "$(<"$git_log")" == *"checkout --detach --quiet aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"* ]]; then
+    printf 'ok - cached remote source fetches and checks out the exact v1.4.1 commit\n'
+  else
+    printf 'not ok - cached remote source did not use the exact pinned ref\n%s\n' "$(<"$git_log")"
+    failures=$((failures + 1))
+  fi
+}
+
+test_remote_cached_checkout_uses_the_exact_pinned_ref
 
 test_repository_tools_skill_references_resolve() {
   local file skill reference_count=0

--- a/tests/test_distribution_release_contract.py
+++ b/tests/test_distribution_release_contract.py
@@ -1,0 +1,89 @@
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class DistributionReleaseContractTests(unittest.TestCase):
+    def test_npm_tarball_contains_the_runtime_and_no_transient_files(self) -> None:
+        result = subprocess.run(
+            ["npm", "pack", "--dry-run", "--json", "--ignore-scripts"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)[0]
+        files = {entry["path"]: entry for entry in payload["files"]}
+
+        required_runtime = {
+            path.relative_to(ROOT).as_posix()
+            for path in (ROOT / "bin").rglob("*.mjs")
+        }
+        self.assertTrue(required_runtime <= files.keys())
+        self.assertEqual(files["bin/agi-super-team.mjs"]["mode"] & 0o111, 0o111)
+        self.assertFalse(
+            any(
+                "__pycache__" in path
+                or path.endswith((".pyc", ".pyo", ".DS_Store", ".env"))
+                for path in files
+            )
+        )
+
+    def test_npm_and_codex_plugin_versions_are_identical(self) -> None:
+        package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        plugin = json.loads(
+            (
+                ROOT
+                / "plugins"
+                / "agi-super-team-codex"
+                / ".codex-plugin"
+                / "plugin.json"
+            ).read_text(encoding="utf-8")
+        )
+
+        self.assertRegex(package["version"], r"^\d+\.\d+\.\d+$")
+        self.assertEqual(plugin["version"], package["version"])
+
+    def test_codex_marketplace_install_never_tracks_a_mutable_branch(self) -> None:
+        package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        cli = (ROOT / "bin" / "agi-super-team.mjs").read_text(encoding="utf-8")
+        shell_installer = (ROOT / "install.sh").read_text(encoding="utf-8")
+        guide = (ROOT / "docs" / "guides" / "codex-install.html").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn('"--ref", "main"', cli)
+        self.assertNotIn("git pull", shell_installer)
+        self.assertIn(f'REPO_REF="${{AGI_SUPER_TEAM_REF:-v{package["version"]}}}"', shell_installer)
+        self.assertNotIn("--ref main", guide)
+        self.assertIn(f"v{package['version']}", guide)
+
+    def test_ci_covers_supported_node_releases_and_primary_harnesses(self) -> None:
+        package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        workflow = (
+            ROOT / ".github" / "workflows" / "validate-repository.yml"
+        ).read_text(encoding="utf-8")
+        packed_smoke = (ROOT / "tests" / "windows_cli_smoke.mjs").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertEqual(package["engines"]["node"], ">=18")
+        for version in ("18", "20", "22", "24"):
+            with self.subTest(node=version):
+                self.assertRegex(workflow, rf'["\']{re.escape(version)}["\']')
+        for harness in ("claude-code", "codex", "openclaw", "hermes"):
+            with self.subTest(harness=harness):
+                self.assertIn(harness, packed_smoke)
+        for runner in ("ubuntu-latest", "macos-latest", "windows-latest"):
+            with self.subTest(runner=runner):
+                self.assertIn(runner, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_connect.py
+++ b/tests/test_harness_connect.py
@@ -12,6 +12,235 @@ NODE = os.environ.get("NODE", "node")
 
 
 class HarnessConnectTests(unittest.TestCase):
+    def _write_fake_openclaw(self, root: Path) -> tuple[Path, Path]:
+        log = root / "openclaw.log"
+        fake = root / "openclaw"
+        fake.write_text(
+            """#!/usr/bin/env node
+import { appendFileSync, chmodSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+const args = process.argv.slice(2);
+const mode = process.env.OPENCLAW_TEST_MODE || 'success';
+const log = process.env.OPENCLAW_TEST_LOG;
+appendFileSync(log, `${args.join(' ')}\\n`);
+const config = join(process.env.OPENCLAW_STATE_DIR, 'openclaw.json');
+
+if (args[0] === '--version') {
+  process.stdout.write('OpenClaw test\\n');
+  if (mode === 'get-spawn-error') unlinkSync(process.argv[1]);
+} else if (args[0] === 'config' && args[1] === 'get') {
+  if (mode === 'get-error') {
+    process.stderr.write('permission denied while reading configuration\\n');
+    process.exitCode = 7;
+  } else if (mode === 'get-signal') {
+    process.kill(process.pid, 'SIGTERM');
+  } else if (mode === 'get-missing' || mode === 'missing-validate-fail') {
+    process.stderr.write('Config path not found: agents.list. Run openclaw config validate to inspect config shape.\\n');
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(`${process.env.OPENCLAW_EXISTING_JSON || '[]'}\\n`);
+  }
+} else if (args[0] === 'config' && args[1] === 'patch') {
+  readFileSync(0, 'utf8');
+  if (args.includes('--dry-run')) {
+    process.stdout.write('{"ok":true}\\n');
+  } else {
+    mkdirSync(dirname(config), { recursive: true });
+    writeFileSync(config, process.env.OPENCLAW_APPLIED_CONTENT || '{"applied":true}\\n');
+    if (mode === 'patch-fail') {
+      process.stderr.write('patch failed after partial write\\n');
+      process.exitCode = 8;
+    } else {
+      process.stdout.write('{"ok":true}\\n');
+    }
+  }
+} else if (args[0] === 'config' && args[1] === 'validate') {
+  if (mode === 'validate-fail' || mode === 'missing-validate-fail') {
+    process.stderr.write('validation failed\\n');
+    process.exitCode = 9;
+  } else if (mode === 'validate-drift') {
+    writeFileSync(config, '{"thirdParty":true}\\n');
+    process.stderr.write('validation failed after concurrent change\\n');
+    process.exitCode = 9;
+  } else if (mode === 'validate-chmod') {
+    chmodSync(config, 0o644);
+    process.stderr.write('validation failed after concurrent chmod\\n');
+    process.exitCode = 9;
+  } else {
+    process.stdout.write('{"ok":true}\\n');
+  }
+} else {
+  process.exitCode = 10;
+}
+""",
+            encoding="utf-8",
+        )
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+        return fake, log
+
+    def _connect_with_fake(
+        self,
+        *,
+        home: Path,
+        fake: Path,
+        log: Path,
+        mode: str,
+        existing: list[dict] | None = None,
+        applied_content: str = '{"applied":true}\n',
+    ) -> subprocess.CompletedProcess[str]:
+        connection = {
+            "requirements": {"requiredMaxDepth": 2, "maxChildrenPerAgent": 2},
+            "configPatch": {"agents": {"list": [{"id": "ast-ceo"}]}},
+        }
+        source = f"""
+import {{ connectHarness }} from './bin/installer/connect.mjs';
+const result = connectHarness({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {json.dumps(connection)},
+  environment: {{
+    ...process.env,
+    OPENCLAW_CLI: {json.dumps(str(fake))},
+    OPENCLAW_TEST_LOG: {json.dumps(str(log))},
+    OPENCLAW_TEST_MODE: {json.dumps(mode)},
+    OPENCLAW_EXISTING_JSON: {json.dumps(json.dumps(existing or []))},
+    OPENCLAW_APPLIED_CONTENT: {json.dumps(applied_content)},
+  }},
+}});
+process.stdout.write(JSON.stringify(result));
+"""
+        return subprocess.run(
+            [NODE, "--input-type=module", "-e", source],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_openclaw_get_failure_aborts_before_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[{"id":"legacy"}]}}\n'
+            config.write_bytes(original)
+            log = root / "openclaw.log"
+            fake = root / "openclaw"
+            fake.write_text(
+                """#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$OPENCLAW_TEST_LOG"
+if [ "$1" = "--version" ]; then
+  echo "OpenClaw test"
+elif [ "$1" = "config" ] && [ "$2" = "get" ]; then
+  echo "permission denied while reading configuration" >&2
+  exit 7
+else
+  echo '{"ok":true}'
+fi
+""",
+                encoding="utf-8",
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            source = f"""
+import {{ connectHarness }} from './bin/installer/connect.mjs';
+connectHarness({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {{ configPatch: {{ agents: {{ list: [] }} }} }},
+  environment: {{
+    ...process.env,
+    OPENCLAW_CLI: {json.dumps(str(fake))},
+    OPENCLAW_TEST_LOG: {json.dumps(str(log))},
+  }},
+}});
+"""
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("permission denied", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+            self.assertFalse(
+                any("config patch" in line for line in log.read_text().splitlines())
+            )
+
+    def test_openclaw_get_signal_aborts_before_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[]}}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="get-signal",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("SIGTERM", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+            self.assertFalse(
+                any("config patch" in line for line in log.read_text().splitlines())
+            )
+
+    def test_openclaw_get_spawn_error_aborts_before_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[]}}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="get-spawn-error",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("ENOENT", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+            self.assertFalse(
+                any("config patch" in line for line in log.read_text().splitlines())
+            )
+
+    def test_openclaw_recognized_missing_agents_list_connects_from_empty_list(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            (home / ".openclaw").mkdir(parents=True)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="get-missing",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            receipt = json.loads(result.stdout)
+            self.assertEqual(receipt["managedAgents"], ["ast-ceo"])
+            self.assertEqual(receipt["preservedAgents"], [])
+
     def test_merge_preserves_unmanaged_openclaw_agents(self) -> None:
         source = """
 import { mergeManagedAgents } from './bin/installer/connect.mjs';
@@ -42,6 +271,473 @@ process.stdout.write(JSON.stringify(mergeManagedAgents(existing, managed)));
                 {"id": "ast-governor", "workspace": "/governor"},
             ],
         )
+
+    def test_openclaw_patch_failure_restores_existing_config_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{\n  "agents": {"list": [{"id": "legacy"}]}\n}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="patch-fail",
+                existing=[{"id": "legacy"}],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("patch failed", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+
+    def test_openclaw_validation_failure_restores_existing_config_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{\r\n  "agents": {"list": [{"id": "legacy"}]}\r\n}\r\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="validate-fail",
+                existing=[{"id": "legacy"}],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("validation failed", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+
+    def test_openclaw_validation_failure_removes_new_config_when_none_existed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="missing-validate-fail",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("validation failed", result.stderr)
+            self.assertFalse(config.exists())
+
+    def test_openclaw_rollback_refuses_to_overwrite_concurrent_config_change(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[{"id":"legacy"}]}}\n'
+            drifted = b'{"thirdParty":true}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="validate-drift",
+                existing=[{"id": "legacy"}],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("changed concurrently", result.stderr)
+            self.assertIn("original backup preserved at", result.stderr)
+            self.assertEqual(config.read_bytes(), drifted)
+            backups = list(
+                (state / ".agi-super-team-backups").glob("openclaw.json.*.bak")
+            )
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_bytes(), original)
+
+    @unittest.skipIf(os.name == "nt", "POSIX permission bits are not authoritative on Windows")
+    def test_openclaw_rollback_detects_concurrent_permission_change(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[]} }\n'
+            config.write_bytes(original)
+            config.chmod(0o600)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="validate-chmod",
+                applied_content=original.decode("utf-8"),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("changed concurrently", result.stderr)
+            self.assertEqual(config.read_bytes(), original)
+            self.assertEqual(stat.S_IMODE(config.stat().st_mode), 0o644)
+
+    @unittest.skipIf(os.name == "nt", "POSIX permission bits are not authoritative on Windows")
+    def test_openclaw_backup_permissions_are_private(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            config.write_text('{"agents":{"list":[]}}\n', encoding="utf-8")
+            backup_root = state / ".agi-super-team-backups"
+            backup_root.mkdir(mode=0o777)
+            backup_root.chmod(0o777)
+            fake, log = self._write_fake_openclaw(root)
+
+            result = self._connect_with_fake(
+                home=home,
+                fake=fake,
+                log=log,
+                mode="success",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            backup = next(backup_root.glob("openclaw.json.*.bak"))
+            self.assertEqual(stat.S_IMODE(backup_root.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(backup.stat().st_mode), 0o600)
+
+    def test_openclaw_transaction_can_rollback_after_successful_connection(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[{"id":"legacy"}]}}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+            connection = {
+                "requirements": {"requiredMaxDepth": 2, "maxChildrenPerAgent": 2},
+                "configPatch": {"agents": {"list": [{"id": "ast-ceo"}]}},
+            }
+            source = f"""
+import {{ connectHarnessTransaction }} from './bin/installer/connect.mjs';
+const transaction = connectHarnessTransaction({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {json.dumps(connection)},
+  environment: {{
+    ...process.env,
+    OPENCLAW_CLI: {json.dumps(str(fake))},
+    OPENCLAW_TEST_LOG: {json.dumps(str(log))},
+    OPENCLAW_TEST_MODE: 'success',
+    OPENCLAW_EXISTING_JSON: '[{{"id":"legacy"}}]',
+    OPENCLAW_APPLIED_CONTENT: '{{"applied":true}}\\n',
+  }},
+}});
+const rollback = transaction.rollback();
+process.stdout.write(JSON.stringify({{ receipt: transaction.receipt, rollback }}));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(result.stdout)
+            self.assertEqual(output["receipt"]["status"], "connected-structural")
+            self.assertEqual(output["rollback"]["status"], "rolled-back")
+            self.assertEqual(config.read_bytes(), original)
+
+    def test_openclaw_transaction_commit_is_idempotent_and_closes_rollback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            config.write_text('{"agents":{"list":[]}}\n', encoding="utf-8")
+            fake, log = self._write_fake_openclaw(root)
+            connection = {
+                "requirements": {"requiredMaxDepth": 2, "maxChildrenPerAgent": 2},
+                "configPatch": {"agents": {"list": [{"id": "ast-ceo"}]}},
+            }
+            source = f"""
+import {{ connectHarnessTransaction }} from './bin/installer/connect.mjs';
+const transaction = connectHarnessTransaction({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {json.dumps(connection)},
+  environment: {{
+    ...process.env,
+    OPENCLAW_CLI: {json.dumps(str(fake))},
+    OPENCLAW_TEST_LOG: {json.dumps(str(log))},
+    OPENCLAW_TEST_MODE: 'success',
+    OPENCLAW_EXISTING_JSON: '[]',
+  }},
+}});
+const first = transaction.commit();
+const second = transaction.commit();
+const rollback = transaction.rollback();
+process.stdout.write(JSON.stringify({{ first, second, rollback }}));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(result.stdout)
+            self.assertEqual(output["first"]["status"], "committed")
+            self.assertEqual(output["second"]["status"], "committed")
+            self.assertEqual(output["rollback"]["status"], "not-active")
+
+    def test_openclaw_preflight_is_read_only_and_exercises_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            state = home / ".openclaw"
+            state.mkdir(parents=True)
+            config = state / "openclaw.json"
+            original = b'{"agents":{"list":[{"id":"legacy"}]}}\n'
+            config.write_bytes(original)
+            fake, log = self._write_fake_openclaw(root)
+            connection = {
+                "requirements": {"requiredMaxDepth": 2, "maxChildrenPerAgent": 2},
+                "configPatch": {"agents": {"list": [{"id": "ast-ceo"}]}},
+            }
+            source = f"""
+import {{ preflightHarnessConnection }} from './bin/installer/connect.mjs';
+const result = preflightHarnessConnection({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {json.dumps(connection)},
+  environment: {{
+    ...process.env,
+    OPENCLAW_CLI: {json.dumps(str(fake))},
+    OPENCLAW_TEST_LOG: {json.dumps(str(log))},
+    OPENCLAW_TEST_MODE: 'success',
+    OPENCLAW_EXISTING_JSON: '[{{"id":"legacy"}}]',
+  }},
+}});
+process.stdout.write(JSON.stringify(result));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(result.stdout)
+            self.assertEqual(output["status"], "ready")
+            self.assertEqual(output["preservedAgents"], ["legacy"])
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertTrue(any("config patch" in call and "--dry-run" in call for call in calls))
+            self.assertFalse(any("config patch" in call and "--dry-run" not in call for call in calls))
+            self.assertFalse(any("config validate" in call for call in calls))
+            self.assertEqual(config.read_bytes(), original)
+            self.assertFalse((state / ".agi-super-team-backups").exists())
+
+    @unittest.skipUnless(os.name == "nt", "requires Windows cmd.exe")
+    def test_openclaw_preflight_launches_cmd_shim_on_windows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="agi super team ") as directory:
+            root = Path(directory)
+            home = root / "home"
+            (home / ".openclaw").mkdir(parents=True)
+            fake = root / "openclaw.cmd"
+            fake.write_text(
+                """@echo off
+if "%1"=="--version" (
+  echo OpenClaw Windows test
+  exit /b 0
+)
+if "%1"=="config" if "%2"=="get" (
+  echo []
+  exit /b 0
+)
+if "%1"=="config" if "%2"=="patch" (
+  more ^> nul
+  echo {"ok":true}
+  exit /b 0
+)
+exit /b 10
+""",
+                encoding="utf-8",
+            )
+            connection = {
+                "requirements": {"requiredMaxDepth": 2, "maxChildrenPerAgent": 2},
+                "configPatch": {"agents": {"list": [{"id": "ast-ceo"}]}},
+            }
+            source = f"""
+import {{ preflightHarnessConnection }} from './bin/installer/connect.mjs';
+const result = preflightHarnessConnection({{
+  tool: {{ id: 'openclaw' }},
+  home: {json.dumps(str(home))},
+  connection: {json.dumps(connection)},
+  environment: {{ ...process.env, OPENCLAW_CLI: {json.dumps(str(fake))} }},
+}});
+process.stdout.write(JSON.stringify(result));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(json.loads(result.stdout)["status"], "ready")
+
+    def test_receipt_transaction_restores_existing_receipt_on_rollback(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            receipt = root / ".openclaw" / "agi-super-team" / "receipt.json"
+            receipt.parent.mkdir(parents=True)
+            original = b'{"status":"previous"}\r\n'
+            receipt.write_bytes(original)
+            source = f"""
+import {{ writeHarnessReceiptTransaction }} from './bin/installer/connect.mjs';
+const transaction = writeHarnessReceiptTransaction({{
+  root: {json.dumps(str(root))},
+  connectionPath: '.openclaw/agi-super-team/connection.json',
+  receipt: {{ status: 'connected-structural' }},
+}});
+const written = await import('node:fs').then((fs) => fs.readFileSync(transaction.path, 'utf8'));
+const rollback = transaction.rollback();
+process.stdout.write(JSON.stringify({{ written, rollback }}));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(result.stdout)
+            self.assertIn("connected-structural", output["written"])
+            self.assertEqual(output["rollback"]["status"], "rolled-back")
+            self.assertEqual(receipt.read_bytes(), original)
+
+    def test_receipt_transaction_refuses_concurrent_change_before_replace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            receipt = root / ".openclaw" / "agi-super-team" / "receipt.json"
+            receipt.parent.mkdir(parents=True)
+            original = b'{"status":"original"}\n'
+            concurrent = b'{"status":"concurrent"}\n'
+            receipt.write_bytes(original)
+            source = f"""
+import {{ writeFileSync }} from 'node:fs';
+import {{ writeHarnessReceiptTransaction }} from './bin/installer/connect.mjs';
+const target = {json.dumps(str(receipt))};
+const nextReceipt = {{
+  get status() {{
+    writeFileSync(target, {json.dumps(concurrent.decode("utf-8"))});
+    return 'connected-structural';
+  }},
+}};
+writeHarnessReceiptTransaction({{
+  root: {json.dumps(str(root))},
+  connectionPath: '.openclaw/agi-super-team/connection.json',
+  receipt: nextReceipt,
+}});
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("changed concurrently before write", result.stderr)
+            self.assertEqual(receipt.read_bytes(), concurrent)
+            leftovers = [
+                path
+                for path in receipt.parent.iterdir()
+                if path.name.startswith(".agi-super-team-receipt")
+            ]
+            self.assertEqual(leftovers, [])
+
+    @unittest.skipIf(os.name == "nt", "uses POSIX directory permissions")
+    def test_receipt_commit_is_idempotent_when_backup_cleanup_cannot_run(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            receipt = root / ".openclaw" / "agi-super-team" / "receipt.json"
+            receipt.parent.mkdir(parents=True)
+            receipt.write_text('{"status":"previous"}\n', encoding="utf-8")
+            source = f"""
+import {{ chmodSync }} from 'node:fs';
+import {{ dirname }} from 'node:path';
+import {{ writeHarnessReceiptTransaction }} from './bin/installer/connect.mjs';
+const transaction = writeHarnessReceiptTransaction({{
+  root: {json.dumps(str(root))},
+  connectionPath: '.openclaw/agi-super-team/connection.json',
+  receipt: {{ status: 'connected-structural' }},
+}});
+chmodSync(dirname(transaction.path), 0o500);
+let first;
+let second;
+let rollback;
+try {{
+  first = transaction.commit();
+  second = transaction.commit();
+  rollback = transaction.rollback();
+}} finally {{
+  chmodSync(dirname(transaction.path), 0o700);
+}}
+process.stdout.write(JSON.stringify({{ first, second, rollback }}));
+"""
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "-e", source],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            output = json.loads(result.stdout)
+            self.assertEqual(output["first"]["status"], "committed")
+            self.assertTrue(output["first"]["backupPreserved"])
+            self.assertTrue(Path(output["first"]["backup"]).exists())
+            self.assertEqual(output["second"], output["first"])
+            self.assertEqual(output["rollback"]["status"], "not-active")
+            self.assertIn("connected-structural", receipt.read_text(encoding="utf-8"))
 
     def test_openclaw_connect_dry_runs_before_validated_apply(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_installer_file_safety.py
+++ b/tests/test_installer_file_safety.py
@@ -1,0 +1,492 @@
+import os
+import json
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPOSITORY_ROOT / "bin" / "agi-super-team.mjs"
+
+
+class InstallerFileSafetyTests(unittest.TestCase):
+    def test_skill_scripts_remain_executable_and_regular_content_is_private(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            home = fixture / "home"
+            project = fixture / "project"
+            project.mkdir()
+            installed = subprocess.run(
+                [
+                    "node",
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "claude-code",
+                    "--no-agents",
+                    "--install",
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+            script = home / ".claude" / "skills" / "systematic-debugging" / "find-polluter.sh"
+            skill = home / ".claude" / "skills" / "systematic-debugging" / "SKILL.md"
+            self.assertTrue(script.stat().st_mode & stat.S_IXUSR)
+            self.assertEqual(stat.S_IMODE(script.stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE(skill.stat().st_mode), 0o600)
+            executed = subprocess.run(
+                [os.fspath(script)],
+                cwd=fixture,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(executed.returncode, 126, executed.stderr)
+            self.assertIn("Usage:", executed.stdout)
+
+    def test_transaction_rollback_restores_original_bytes_and_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            existing = fixture / "existing.txt"
+            existing.write_text("original\n", encoding="utf-8")
+            existing.chmod(0o750)
+            added = fixture / "added.txt"
+            script = r"""
+import { lstatSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlanTransaction } from "./bin/installer/core.mjs";
+
+const root = process.argv[1];
+const existing = join(root, "existing.txt");
+const added = join(root, "added.txt");
+const baseline = readFileSync(existing);
+const transaction = applyPlanTransaction([
+  {
+    tool: "fixture",
+    root,
+    destination: existing,
+    content: Buffer.from("replacement\n"),
+    baseline,
+    baselineMode: lstatSync(existing).mode & 0o777,
+    mode: 0o600,
+    label: "existing",
+    status: "update",
+  },
+  {
+    tool: "fixture",
+    root,
+    destination: added,
+    content: Buffer.from("added\n"),
+    baseline: null,
+    baselineMode: null,
+    mode: 0o700,
+    label: "added",
+    status: "add",
+  },
+]);
+transaction.rollback();
+console.log(JSON.stringify({ backups: transaction.backups }));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(fixture)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(json.loads(result.stdout)["backups"])
+            self.assertEqual(existing.read_text(encoding="utf-8"), "original\n")
+            self.assertEqual(stat.S_IMODE(existing.stat().st_mode), 0o750)
+            self.assertFalse(added.exists())
+            self.assertFalse((fixture / ".agi-super-team-backups").exists())
+
+    def test_apply_rejects_mode_drift_after_preview_before_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            destination = fixture / "existing.txt"
+            destination.write_text("original\n", encoding="utf-8")
+            destination.chmod(0o644)
+            script = r"""
+import { chmodSync, readFileSync } from "node:fs";
+import { applyPlan } from "./bin/installer/core.mjs";
+
+const [root, destination] = process.argv.slice(1);
+const baseline = readFileSync(destination);
+chmodSync(destination, 0o600);
+try {
+  applyPlan([{
+    tool: "fixture",
+    root,
+    destination,
+    content: Buffer.from("replacement\n"),
+    baseline,
+    baselineMode: 0o644,
+    mode: 0o600,
+    label: "existing",
+    status: "update",
+  }]);
+  console.log("accepted");
+} catch (error) {
+  console.log(error.message);
+}
+"""
+            result = subprocess.run(
+                [
+                    "node",
+                    "--input-type=module",
+                    "--eval",
+                    script,
+                    str(fixture),
+                    str(destination),
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("destination changed after preview", result.stdout)
+            self.assertEqual(destination.read_text(encoding="utf-8"), "original\n")
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o600)
+            self.assertEqual(sorted(path.name for path in fixture.iterdir()), ["existing.txt"])
+
+    def test_doctor_reports_an_installed_script_that_lost_execute_permission(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            home = fixture / "home"
+            project = fixture / "project"
+            project.mkdir()
+            arguments = [
+                "node",
+                str(CLI),
+                "--home",
+                str(home),
+                "--project-dir",
+                str(project),
+                "--tool",
+                "claude-code",
+                "--no-agents",
+            ]
+            installed = subprocess.run(
+                [*arguments, "--install"],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(installed.returncode, 0, installed.stdout + installed.stderr)
+            script = home / ".claude" / "skills" / "systematic-debugging" / "find-polluter.sh"
+            script.chmod(0o600)
+
+            doctor = subprocess.run(
+                [*arguments, "--doctor"],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(doctor.returncode, 0, doctor.stdout + doctor.stderr)
+            self.assertIn("mode", doctor.stdout.lower())
+
+    def test_windows_doctor_compares_only_the_writable_mode_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            destination = fixture / "script.sh"
+            destination.write_text("payload\n", encoding="utf-8")
+            script = r"""
+import { chmodSync, readFileSync } from "node:fs";
+import { doctor } from "./bin/installer/core.mjs";
+
+const destination = process.argv[1];
+const content = readFileSync(destination);
+const plan = [{
+  tool: "fixture",
+  root: process.argv[2],
+  destination,
+  content,
+  baseline: content,
+  baselineMode: 0o666,
+  mode: 0o700,
+  platform: "win32",
+  label: "script",
+  status: "unchanged",
+}];
+chmodSync(destination, 0o666);
+const writable = doctor(plan, []);
+chmodSync(destination, 0o444);
+const readonly = doctor(plan, []);
+console.log(JSON.stringify({ writable, readonly }));
+"""
+            result = subprocess.run(
+                [
+                    "node",
+                    "--input-type=module",
+                    "--eval",
+                    script,
+                    str(destination),
+                    str(fixture),
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = json.loads(result.stdout)
+            self.assertTrue(output["writable"]["ok"])
+            self.assertFalse(output["readonly"]["ok"])
+            self.assertIn("mode drifted", output["readonly"]["issues"][0])
+
+    def test_windows_repeated_plan_is_unchanged_when_only_unrepresentable_bits_differ(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            script = r"""
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlan, buildPlan } from "./bin/installer/core.mjs";
+
+const home = process.argv[1];
+const catalog = {
+  agents: [],
+  specialistGroups: {},
+  assignedSkills: { byAgent: {} },
+  skills: [],
+};
+const tools = [{
+  id: "fixture",
+  scope: "global",
+  agentMode: "combined-rules",
+  agentPaths: ["rules.md"],
+  skillPaths: [],
+}];
+const options = {
+  packageRoot: home,
+  catalog,
+  tools,
+  home,
+  projectDir: null,
+  includeAgents: false,
+  includeSkills: false,
+  platform: "win32",
+};
+applyPlan(buildPlan(options));
+chmodSync(join(home, "rules.md"), 0o666);
+console.log(JSON.stringify(buildPlan(options).map(({ status, platform }) => ({ status, platform }))));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(fixture)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(result.stdout),
+                [{"status": "unchanged", "platform": "win32"}],
+            )
+
+    def test_windows_transaction_rolls_back_after_runtime_reports_a_coarser_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            destination = fixture / "existing.txt"
+            destination.write_text("original\n", encoding="utf-8")
+            destination.chmod(0o644)
+            script = r"""
+import { chmodSync, lstatSync, readFileSync } from "node:fs";
+import { applyPlanTransaction } from "./bin/installer/core.mjs";
+
+const [root, destination] = process.argv.slice(1);
+const baseline = readFileSync(destination);
+const transaction = applyPlanTransaction([{
+  tool: "fixture",
+  root,
+  destination,
+  content: Buffer.from("replacement\n"),
+  baseline,
+  baselineMode: lstatSync(destination).mode & 0o777,
+  mode: 0o700,
+  platform: "win32",
+  label: "existing",
+  status: "update",
+}]);
+chmodSync(destination, 0o666);
+transaction.rollback();
+console.log(JSON.stringify({
+  content: readFileSync(destination, "utf8"),
+  mode: lstatSync(destination).mode & 0o777,
+}));
+"""
+            result = subprocess.run(
+                [
+                    "node",
+                    "--input-type=module",
+                    "--eval",
+                    script,
+                    str(fixture),
+                    str(destination),
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(result.stdout),
+                {"content": "original\n", "mode": 0o644},
+            )
+
+    def test_transaction_rollback_removes_only_its_new_empty_directory_tree(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            root = fixture / "new-home"
+            script = r"""
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlanTransaction } from "./bin/installer/core.mjs";
+
+const root = process.argv[1];
+const destination = join(root, "nested", "deeper", "installed.txt");
+const transaction = applyPlanTransaction([{
+  tool: "fixture",
+  root,
+  destination,
+  content: Buffer.from("installed\n"),
+  baseline: null,
+  baselineMode: null,
+  mode: 0o600,
+  label: "added",
+  status: "add",
+}]);
+const installed = existsSync(destination);
+transaction.rollback();
+console.log(JSON.stringify({ installed, rootExists: existsSync(root) }));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(root)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(result.stdout),
+                {"installed": True, "rootExists": False},
+            )
+
+    def test_windows_later_write_failure_rolls_back_file_and_created_directories(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            root = fixture / "new-home"
+            script = r"""
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlanTransaction } from "./bin/installer/core.mjs";
+
+const root = process.argv[1];
+const destination = join(root, "nested", "installed.txt");
+const common = {
+  tool: "fixture",
+  root,
+  destination,
+  baseline: null,
+  baselineMode: null,
+  platform: "win32",
+  label: "added",
+  status: "add",
+};
+let message = "accepted";
+try {
+  applyPlanTransaction([
+    { ...common, content: Buffer.from("first\n"), mode: 0o700 },
+    { ...common, content: Buffer.from("second\n"), mode: 0o600 },
+  ]);
+} catch (error) {
+  message = error.message;
+}
+console.log(JSON.stringify({ message, rootExists: existsSync(root) }));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(root)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = json.loads(result.stdout)
+            self.assertIn("destination changed after preview", output["message"])
+            self.assertFalse(output["rootExists"])
+
+    def test_transaction_rollback_preserves_user_content_added_to_a_new_root(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory).resolve()
+            root = fixture / "new-home"
+            script = r"""
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlanTransaction } from "./bin/installer/core.mjs";
+
+const root = process.argv[1];
+const destination = join(root, "nested", "installed.txt");
+const transaction = applyPlanTransaction([{
+  tool: "fixture",
+  root,
+  destination,
+  content: Buffer.from("installed\n"),
+  baseline: null,
+  baselineMode: null,
+  mode: 0o600,
+  label: "added",
+  status: "add",
+}]);
+const userFile = join(root, "user.txt");
+writeFileSync(userFile, "user\n");
+transaction.rollback();
+console.log(JSON.stringify({
+  rootExists: existsSync(root),
+  userFileExists: existsSync(userFile),
+  nestedExists: existsSync(join(root, "nested")),
+}));
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(root)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                json.loads(result.stdout),
+                {
+                    "rootExists": True,
+                    "userFileExists": True,
+                    "nestedExists": False,
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_installer_path_safety.py
+++ b/tests/test_installer_path_safety.py
@@ -1,0 +1,144 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class InstallerPathSafetyTests(unittest.TestCase):
+    def test_posix_and_windows_paths_require_strict_containment(self):
+        script = r"""
+import path from "node:path";
+import { isStrictDescendant } from "./bin/installer/path-safety.mjs";
+
+const contracts = {
+  posix: {
+    api: path.posix,
+    root: "/pkg/agents",
+    cases: {
+      root: "/pkg/agents",
+      child: "/pkg/agents/ceo",
+      traversal: "/pkg/agents/../outside",
+      siblingPrefix: "/pkg/agents-evil/ceo",
+    },
+  },
+  win32: {
+    api: path.win32,
+    root: String.raw`C:\pkg\agents`,
+    cases: {
+      root: String.raw`C:\pkg\agents`,
+      child: String.raw`C:\pkg\agents\ceo`,
+      traversal: String.raw`C:\pkg\agents\..\outside`,
+      siblingPrefix: String.raw`C:\pkg\agents-evil\ceo`,
+      crossDrive: String.raw`D:\pkg\agents\ceo`,
+    },
+  },
+  win32Unc: {
+    api: path.win32,
+    root: String.raw`\\server\share\agents`,
+    cases: {
+      child: String.raw`\\server\share\agents\ceo`,
+      otherServer: String.raw`\\other\share\agents\ceo`,
+      otherShare: String.raw`\\server\other\agents\ceo`,
+    },
+  },
+};
+
+console.log(JSON.stringify(Object.fromEntries(Object.entries(contracts).map(
+  ([contract, { api, root, cases }]) => [
+    contract,
+    Object.fromEntries(Object.entries(cases).map(([name, candidate]) => [
+      name,
+      isStrictDescendant(root, candidate, api),
+    ])),
+  ],
+))));
+"""
+        result = subprocess.run(
+            ["node", "--input-type=module", "--eval", script],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "posix": {
+                    "root": False,
+                    "child": True,
+                    "traversal": False,
+                    "siblingPrefix": False,
+                },
+                "win32": {
+                    "root": False,
+                    "child": True,
+                    "traversal": False,
+                    "siblingPrefix": False,
+                    "crossDrive": False,
+                },
+                "win32Unc": {
+                    "child": True,
+                    "otherServer": False,
+                    "otherShare": False,
+                },
+            },
+        )
+
+    def test_physical_containment_rejects_leaf_and_ancestor_symlinks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            root = fixture / "agents"
+            child = root / "ceo" / "AGENTS.md"
+            child.parent.mkdir(parents=True)
+            child.write_text("canonical", encoding="utf-8")
+            outside = fixture / "outside"
+            outside.mkdir()
+            outside_file = outside / "AGENTS.md"
+            outside_file.write_text("outside", encoding="utf-8")
+            leaf_link = root / "ceo" / "SOUL.md"
+            leaf_link.symlink_to(outside_file)
+            ancestor_link = root / "linked-agent"
+            ancestor_link.symlink_to(outside, target_is_directory=True)
+
+            script = r"""
+import { isPhysicalStrictDescendant } from "./bin/installer/path-safety.mjs";
+
+const [root, child, leafLink, ancestorChild] = process.argv.slice(1);
+console.log(JSON.stringify({
+  child: isPhysicalStrictDescendant(root, child),
+  leafLink: isPhysicalStrictDescendant(root, leafLink),
+  ancestorLink: isPhysicalStrictDescendant(root, ancestorChild),
+}));
+"""
+            result = subprocess.run(
+                [
+                    "node",
+                    "--input-type=module",
+                    "--eval",
+                    script,
+                    str(root),
+                    str(child),
+                    str(leaf_link),
+                    str(ancestor_link / "AGENTS.md"),
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {"child": True, "leafLink": False, "ancestorLink": False},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_installer_path_safety.py
+++ b/tests/test_installer_path_safety.py
@@ -9,6 +9,206 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class InstallerPathSafetyTests(unittest.TestCase):
+    def test_safe_root_rejects_posix_windows_drive_and_unc_roots(self):
+        script = r"""
+import path from "node:path";
+import { safeRoot } from "./bin/installer/core.mjs";
+
+const cases = [
+  ["posix", "/", path.posix],
+  ["win32-drive", "C:\\", path.win32],
+  ["win32-unc", "\\\\server\\share\\", path.win32],
+];
+const results = Object.fromEntries(cases.map(([name, candidate, api]) => {
+  try {
+    safeRoot(candidate, "test root", api);
+    return [name, "accepted"];
+  } catch (error) {
+    return [name, error.message];
+  }
+}));
+console.log(JSON.stringify(results));
+"""
+        result = subprocess.run(
+            ["node", "--input-type=module", "--eval", script],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outcomes = json.loads(result.stdout)
+        for platform, outcome in outcomes.items():
+            with self.subTest(platform=platform):
+                self.assertIn("refusing unsafe test root", outcome)
+
+    def test_safe_root_pins_the_physical_parent_of_a_missing_root(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            first = fixture / "first"
+            second = fixture / "second"
+            first.mkdir()
+            second.mkdir()
+            alias = fixture / "alias"
+            alias.symlink_to(first, target_is_directory=True)
+
+            script = r"""
+import { unlinkSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { applyPlan, safeRoot } from "./bin/installer/core.mjs";
+
+const [alias, first, second] = process.argv.slice(1);
+const root = safeRoot(join(alias, "new-home"), "home");
+unlinkSync(alias);
+symlinkSync(second, alias, "dir");
+const destination = join(root, "installed.txt");
+applyPlan([{
+  tool: "fixture",
+  root,
+  destination,
+  content: Buffer.from("installed\n"),
+  baseline: null,
+  label: "fixture",
+  status: "add",
+}]);
+console.log(JSON.stringify({ root, destination }));
+"""
+            result = subprocess.run(
+                [
+                    "node",
+                    "--input-type=module",
+                    "--eval",
+                    script,
+                    str(alias),
+                    str(first),
+                    str(second),
+                ],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = json.loads(result.stdout)
+            # macOS exposes /var and /tmp through stable system aliases. The
+            # installer pins their physical /private paths before planning.
+            self.assertEqual(Path(output["root"]), first.resolve() / "new-home")
+            self.assertEqual((first / "new-home" / "installed.txt").read_text(), "installed\n")
+            self.assertFalse((second / "new-home").exists())
+
+    def test_apply_rejects_an_unpinned_symlink_ancestor_before_writes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            outside = fixture / "outside"
+            outside.mkdir()
+            sentinel = outside / "keep.txt"
+            sentinel.write_text("keep\n", encoding="utf-8")
+            alias = fixture / "alias"
+            alias.symlink_to(outside, target_is_directory=True)
+
+            script = r"""
+import { join } from "node:path";
+import { applyPlan } from "./bin/installer/core.mjs";
+
+const root = join(process.argv[1], "new-home");
+try {
+  applyPlan([{
+    tool: "fixture",
+    root,
+    destination: join(root, "installed.txt"),
+    content: Buffer.from("installed\n"),
+    baseline: null,
+    label: "fixture",
+    status: "add",
+  }]);
+  console.log("accepted");
+} catch (error) {
+  console.log(error.message);
+}
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(alias)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("unsafe target root", result.stdout)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep\n")
+            self.assertEqual(sorted(path.name for path in outside.iterdir()), ["keep.txt"])
+
+    def test_walk_files_rejects_a_symlinked_source_root(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            physical = fixture / "physical"
+            physical.mkdir()
+            (physical / "payload.txt").write_text("outside\n", encoding="utf-8")
+            linked = fixture / "linked-source"
+            linked.symlink_to(physical, target_is_directory=True)
+            script = r"""
+import { walkFiles } from "./bin/installer/render.mjs";
+
+try {
+  walkFiles(process.argv[1]);
+  console.log("accepted");
+} catch (error) {
+  console.log(error.message);
+}
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(linked)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("refusing symlinked source root", result.stdout)
+
+    def test_global_ceo_payload_rejects_a_symlinked_source_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            global_root = (
+                fixture
+                / "plugins"
+                / "agi-super-team-codex"
+                / "payload"
+                / "global"
+            )
+            global_root.mkdir(parents=True)
+            outside = fixture / "outside.md"
+            outside.write_text(
+                "<!-- AGI-SUPER-TEAM:CEO:BEGIN -->\noutside\n"
+                "<!-- AGI-SUPER-TEAM:CEO:END -->\n",
+                encoding="utf-8",
+            )
+            (global_root / "AGENTS.md").symlink_to(outside)
+            script = r"""
+import { globalCeoPayload } from "./bin/installer/render.mjs";
+
+try {
+  globalCeoPayload(process.argv[1]);
+  console.log("accepted");
+} catch (error) {
+  console.log(error.message);
+}
+"""
+            result = subprocess.run(
+                ["node", "--input-type=module", "--eval", script, str(fixture)],
+                cwd=REPOSITORY_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("unsafe global CEO payload", result.stdout)
+
     def test_content_addressed_agent_markdown_pins_lf_checkouts(self):
         result = subprocess.run(
             [

--- a/tests/test_installer_path_safety.py
+++ b/tests/test_installer_path_safety.py
@@ -9,6 +9,27 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 class InstallerPathSafetyTests(unittest.TestCase):
+    def test_content_addressed_agent_markdown_pins_lf_checkouts(self):
+        result = subprocess.run(
+            [
+                "git",
+                "check-attr",
+                "eol",
+                "--",
+                "agents/cto/subagents/frontend-developer/AGENTS.md",
+            ],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(),
+            "agents/cto/subagents/frontend-developer/AGENTS.md: eol: lf",
+        )
+
     def test_posix_and_windows_paths_require_strict_containment(self):
         script = r"""
 import path from "node:path";

--- a/tests/test_multi_cli_installer.py
+++ b/tests/test_multi_cli_installer.py
@@ -155,6 +155,44 @@ class MultiCliInstallerTests(unittest.TestCase):
                 ],
             )
 
+    def test_spawn_cli_does_not_quote_bare_windows_command_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_comspec = root / "fake-comspec"
+            log = root / "comspec.json"
+            fake_comspec.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "with open(os.environ['FAKE_COMSPEC_LOG'], 'w', encoding='utf-8') as f:\n"
+                "    json.dump(sys.argv[1:], f)\n",
+                encoding="utf-8",
+            )
+            fake_comspec.chmod(0o755)
+            script = (
+                "import {spawnCli} from './bin/installer/process.mjs';"
+                "const result=spawnCli('openclaw',['--version'],"
+                "{platform:'win32',comspec:process.env.FAKE_COMSPEC,env:process.env});"
+                "process.exit(result.status ?? 1);"
+            )
+            environment = os.environ.copy()
+            environment["FAKE_COMSPEC"] = str(fake_comspec)
+            environment["FAKE_COMSPEC_LOG"] = str(log)
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "--eval", script],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assert_success(result)
+            self.assertEqual(
+                json.loads(log.read_text(encoding="utf-8")),
+                ["/d", "/s", "/c", "openclaw --version"],
+            )
+
     def test_spawn_cli_rejects_windows_shell_metacharacters(self) -> None:
         script = (
             "import {spawnCli} from './bin/installer/process.mjs';"

--- a/tests/test_multi_cli_installer.py
+++ b/tests/test_multi_cli_installer.py
@@ -111,6 +111,68 @@ class MultiCliInstallerTests(unittest.TestCase):
         for tool_id in self.tools:
             self.assertIn(tool_id, result.stdout)
 
+    def test_spawn_cli_uses_comspec_for_windows_command_shims(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_comspec = root / "fake-comspec"
+            log = root / "comspec.json"
+            fake_comspec.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "with open(os.environ['FAKE_COMSPEC_LOG'], 'w', encoding='utf-8') as f:\n"
+                "    json.dump(sys.argv[1:], f)\n",
+                encoding="utf-8",
+            )
+            fake_comspec.chmod(0o755)
+            script = (
+                "import {spawnCli} from './bin/installer/process.mjs';"
+                "const result=spawnCli('C:\\\\Program Files (x86)\\\\Codex\\\\codex.cmd',"
+                "['plugin','marketplace','upgrade','agi-super-team'],"
+                "{platform:'win32',comspec:process.env.FAKE_COMSPEC,env:process.env});"
+                "process.exit(result.status ?? 1);"
+            )
+            environment = os.environ.copy()
+            environment["FAKE_COMSPEC"] = str(fake_comspec)
+            environment["FAKE_COMSPEC_LOG"] = str(log)
+
+            result = subprocess.run(
+                [NODE, "--input-type=module", "--eval", script],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assert_success(result)
+            self.assertEqual(
+                json.loads(log.read_text(encoding="utf-8")),
+                [
+                    "/d",
+                    "/s",
+                    "/c",
+                    '\"\"C:\\Program Files (x86)\\Codex\\codex.cmd\" plugin marketplace upgrade agi-super-team\"',
+                ],
+            )
+
+    def test_spawn_cli_rejects_windows_shell_metacharacters(self) -> None:
+        script = (
+            "import {spawnCli} from './bin/installer/process.mjs';"
+            "try { spawnCli('codex',['plugin&whoami'],{platform:'win32'}); }"
+            "catch (error) { console.error(error.message); process.exit(23); }"
+        )
+
+        result = subprocess.run(
+            [NODE, "--input-type=module", "--eval", script],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 23, result.stdout + result.stderr)
+        self.assertIn("unsafe Windows CLI argument", result.stderr)
+
     def test_default_preview_does_not_create_or_change_destinations(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -125,6 +187,74 @@ class MultiCliInstallerTests(unittest.TestCase):
 
             self.assert_success(result)
             self.assertIn("PREVIEW", result.stdout.upper())
+            self.assertEqual(self.snapshot(home, project), before)
+
+    def test_connect_rejects_targets_without_an_adapter_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            sentinel = project / "keep.txt"
+            sentinel.write_text("owned by user\n", encoding="utf-8")
+            before = self.snapshot(home, project)
+
+            result = self.run_cli(
+                home,
+                project,
+                "--tool",
+                "cursor",
+                "--install",
+                "--connect",
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("does not support --connect", result.stderr)
+            self.assertEqual(self.snapshot(home, project), before)
+
+    def test_legacy_team_options_reject_all_tools_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            before = self.snapshot(home, project)
+
+            result = self.run_cli(
+                home,
+                project,
+                "--all-tools",
+                "--team",
+                "solo-founder",
+                "--install",
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("legacy Team options only apply to the codex target", result.stderr)
+            self.assertEqual(self.snapshot(home, project), before)
+
+    def test_subagent_group_requires_its_manager_in_the_selected_team(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            before = self.snapshot(home, project)
+
+            result = self.run_cli(
+                home,
+                project,
+                "--tool",
+                "codex",
+                "--team",
+                "content-creator",
+                "--with-subagents",
+                "cto",
+                "--install",
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("subagent manager is not in the selected Team: cto", result.stderr)
             self.assertEqual(self.snapshot(home, project), before)
 
     def test_priority_tools_install_agents_at_their_native_paths(self) -> None:
@@ -372,6 +502,8 @@ class MultiCliInstallerTests(unittest.TestCase):
             healthy = self.run_cli(home, project, *arguments, "--doctor")
             self.assert_success(healthy)
             self.assertRegex(healthy.stdout.lower(), r"ok|pass|healthy|installed")
+            self.assertIn("FILES_HEALTHY", healthy.stdout)
+            self.assertIn("connection/runtime status requires a receipt", healthy.stdout)
 
     def test_codex_install_uses_allowlisted_plugin_commands(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -406,6 +538,7 @@ class MultiCliInstallerTests(unittest.TestCase):
                     str(project),
                     "--tool",
                     "codex",
+                    "--plugin",
                     "--install",
                 ],
                 capture_output=True,
@@ -417,9 +550,349 @@ class MultiCliInstallerTests(unittest.TestCase):
             self.assert_success(result)
             calls = log.read_text(encoding="utf-8").splitlines()
             self.assertIn("--version", calls)
-            self.assertIn("plugin marketplace add aAAaqwq/AGI-Super-Team --ref main", calls)
+            self.assertIn("plugin marketplace add aAAaqwq/AGI-Super-Team --ref v1.4.1", calls)
             self.assertIn("plugin marketplace upgrade agi-super-team", calls)
             self.assertIn("plugin add agi-super-team-codex@agi-super-team", calls)
+
+    def test_codex_plugin_capability_failure_prevents_mutation_and_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            fake_codex = root / "codex"
+            log = root / "codex.log"
+            fake_codex.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, sys\n"
+                "args = sys.argv[1:]\n"
+                "with open(os.environ['FAKE_CODEX_LOG'], 'a', encoding='utf-8') as f:\n"
+                "    f.write(' '.join(args) + '\\n')\n"
+                "if args == ['plugin', 'marketplace', 'add', '--help']:\n"
+                "    print('unknown command', file=sys.stderr)\n"
+                "    raise SystemExit(64)\n",
+                encoding="utf-8",
+            )
+            fake_codex.chmod(0o755)
+            environment = os.environ.copy()
+            environment["CODEX_CLI"] = str(fake_codex)
+            environment["FAKE_CODEX_LOG"] = str(log)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "codex",
+                    "--plugin",
+                    "--install",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("does not support required plugin command", result.stderr)
+            calls = log.read_text(encoding="utf-8").splitlines()
+            self.assertIn("plugin marketplace add --help", calls)
+            self.assertFalse(any(call.startswith("plugin marketplace add aAAaqwq/") for call in calls))
+            self.assertFalse((home / ".codex" / "agents" / "ast-cto.toml").exists())
+            self.assertFalse(home.exists(), "failed plugin preflight must restore the original directory tree")
+
+    def test_codex_plugin_is_an_explicit_opt_in(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            fake_codex = root / "codex"
+            log = root / "codex.log"
+            fake_codex.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, sys\n"
+                "with open(os.environ['FAKE_CODEX_LOG'], 'a', encoding='utf-8') as f:\n"
+                "    f.write(' '.join(sys.argv[1:]) + '\\n')\n",
+                encoding="utf-8",
+            )
+            fake_codex.chmod(0o755)
+            environment = os.environ.copy()
+            environment["CODEX_CLI"] = str(fake_codex)
+            environment["FAKE_CODEX_LOG"] = str(log)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "codex",
+                    "--no-skills",
+                    "--install",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assert_success(result)
+            self.assertFalse(log.exists(), "default Codex install must not invoke the external plugin CLI")
+            self.assertIn("disabled (add --plugin to opt in)", result.stdout)
+
+    def test_codex_home_controls_artifacts_and_connection_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            codex_home = root / "custom-codex"
+            project.mkdir()
+            environment = os.environ.copy()
+            environment["HOME"] = str(home)
+            environment["CODEX_HOME"] = str(codex_home)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "codex",
+                    "--skip-plugin",
+                    "--install",
+                    "--connect",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assert_success(result)
+            self.assertTrue((codex_home / "agents" / "ast-cto.toml").is_file())
+            self.assertTrue((codex_home / "agi-super-team" / "connection.json").is_file())
+            self.assertTrue((codex_home / "agi-super-team" / "receipt.json").is_file())
+            self.assertFalse((home / ".codex").exists())
+            self.assertTrue((home / ".agents" / "skills" / "agi-super-team-orchestrator" / "SKILL.md").is_file())
+            self.assertFalse((codex_home / "skills").exists())
+
+    def test_conflicting_home_and_codex_home_are_rejected_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            codex_home = root / "different-codex"
+            project.mkdir()
+            before = self.snapshot(home, project, codex_home)
+            environment = os.environ.copy()
+            environment["CODEX_HOME"] = str(codex_home)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "codex",
+                    "--skip-plugin",
+                    "--install",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("--home conflicts with CODEX_HOME", result.stderr)
+            self.assertEqual(self.snapshot(home, project, codex_home), before)
+
+    def test_codex_home_does_not_affect_non_codex_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            environment = os.environ.copy()
+            environment["CODEX_HOME"] = str(root / "unrelated-codex-home")
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "claude-code",
+                    "--no-skills",
+                    "--install",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assert_success(result)
+            self.assertTrue((home / ".claude" / "agents" / "ast-ceo.md").is_file())
+            self.assertFalse((root / "unrelated-codex-home").exists())
+
+    def test_failed_connect_rolls_back_installed_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            fake_openclaw = root / "openclaw"
+            fake_openclaw.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "if args == ['--version']:\n"
+                "    print('openclaw-test')\n"
+                "elif args == ['config', 'get', 'agents.list', '--json']:\n"
+                "    print('Config path not found: agents.list', file=sys.stderr)\n"
+                "    raise SystemExit(1)\n"
+                "elif args[:2] == ['config', 'patch'] and '--dry-run' not in args:\n"
+                "    state = pathlib.Path(os.environ['OPENCLAW_STATE_DIR'])\n"
+                "    state.mkdir(parents=True, exist_ok=True)\n"
+                "    (state / 'openclaw.json').write_text(sys.stdin.read(), encoding='utf-8')\n"
+                "elif args == ['config', 'validate', '--json']:\n"
+                "    print('invalid test config', file=sys.stderr)\n"
+                "    raise SystemExit(9)\n",
+                encoding="utf-8",
+            )
+            fake_openclaw.chmod(0o755)
+            environment = os.environ.copy()
+            environment["OPENCLAW_CLI"] = str(fake_openclaw)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "openclaw",
+                    "--no-skills",
+                    "--install",
+                    "--connect",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("invalid test config", result.stderr)
+            self.assertFalse((home / ".openclaw" / "agency-agents" / "agi-super-team" / "ast-ceo" / "AGENTS.md").exists())
+            self.assertFalse((home / ".openclaw" / "agi-super-team" / "connection.json").exists())
+            self.assertFalse((home / ".openclaw" / "openclaw.json").exists())
+
+    def test_later_receipt_failure_rolls_back_all_selected_harnesses(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            unsafe_receipt = home / ".hermes" / "agi-super-team" / "receipt.json"
+            unsafe_receipt.mkdir(parents=True)
+
+            result = self.run_cli(
+                home,
+                project,
+                "--tool",
+                "claude-code",
+                "--tool",
+                "hermes",
+                "--no-skills",
+                "--install",
+                "--connect",
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("unsafe receipt destination", result.stderr)
+            self.assertTrue(unsafe_receipt.is_dir())
+            self.assertFalse((home / ".claude" / "agents" / "ast-ceo.md").exists())
+            self.assertFalse((home / ".claude" / "agi-super-team" / "connection.json").exists())
+            self.assertFalse((home / ".claude" / "agi-super-team" / "receipt.json").exists())
+            self.assertFalse((home / ".hermes" / "skills" / "agi-super-team-agents" / "ast-ceo" / "SKILL.md").exists())
+            self.assertFalse((home / ".hermes" / "agi-super-team" / "connection.json").exists())
+
+    def test_all_connections_are_preflighted_before_codex_plugin_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            project = root / "project"
+            project.mkdir()
+            codex_log = root / "codex.log"
+            fake_codex = root / "codex"
+            fake_codex.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, sys\n"
+                "with open(os.environ['FAKE_CODEX_LOG'], 'a', encoding='utf-8') as f:\n"
+                "    f.write(' '.join(sys.argv[1:]) + '\\n')\n",
+                encoding="utf-8",
+            )
+            fake_codex.chmod(0o755)
+            fake_openclaw = root / "openclaw"
+            fake_openclaw.write_text(
+                "#!/usr/bin/env python3\n"
+                "import sys\n"
+                "print('OpenClaw unavailable', file=sys.stderr)\n"
+                "raise SystemExit(8)\n",
+                encoding="utf-8",
+            )
+            fake_openclaw.chmod(0o755)
+            environment = os.environ.copy()
+            environment["CODEX_CLI"] = str(fake_codex)
+            environment["FAKE_CODEX_LOG"] = str(codex_log)
+            environment["OPENCLAW_CLI"] = str(fake_openclaw)
+
+            result = subprocess.run(
+                [
+                    NODE,
+                    str(CLI),
+                    "--home",
+                    str(home),
+                    "--project-dir",
+                    str(project),
+                    "--tool",
+                    "codex",
+                    "--plugin",
+                    "--tool",
+                    "openclaw",
+                    "--no-skills",
+                    "--install",
+                    "--connect",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("OpenClaw unavailable", result.stderr)
+            self.assertFalse(codex_log.exists(), "Codex plugin commands ran before every connection preflight passed")
+            self.assertFalse(home.exists(), "failed preflight must not create the installation home")
 
 
 if __name__ == "__main__":

--- a/tests/windows_cli_smoke.mjs
+++ b/tests/windows_cli_smoke.mjs
@@ -1,14 +1,14 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cli = resolve(process.argv[2] || join(repositoryRoot, "bin", "agi-super-team.mjs"));
 const sandbox = mkdtempSync(join(tmpdir(), "agi-super-team-windows-smoke-"));
 
-function isolatedEnvironment(home) {
+function isolatedEnvironment(home, extra = {}) {
   const environment = {};
   for (const name of [
     "PATH", "PATHEXT", "SystemRoot", "ComSpec", "WINDIR",
@@ -20,17 +20,17 @@ function isolatedEnvironment(home) {
   environment.USERPROFILE = home;
   environment.CODEX_HOME = join(home, ".codex");
   environment.NO_COLOR = "1";
-  return environment;
+  return {...environment, ...extra};
 }
 
-function invoke(label, args, home) {
+function invoke(label, args, home, extraEnvironment = {}) {
   const sourceModule = extname(cli) === ".mjs";
   const command = sourceModule ? process.execPath : cli;
   const commandArgs = sourceModule ? [cli, ...args] : args;
   const result = spawnSync(command, commandArgs, {
     cwd: sandbox,
     encoding: "utf8",
-    env: isolatedEnvironment(home),
+    env: isolatedEnvironment(home, extraEnvironment),
     maxBuffer: 64 * 1024 * 1024,
     shell: process.platform === "win32" && !sourceModule,
   });
@@ -105,7 +105,7 @@ try {
   const installed = roots("claude-install");
   const installOutput = invoke("claude-code install/connect", [
     "--tool", "claude-code", "--home", installed.home,
-    "--project-dir", installed.project, "--skip-plugin", "--install", "--connect",
+    "--project-dir", installed.project, "--skip-plugin", "--no-skills", "--install", "--connect",
   ], installed.home);
   expectIncludes(installOutput, "Connected: claude-code (filesystem-connected)", "claude-code install/connect");
   expectIncludes(installOutput, "Installed. Restart the selected CLI", "claude-code install/connect");
@@ -127,10 +127,117 @@ try {
 
   const doctorOutput = invoke("claude-code doctor", [
     "--tool", "claude-code", "--home", installed.home,
-    "--project-dir", installed.project, "--skip-plugin", "--doctor",
+    "--project-dir", installed.project, "--skip-plugin", "--no-skills", "--doctor",
   ], installed.home);
-  expectIncludes(doctorOutput, "AGI Super Team doctor: HEALTHY", "claude-code doctor");
+  expectIncludes(doctorOutput, "AGI Super Team doctor: FILES_HEALTHY", "claude-code doctor");
   expectIncludes(doctorOutput, "0 issues", "claude-code doctor");
+
+  invoke("claude-code repeat install/connect", [
+    "--tool", "claude-code", "--home", installed.home,
+    "--project-dir", installed.project, "--skip-plugin", "--no-skills", "--install", "--connect",
+  ], installed.home);
+
+  const fakeBin = join(sandbox, "fake-bin");
+  mkdirSync(fakeBin, {recursive: true});
+  const fakePath = `${fakeBin}${delimiter}${process.env.PATH || ""}`;
+  const codex = roots("codex-plugin");
+  const codexLog = join(sandbox, "fake-codex.log");
+  const fakeCodex = join(fakeBin, process.platform === "win32" ? "codex.cmd" : "codex");
+  if (process.platform === "win32") {
+    writeFileSync(fakeCodex, "@echo off\r\necho %*>>\"%FAKE_CODEX_LOG%\"\r\nexit /b 0\r\n");
+  } else {
+    writeFileSync(fakeCodex, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$FAKE_CODEX_LOG\"\n");
+    chmodSync(fakeCodex, 0o755);
+  }
+  const codexOutput = invoke("codex install with plugin", [
+    "--tool", "codex", "--home", codex.home,
+    "--project-dir", codex.project, "--no-skills", "--plugin", "--install", "--connect",
+  ], codex.home, {
+    PATH: fakePath,
+    FAKE_CODEX_LOG: codexLog,
+  });
+  expectIncludes(codexOutput, "Installed. Restart the selected CLI", "codex install with plugin");
+  expectIncludes(codexOutput, "Connected: codex (filesystem-connected)", "codex install with plugin");
+  const codexCalls = readFileSync(codexLog, "utf8").split(/\r?\n/).filter(Boolean);
+  for (const expected of [
+    "--version",
+    "plugin marketplace add aAAaqwq/AGI-Super-Team --ref v1.4.1",
+    "plugin marketplace upgrade agi-super-team",
+    "plugin add agi-super-team-codex@agi-super-team",
+  ]) {
+    if (!codexCalls.includes(expected)) throw new Error(`fake Codex did not receive ${JSON.stringify(expected)}: ${codexCalls.join(" | ")}`);
+  }
+  expectNonEmptyFile(join(codex.home, ".codex", "agents", "ast-cto.toml"), "Codex Agent");
+  expectNonEmptyFile(join(codex.home, ".codex", "agi-super-team", "connection.json"), "Codex connection");
+  expectNonEmptyFile(join(codex.home, ".codex", "agi-super-team", "receipt.json"), "Codex receipt");
+  const codexDoctor = invoke("codex doctor", [
+    "--tool", "codex", "--home", codex.home,
+    "--project-dir", codex.project, "--no-skills", "--doctor",
+  ], codex.home, {PATH: fakePath, FAKE_CODEX_LOG: codexLog});
+  expectIncludes(codexDoctor, "FILES_HEALTHY", "codex doctor");
+  invoke("codex repeat install/connect", [
+    "--tool", "codex", "--home", codex.home,
+    "--project-dir", codex.project, "--no-skills", "--plugin", "--install", "--connect",
+  ], codex.home, {PATH: fakePath, FAKE_CODEX_LOG: codexLog});
+
+  const fakeOpenClawRunner = join(fakeBin, "fake-openclaw.mjs");
+  writeFileSync(fakeOpenClawRunner, `
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from "node:fs";
+import {dirname, join} from "node:path";
+const args = process.argv.slice(2);
+const config = join(process.env.OPENCLAW_STATE_DIR, "openclaw.json");
+if (args.length === 1 && args[0] === "--version") {
+  console.log("openclaw-smoke");
+} else if (args.join(" ") === "config get agents.list --json") {
+  if (!existsSync(config)) {
+    console.error("Config path not found: agents.list");
+    process.exit(1);
+  }
+  const current = JSON.parse(readFileSync(config, "utf8"));
+  console.log(JSON.stringify(current.agents?.list || []));
+} else if (args[0] === "config" && args[1] === "patch") {
+  const input = readFileSync(0, "utf8");
+  JSON.parse(input);
+  if (!args.includes("--dry-run")) {
+    mkdirSync(dirname(config), {recursive: true});
+    writeFileSync(config, input);
+  }
+  console.log("{}");
+} else if (args.join(" ") === "config validate --json") {
+  JSON.parse(readFileSync(config, "utf8"));
+  console.log("{}");
+} else {
+  console.error("unexpected fake OpenClaw command: " + args.join(" "));
+  process.exit(64);
+}
+`);
+  const fakeOpenClaw = join(fakeBin, process.platform === "win32" ? "openclaw.cmd" : "openclaw");
+  if (process.platform === "win32") {
+    writeFileSync(fakeOpenClaw, `@echo off\r\n"${process.execPath}" "%~dp0fake-openclaw.mjs" %*\r\nexit /b %errorlevel%\r\n`);
+  } else {
+    writeFileSync(fakeOpenClaw, `#!/bin/sh\nexec "${process.execPath}" "${fakeOpenClawRunner}" "$@"\n`);
+    chmodSync(fakeOpenClaw, 0o755);
+  }
+
+  const openclawInstalled = roots("openclaw-install");
+  const openclawEnvironment = {PATH: fakePath};
+  const openclawInstall = invoke("openclaw install/connect", [
+    "--tool", "openclaw", "--home", openclawInstalled.home,
+    "--project-dir", openclawInstalled.project, "--no-skills", "--install", "--connect",
+  ], openclawInstalled.home, openclawEnvironment);
+  expectIncludes(openclawInstall, "Connected: openclaw (connected-structural)", "openclaw install/connect");
+  expectNonEmptyFile(join(openclawInstalled.home, ".openclaw", "agency-agents", "agi-super-team", "ast-ceo", "AGENTS.md"), "OpenClaw CEO Agent");
+  expectNonEmptyFile(join(openclawInstalled.home, ".openclaw", "agi-super-team", "connection.json"), "OpenClaw connection");
+  expectNonEmptyFile(join(openclawInstalled.home, ".openclaw", "agi-super-team", "receipt.json"), "OpenClaw receipt");
+  const openclawDoctor = invoke("openclaw doctor", [
+    "--tool", "openclaw", "--home", openclawInstalled.home,
+    "--project-dir", openclawInstalled.project, "--no-skills", "--doctor",
+  ], openclawInstalled.home, openclawEnvironment);
+  expectIncludes(openclawDoctor, "FILES_HEALTHY", "openclaw doctor");
+  invoke("openclaw repeat install/connect", [
+    "--tool", "openclaw", "--home", openclawInstalled.home,
+    "--project-dir", openclawInstalled.project, "--no-skills", "--install", "--connect",
+  ], openclawInstalled.home, openclawEnvironment);
 
   const openclaw = roots("openclaw-subagents");
   const openclawOutput = invoke("openclaw --all-subagents preview", [
@@ -142,6 +249,25 @@ try {
   expectIncludes(openclawOutput, "Preview only. Add --install to apply.", "openclaw --all-subagents preview");
   if (tree(dirname(openclaw.home)).length !== 0) throw new Error("openclaw preview mutated its isolated roots");
 
+  const hermes = roots("hermes-install");
+  const hermesInstall = invoke("hermes install/connect", [
+    "--tool", "hermes", "--home", hermes.home,
+    "--project-dir", hermes.project, "--no-skills", "--install", "--connect",
+  ], hermes.home);
+  expectIncludes(hermesInstall, "Connected: hermes (filesystem-connected)", "hermes install/connect");
+  expectNonEmptyFile(join(hermes.home, ".hermes", "skills", "agi-super-team-agents", "ast-ceo", "SKILL.md"), "Hermes CEO Agent");
+  expectNonEmptyFile(join(hermes.home, ".hermes", "agi-super-team", "connection.json"), "Hermes connection");
+  expectNonEmptyFile(join(hermes.home, ".hermes", "agi-super-team", "receipt.json"), "Hermes receipt");
+  const hermesDoctor = invoke("hermes doctor", [
+    "--tool", "hermes", "--home", hermes.home,
+    "--project-dir", hermes.project, "--no-skills", "--doctor",
+  ], hermes.home);
+  expectIncludes(hermesDoctor, "FILES_HEALTHY", "hermes doctor");
+  invoke("hermes repeat install/connect", [
+    "--tool", "hermes", "--home", hermes.home,
+    "--project-dir", hermes.project, "--no-skills", "--install", "--connect",
+  ], hermes.home);
+
   const allTools = roots("all-tools");
   const allToolsOutput = invoke("--all-tools preview", [
     "--all-tools", "--home", allTools.home,
@@ -152,7 +278,7 @@ try {
   expectIncludes(allToolsOutput, "Preview only. Add --install to apply.", "--all-tools preview");
   if (tree(dirname(allTools.home)).length !== 0) throw new Error("--all-tools preview mutated its isolated roots");
 
-  console.log(`Windows CLI smoke passed via ${basename(cli)}`);
+  console.log(`Packed CLI smoke passed via ${basename(cli)} on ${process.platform}`);
 } finally {
   rmSync(sandbox, { recursive: true, force: true });
 }

--- a/tests/windows_cli_smoke.mjs
+++ b/tests/windows_cli_smoke.mjs
@@ -1,0 +1,158 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = resolve(process.argv[2] || join(repositoryRoot, "bin", "agi-super-team.mjs"));
+const sandbox = mkdtempSync(join(tmpdir(), "agi-super-team-windows-smoke-"));
+
+function isolatedEnvironment(home) {
+  const environment = {};
+  for (const name of [
+    "PATH", "PATHEXT", "SystemRoot", "ComSpec", "WINDIR",
+    "TEMP", "TMP", "TMPDIR", "LANG", "LC_ALL", "NO_COLOR", "CI",
+  ]) {
+    if (process.env[name] !== undefined) environment[name] = process.env[name];
+  }
+  environment.HOME = home;
+  environment.USERPROFILE = home;
+  environment.CODEX_HOME = join(home, ".codex");
+  environment.NO_COLOR = "1";
+  return environment;
+}
+
+function invoke(label, args, home) {
+  const sourceModule = extname(cli) === ".mjs";
+  const command = sourceModule ? process.execPath : cli;
+  const commandArgs = sourceModule ? [cli, ...args] : args;
+  const result = spawnSync(command, commandArgs, {
+    cwd: sandbox,
+    encoding: "utf8",
+    env: isolatedEnvironment(home),
+    maxBuffer: 64 * 1024 * 1024,
+    shell: process.platform === "win32" && !sourceModule,
+  });
+  if (result.status !== 0) {
+    throw new Error(`${label} failed (${result.status}):\n${result.stdout}\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+function tree(root) {
+  if (!existsSync(root)) return [];
+  const entries = [];
+  function visit(path, relative = "") {
+    for (const item of readdirSync(path, { withFileTypes: true })) {
+      const itemRelative = join(relative, item.name);
+      entries.push(`${item.isDirectory() ? "d" : "f"}:${itemRelative}`);
+      if (item.isDirectory()) visit(join(path, item.name), itemRelative);
+    }
+  }
+  visit(root);
+  return entries.sort();
+}
+
+function expectIncludes(output, expected, label) {
+  if (!output.includes(expected)) {
+    throw new Error(`${label} did not include ${JSON.stringify(expected)}:\n${output.slice(0, 4000)}`);
+  }
+}
+
+function expectNonEmptyFile(path, label) {
+  if (!existsSync(path) || !statSync(path).isFile() || statSync(path).size === 0) {
+    throw new Error(`${label} was not created as a non-empty file: ${path}`);
+  }
+}
+
+function roots(name) {
+  return {
+    home: join(sandbox, name, "home"),
+    project: join(sandbox, name, "project"),
+  };
+}
+
+try {
+  const listHome = join(sandbox, "list-home");
+  const listed = invoke("--list-tools", ["--list-tools"], listHome);
+  expectIncludes(listed, "AGI Super Team CLI targets (18)", "--list-tools");
+  const listedTools = listed.split(/\r?\n/)
+    .map((line) => /^\s{2}(\S+)\s+(?:global|project)\s+/.exec(line)?.[1])
+    .filter(Boolean);
+  if (listedTools.length !== 18 || new Set(listedTools).size !== 18) {
+    throw new Error(`--list-tools returned ${listedTools.length} rows (${new Set(listedTools).size} unique)`);
+  }
+  for (const tool of ["claude-code", "codex", "openclaw", "hermes"]) {
+    if (!listedTools.includes(tool)) throw new Error(`--list-tools omitted ${tool}`);
+  }
+
+  const preview = roots("claude-preview");
+  const previewParent = dirname(preview.home);
+  const beforePreview = tree(previewParent);
+  const previewed = invoke("claude-code preview", [
+    "--tool", "claude-code", "--home", preview.home,
+    "--project-dir", preview.project, "--skip-plugin",
+  ], preview.home);
+  expectIncludes(previewed, "AGI Super Team — PREVIEW", "claude-code preview");
+  expectIncludes(previewed, "Tools: claude-code", "claude-code preview");
+  expectIncludes(previewed, "Preview only. Add --install to apply.", "claude-code preview");
+  const afterPreview = tree(previewParent);
+  if (JSON.stringify(afterPreview) !== JSON.stringify(beforePreview)) {
+    throw new Error(`claude-code preview mutated its isolated roots: ${afterPreview.join(", ")}`);
+  }
+
+  const installed = roots("claude-install");
+  const installOutput = invoke("claude-code install/connect", [
+    "--tool", "claude-code", "--home", installed.home,
+    "--project-dir", installed.project, "--skip-plugin", "--install", "--connect",
+  ], installed.home);
+  expectIncludes(installOutput, "Connected: claude-code (filesystem-connected)", "claude-code install/connect");
+  expectIncludes(installOutput, "Installed. Restart the selected CLI", "claude-code install/connect");
+  const claudeRoot = join(installed.home, ".claude");
+  expectNonEmptyFile(join(claudeRoot, "agents", "ast-ceo.md"), "installed CEO Agent");
+  expectNonEmptyFile(join(claudeRoot, "agi-super-team", "connection.json"), "connection spec");
+  const receiptPath = join(claudeRoot, "agi-super-team", "receipt.json");
+  expectNonEmptyFile(receiptPath, "connection receipt");
+  const receipt = JSON.parse(readFileSync(receiptPath, "utf8"));
+  for (const [field, expected] of Object.entries({
+    harness: "claude-code",
+    status: "filesystem-connected",
+    runtimeEvidence: "pending",
+  })) {
+    if (receipt[field] !== expected) {
+      throw new Error(`connection receipt ${field} was ${JSON.stringify(receipt[field])}, expected ${JSON.stringify(expected)}`);
+    }
+  }
+
+  const doctorOutput = invoke("claude-code doctor", [
+    "--tool", "claude-code", "--home", installed.home,
+    "--project-dir", installed.project, "--skip-plugin", "--doctor",
+  ], installed.home);
+  expectIncludes(doctorOutput, "AGI Super Team doctor: HEALTHY", "claude-code doctor");
+  expectIncludes(doctorOutput, "0 issues", "claude-code doctor");
+
+  const openclaw = roots("openclaw-subagents");
+  const openclawOutput = invoke("openclaw --all-subagents preview", [
+    "--tool", "openclaw", "--home", openclaw.home,
+    "--project-dir", openclaw.project, "--skip-plugin", "--all-subagents",
+  ], openclaw.home);
+  expectIncludes(openclawOutput, "AGI Super Team — PREVIEW", "openclaw --all-subagents preview");
+  expectIncludes(openclawOutput, "Tools: openclaw", "openclaw --all-subagents preview");
+  expectIncludes(openclawOutput, "Preview only. Add --install to apply.", "openclaw --all-subagents preview");
+  if (tree(dirname(openclaw.home)).length !== 0) throw new Error("openclaw preview mutated its isolated roots");
+
+  const allTools = roots("all-tools");
+  const allToolsOutput = invoke("--all-tools preview", [
+    "--all-tools", "--home", allTools.home,
+    "--project-dir", allTools.project, "--skip-plugin",
+  ], allTools.home);
+  expectIncludes(allToolsOutput, "AGI Super Team — PREVIEW", "--all-tools preview");
+  expectIncludes(allToolsOutput, "Tools: claude-code, codex, openclaw, hermes", "--all-tools preview");
+  expectIncludes(allToolsOutput, "Preview only. Add --install to apply.", "--all-tools preview");
+  if (tree(dirname(allTools.home)).length !== 0) throw new Error("--all-tools preview mutated its isolated roots");
+
+  console.log(`Windows CLI smoke passed via ${basename(cli)}`);
+} finally {
+  rmSync(sandbox, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- replace hard-coded forward-slash containment checks with a shared cross-platform path contract
- fix all affected catalog and OpenClaw paths: canonical Agents, manager routing files, vendored subagents, adapter modules, and rendered role files
- reject traversal, sibling-prefix, cross-drive, UNC escape, and source symlinks while preserving canonical package layouts
- add packed npm CLI smoke tests on Windows with both Node 22 and the reported Node 24 runtime
- prepare the patch release as 1.4.1 and update exact-version examples in all three READMEs

## User-visible result

On Windows, catalog-backed commands can proceed instead of failing immediately on agents/ceo:

- --list-tools
- preview
- --install --connect
- --doctor
- OpenClaw --all-subagents
- --all-tools

The Windows job packs this commit, installs the tarball into an isolated npm prefix, and invokes the generated agi-super-team.cmd shim. It does not test against a stale registry package.

## Verification

- npm test: passed (213 repository tests plus installer and generated-contract checks)
- npm run validate:strict: passed (0 errors, 0 warnings)
- npm run test:windows-cli: passed locally
- packed 1.4.1 tarball isolated-install smoke: passed locally through the installed POSIX shim
- focused adapter/path suite: 40/40 passed
- git diff --check: passed
- independent path-security review: no P0/P1 findings

Real Windows .cmd execution is intentionally delegated to the required windows-latest Node 22/24 CI jobs in this PR.

## Security note

The package now performs lexical and physical containment and rejects leaf/ancestor symlinks for protected source paths. A pre-existing local TOCTOU hardening opportunity remains if an attacker already has concurrent write access to the installed package tree; this does not block the Windows compatibility fix and should be addressed separately by validating and consuming the same opened file/Buffer.

## Release boundary

This PR prepares version 1.4.1. It does not publish to npm or merge itself.
