### PR TITLE
fix(pages): use the dedicated star history token

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build current repository statistics
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN || github.token }}
         run: python3 scripts/build_site_data.py
 
       - name: Mark artifact as static

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -53,7 +53,7 @@ Digest-backed first-party work with reviewed authorship.
 |---|---|---|---|---|
 | [`5minbtc`](../skills/5minbtc/) | 💹 Finance, Trading & Markets | Project original · stale review | Unscored | Pending |
 | [`bb-scalper`](../skills/bb-scalper/) | 💹 Finance, Trading & Markets | Project original · stale review | Unscored | Pending |
-| [`binance-square`](../skills/binance-square/) | 💹 Finance, Trading & Markets | Project original · reviewed | Unscored | Pending |
+| [`binance-square`](../skills/binance-square/) | 💹 Finance, Trading & Markets | Project original · stale review | Unscored | Pending |
 | [`content-cover-gen`](../skills/content-cover-gen/) | ✍️ Content, Media & Publishing | Project original · reviewed | Unscored | Pending |
 | [`content-illustration-strategy`](../skills/content-illustration-strategy/) | ✍️ Content, Media & Publishing | Project original · reviewed | Unscored | Pending |
 | [`content-typography`](../skills/content-typography/) | ✍️ Content, Media & Publishing | Project original · reviewed | 80/100 · Selected | Pending |
@@ -731,7 +731,7 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 | [`bankr-signals`](../skills/bankr-signals/) | Transaction-verified trading signals on Base blockchain. Agents publish trades | Unknown · unreviewed | Unscored | Catalog only |
 | [`bb-scalper`](../skills/bb-scalper/) | BB 双向套利策略：加密合约 10x 杠杆布林带均值回归。布林带收窄=横盘→在下轨买、上轨卖；三重过滤器(1h趋势/RSI/BB甜区)确认碗平放，轨对轨止盈(RR… | Project original · stale review | Unscored | Catalog only |
 | [`billing-automation`](../skills/billing-automation/) | Build automated billing systems for recurring payments, invoicing, subscription lifecycle, and dunning management. Use when implementing subscription billing, automating… | Unknown · unreviewed | Unscored | Catalog only |
-| [`binance-square`](../skills/binance-square/) | 币安广场合约投机雷达 v5：以最近24小时专业交易帖为主要证据，回源核验帖子， 联合币安公共合约行情、4周期K线、布林带、ATR、量能和RR，生成可审计的本地影子报告。 触发词：币安广场、扫描币安、binance square、合约机会、交易信号雷达、4小时雷达 | Project original · reviewed | Unscored | Catalog only |
+| [`binance-square`](../skills/binance-square/) | 币安广场合约投机雷达 v5：以最近24小时专业交易帖为主要证据，回源核验帖子， 联合币安公共合约行情、4周期K线、布林带、ATR、量能和RR，生成可审计的本地影子报告。 触发词：币安广场、扫描币安、binance square、合约机会、交易信号雷达、4小时雷达 | Project original · stale review | Unscored | Catalog only |
 | [`binance-trending`](../skills/binance-trending/) | Description needs review; inspect source. | Unknown · unreviewed | Unscored | Catalog only |
 | [`bookkeeping-basics`](../skills/bookkeeping-basics/) | Set up and maintain basic bookkeeping for a solopreneur business. Use when tracking income and expenses, preparing for taxes, managing invoices and receipts, understanding cash… | Unknown · unreviewed | Unscored | Portable optional assignment · structure checked · CFO |
 | [`btc-5min-scalper`](../skills/btc-5min-scalper/) | BTC 5-minute Up/Down paper trading on Polymarket. Scans Binance 1m candles for momentum/mean-reversion/volume signals, makes virtual trades on Polymarket 5-min markets, tracks… | Unknown · unreviewed | Unscored | Catalog only |

--- a/catalog/skill-index.json
+++ b/catalog/skill-index.json
@@ -3990,7 +3990,7 @@
           "spdx": "MIT"
         },
         "origin_kind": "project-original",
-        "review_state": "reviewed"
+        "review_state": "stale"
       },
       "review_signals": [],
       "skill_id": "binance-square",

--- a/scripts/build_site_data.py
+++ b/scripts/build_site_data.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Iterable
 
 
-API_VERSION = "2022-11-28"
+API_VERSION = "2026-03-10"
 DEFAULT_REPOSITORY = "aAAaqwq/AGI-Super-Team"
 USER_AGENT = "agi-super-team-site-data/1.0"
 HISTORY_UNAVAILABLE_STATUS_CODES = frozenset({401, 403, 429})

--- a/tests/test_official_stars_contract.py
+++ b/tests/test_official_stars_contract.py
@@ -42,6 +42,17 @@ class OfficialStarsContractTests(unittest.TestCase):
         self.assertIn("persist-credentials: false", workflow)
         self.assertNotIn("git push origin HEAD:main", workflow)
 
+    def test_pages_workflow_uses_the_dedicated_star_history_token(self) -> None:
+        workflow = (ROOT / ".github/workflows/pages.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "GITHUB_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN || github.token }}",
+            workflow,
+        )
+        self.assertNotIn("GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}", workflow)
+
     def test_pages_workflow_uses_a_site_scoped_quality_gate(self) -> None:
         workflow = (ROOT / ".github/workflows/pages.yml").read_text(
             encoding="utf-8"

--- a/tests/test_site_data.py
+++ b/tests/test_site_data.py
@@ -40,6 +40,21 @@ class RawResponse(FakeResponse):
 
 
 class SiteDataTests(unittest.TestCase):
+    @mock.patch("scripts.build_site_data.urllib.request.urlopen")
+    def test_github_requests_use_the_current_api_contract(
+        self, urlopen: mock.Mock
+    ) -> None:
+        urlopen.return_value = FakeResponse({"ok": True})
+
+        _request_json(
+            "https://api.github.test/repo", None, "application/vnd.github+json"
+        )
+
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            request.get_header("X-github-api-version"), "2026-03-10"
+        )
+
     @mock.patch("scripts.build_site_data.time.sleep", return_value=None)
     @mock.patch("scripts.build_site_data.urllib.request.urlopen")
     def test_github_request_retries_rate_limit_then_fails(


### PR DESCRIPTION
## Root cause

The repository secret was correctly named `STAR_HISTORY_TOKEN`, but the Pages workflow injected `secrets.GITHUB_TOKEN`. The fine-grained token was never used, so the restricted stargazers endpoint always received the default Actions token.

The data builder also sent the retired `2022-11-28` API version instead of the current `2026-03-10` contract.

## Fix

- inject `secrets.STAR_HISTORY_TOKEN`, falling back to `github.token` only when the dedicated secret is absent
- use GitHub REST API version `2026-03-10`
- add regression contracts for both boundaries
- refresh generated Skill catalog artifacts already stale on main

## Verification

- RED reproduced for both token wiring and API version
- `npm run test:site`: 48 passed
- `npm test`: 288 passed, 1 Windows-only skip; installer and generated contracts passed
- `npm run validate:strict`: 0 errors, 0 warnings
- architecture contracts: 100/100
- gitleaks commit-range scan: no leaks