### PR TITLE
feat(skills): add confirmed Atlas Cloud video generation

### DIFF
--- a/catalog/README.md
+++ b/catalog/README.md
@@ -42,7 +42,7 @@ Choose a reviewed origin boundary before browsing by outcome. Provenance and cur
 | [Project original](#project-original-skills) | Digest-backed first-party work with reviewed authorship. | 34 |
 | [Adapted](#adapted-skills) | Modified from a named source with the adaptation recorded. | 0 |
 | [Collected](#collected-skills) | Preserved from a named source with provenance recorded. | 0 |
-| [Unknown origin](#unknown-origin-skills) | Source review is incomplete; inspect before use. | 793 |
+| [Unknown origin](#unknown-origin-skills) | Source review is incomplete; inspect before use. | 795 |
 
 <a id="project-original-skills"></a>
 ### Project original
@@ -105,11 +105,11 @@ No entries currently meet this provenance contract.
 
 Source review is incomplete; inspect before use.
 
-793 entries are awaiting source review. Use the [machine-readable index](./skill-index.json) or browse by outcome below; they are not promoted as curated recommendations.
+795 entries are awaiting source review. Use the [machine-readable index](./skill-index.json) or browse by outcome below; they are not promoted as curated recommendations.
 
 ## 🗂️ Browse by outcome
 
-This revision contains 827 canonical catalog entries. The number is generated here rather than used as a product claim.
+This revision contains 829 canonical catalog entries. The number is generated here rather than used as a product claim.
 
 | Category | Use it for | Entries |
 |---|---|---:|
@@ -120,9 +120,9 @@ This revision contains 827 canonical catalog entries. The number is generated he
 | [🛡️ Security, Privacy & Legal](#security-privacy-legal) | Review security, privacy, compliance, permissions, contracts, and legal risk. | 34 |
 | [🎨 Product, Design & UX](#product-design-ux) | Shape product requirements, interfaces, design systems, and user experience. | 22 |
 | [📈 Marketing, SEO & Growth](#marketing-seo-growth) | Acquire audiences through positioning, campaigns, search, ads, and social growth. | 49 |
-| [✍️ Content, Media & Publishing](#content-media-publishing) | Create, edit, repurpose, and publish writing, images, audio, and video. | 87 |
+| [✍️ Content, Media & Publishing](#content-media-publishing) | Create, edit, repurpose, and publish writing, images, audio, and video. | 88 |
 | [🤝 Sales, CRM & Customer Success](#sales-crm-customer-success) | Find, win, onboard, support, and retain customers with accountable workflows. | 40 |
-| [💹 Finance, Trading & Markets](#finance-trading-markets) | Analyze markets, backtest strategies, track portfolios, and review financial risk. | 69 |
+| [💹 Finance, Trading & Markets](#finance-trading-markets) | Analyze markets, backtest strategies, track portfolios, and review financial risk. | 70 |
 | [🧭 Business Operations & Strategy](#business-operations-strategy) | Plan work, make decisions, manage teams, and improve operating systems. | 74 |
 | [⚙️ Apps & Workflow Automation](#apps-workflow-automation) | Connect everyday apps, browsers, messaging systems, and repeatable workflows. | 89 |
 | [🇨🇳 Chinese Platform Workflows](#chinese-platform-workflows) | Create, analyze, and publish for major Chinese-language platforms and channels. | 40 |
@@ -583,6 +583,7 @@ Create, edit, repurpose, and publish writing, images, audio, and video.
 | [`arch-video-cut`](../skills/arch-video-cut/) | Automatic architecture video editing workflow with self-learning preferences | Unknown · unreviewed | Unscored | Catalog only |
 | [`article-material-collect`](../skills/article-material-collect/) | 上层编排 Skill，通过 **Brave Search 发现 → 智能选择浏览器截图** 完成结构化素材采集。 | Unknown · unreviewed | Unscored | Catalog only |
 | [`article-to-infographic`](../skills/article-to-infographic/) | 长文/测评文章 → 知识视觉笔记套图（3-5张）。自动提炼核心逻辑、规划分镜、生成高阶图像Prompt（4模块结构）。支持手写笔记/思维导图/架构图/对比矩阵四种风格。Use when: 文章转知识笔记、知识笔记图片、思维导图、视觉笔记、长文转图、知识卡片、文章可视化、article to infographic、knowledge… | Unknown · unreviewed | Unscored | Harness-specific assignment · generic installer skips · CCO |
+| [`atlas-video-gen`](../skills/atlas-video-gen/) | Generate one Veo 3.1 Lite video through Atlas Cloud. Use when text-to-video needs an Atlas route, explicit paid-request confirmation, bounded polling, and a local MP4. | Unknown · unreviewed | Unscored | Catalog only |
 | [`cinematic-video-gen`](../skills/cinematic-video-gen/) | AI视频生成质量增强引擎。解决AI视频角色僵硬、表情空白、动作机械的问题。通过高级prompt工程+角色卡+运镜指令+表情库，让AI视频角色活起来。触发词：视频质量、角色僵硬、灵动、表情、动作、cinematic video、视频生成增强、MV视频、角色动画 | Unknown · unreviewed | Unscored | Catalog only |
 | [`code-to-image`](../skills/code-to-image/) | 最强免费生图方案：用前端代码(HTML/CSS/JS/Canvas/SVG)设计画面，通过 Playwright 渲染为任意分辨率高清 PNG。 零API成本、无限分辨率、中文100%准确、代码可复用、Git可追踪。 配合 frontend-design / canvas-design / frontend-design-ultimate 产出 HTML… | Unknown · unreviewed | Unscored | Catalog only |
 | [`content-cover-gen`](../skills/content-cover-gen/) | 内容驱动封面生成:从文章标题/核心观点自动生成视觉隐喻提示词,调用 relay-image-gen 出图。 每张封面3秒内传达文章核心观点,杜绝通用背景。 支持小红书(3:4)、抖音(9:16)、公众号(16:9)、知识星球(1:1)、掘金(16:9)。 触发:'生成封面'、'封面生成'、'cover'、'thumbnail'、'封面图'、'缩略图'。 | Project original · reviewed | Unscored | Harness-specific assignment · generic installer skips · CCO |
@@ -759,6 +760,7 @@ Analyze markets, backtest strategies, track portfolios, and review financial ris
 | [`invoice`](../skills/invoice/) | Manual invoice generation without CRM | Unknown · unreviewed | Unscored | Catalog only |
 | [`invoice-generator-agent`](../skills/invoice-generator-agent/) | Automatic invoice generation with CRM integration | Unknown · unreviewed | Unscored | Catalog only |
 | [`invoice-organizer`](../skills/invoice-organizer/) | Use when "organizing invoices", "sorting receipts", "tax preparation", "expense tracking", or asking about "invoice renaming", "financial documents", "bookkeeping automation" | Unknown · unreviewed | Unscored | Portable optional assignment · structure checked · CFO |
+| [`jiuyangongshe-stock-industry-logic`](../skills/jiuyangongshe-stock-industry-logic/) | 爬取韭研公社个股产业逻辑与异动解析。输入个股名（如白银有色），自动获取该股异动解析、题材标签、相关文章与产业逻辑内容。 | Unknown · unreviewed | Unscored | Catalog only |
 | [`llm-stock-analyzer`](../skills/llm-stock-analyzer/) | stock analysis, 个股分析, A股分析, 港股分析, 美股分析, daily analysis, 决策仪表盘 | Unknown · unreviewed | Unscored | Catalog only |
 | [`market-movers-scanner`](../skills/market-movers-scanner/) | Description needs review; inspect source. | Unknown · unreviewed | Unscored | Catalog only |
 | [`market-price-tracker`](../skills/market-price-tracker/) | Foundation skill providing real-time and historical cryptocurrency price data. This skill is the data layer for the crypto plugin ecosystem - 10+ othe | Unknown · unreviewed | Unscored | Catalog only |

--- a/catalog/skill-index.json
+++ b/catalog/skill-index.json
@@ -51,7 +51,7 @@
       "title": "Marketing, SEO & Growth"
     },
     {
-      "count": 87,
+      "count": 88,
       "description": "Create, edit, repurpose, and publish writing, images, audio, and video.",
       "emoji": "✍️",
       "id": "content-media-publishing",
@@ -65,7 +65,7 @@
       "title": "Sales, CRM & Customer Success"
     },
     {
-      "count": 69,
+      "count": 70,
       "description": "Analyze markets, backtest strategies, track portfolios, and review financial risk.",
       "emoji": "💹",
       "id": "finance-trading-markets",
@@ -100,7 +100,7 @@
       "title": "Specialized Domains & Utilities"
     }
   ],
-  "inventoryCount": 827,
+  "inventoryCount": 829,
   "inventorySemantics": "tracked physical top-level directories with SKILL.md",
   "schemaVersion": 2,
   "skills": [
@@ -2770,6 +2770,45 @@
       "used_by": [
         "COO"
       ]
+    },
+    {
+      "assignments": [],
+      "category_id": "content-media-publishing",
+      "classification": "slug:video;metadata:frontmatter",
+      "classification_details": {
+        "matched_signals": [
+          "video"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
+        "review_state": "unreviewed",
+        "runner_ups": [],
+        "winner": {
+          "category_id": "content-media-publishing",
+          "match_count": 1,
+          "matched_signals": [
+            "video"
+          ],
+          "priority": 100,
+          "tie_detected": false
+        }
+      },
+      "curation": {
+        "runtime_evidence": "pending",
+        "status": "unscored"
+      },
+      "description": "Generate one Veo 3.1 Lite video through Atlas Cloud. Use when text-to-video needs an Atlas route, explicit paid-request confirmation, bounded polling, and a local MP4.",
+      "description_status": "source-text",
+      "path": "skills/atlas-video-gen/SKILL.md",
+      "portability_class": "catalog-only",
+      "provenance": {
+        "origin_kind": "unknown",
+        "review_state": "unreviewed"
+      },
+      "review_signals": [],
+      "skill_id": "atlas-video-gen",
+      "support_level": "catalog",
+      "used_by": []
     },
     {
       "assignments": [],
@@ -16814,6 +16853,45 @@
       "used_by": [
         "COO"
       ]
+    },
+    {
+      "assignments": [],
+      "category_id": "finance-trading-markets",
+      "classification": "slug:stock;metadata:frontmatter",
+      "classification_details": {
+        "matched_signals": [
+          "stock"
+        ],
+        "method": "slug",
+        "resolution_status": "rule-match",
+        "review_state": "unreviewed",
+        "runner_ups": [],
+        "winner": {
+          "category_id": "finance-trading-markets",
+          "match_count": 1,
+          "matched_signals": [
+            "stock"
+          ],
+          "priority": 120,
+          "tie_detected": false
+        }
+      },
+      "curation": {
+        "runtime_evidence": "pending",
+        "status": "unscored"
+      },
+      "description": "爬取韭研公社个股产业逻辑与异动解析。输入个股名（如白银有色），自动获取该股异动解析、题材标签、相关文章与产业逻辑内容。",
+      "description_status": "source-text",
+      "path": "skills/jiuyangongshe-stock-industry-logic/SKILL.md",
+      "portability_class": "catalog-only",
+      "provenance": {
+        "origin_kind": "unknown",
+        "review_state": "unreviewed"
+      },
+      "review_signals": [],
+      "skill_id": "jiuyangongshe-stock-industry-logic",
+      "support_level": "catalog",
+      "used_by": []
     },
     {
       "assignments": [],

--- a/catalog/skill-quality.json
+++ b/catalog/skill-quality.json
@@ -2,12 +2,12 @@
   "schemaVersion": 1,
   "scope": "deterministic-structural-evidence-not-semantic-verification",
   "summary": {
-    "inventoryCount": 827,
+    "inventoryCount": 829,
     "structureInvalid": 175,
-    "disclosureWarnings": 568,
-    "executionReviewRequired": 175,
+    "disclosureWarnings": 569,
+    "executionReviewRequired": 176,
     "issueCounts": {
-      "description-missing-trigger": 263,
+      "description-missing-trigger": 264,
       "description-over-180": 293,
       "invalid-frontmatter-yaml": 35,
       "link-outside-repository": 5,
@@ -15,7 +15,7 @@
       "name-folder-mismatch": 71,
       "over-500-lines": 55,
       "personal-absolute-path": 51,
-      "scripts-without-test-evidence": 174,
+      "scripts-without-test-evidence": 175,
       "unmentioned-assets": 10,
       "unmentioned-references": 55,
       "unmentioned-scripts": 76,
@@ -3023,6 +3023,17 @@
       "issues": [
         "description-missing-trigger",
         "personal-absolute-path"
+      ]
+    },
+    {
+      "skill_id": "jiuyangongshe-stock-industry-logic",
+      "path": "skills/jiuyangongshe-stock-industry-logic/SKILL.md",
+      "structure_status": "pass",
+      "disclosure_status": "warn",
+      "execution_status": "review-required",
+      "issues": [
+        "description-missing-trigger",
+        "scripts-without-test-evidence"
       ]
     },
     {

--- a/config/team-manifest.json
+++ b/config/team-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "inventory": {
     "agentCount": 14,
-    "physicalSkillCount": 827,
+    "physicalSkillCount": 829,
     "skillEntrypoint": "SKILL.md",
     "symlinkPolicy": "forbid"
   },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "skills/architecture-decision-records/",
     "skills/architecture-patterns/",
     "skills/arxiv-automation/",
+    "skills/atlas-video-gen/",
     "skills/asana-automation/",
     "skills/backtest-expert/",
     "skills/backtesting-frameworks/",

--- a/skills/atlas-video-gen/SKILL.md
+++ b/skills/atlas-video-gen/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: atlas-video-gen
+description: Generate one Veo 3.1 Lite video through Atlas Cloud. Use when text-to-video needs an Atlas route, explicit paid-request confirmation, bounded polling, and a local MP4.
+---
+
+# Atlas Cloud Video Generation
+
+Generate one text-to-video clip with Atlas Cloud's `google/veo3.1-lite/text-to-video`
+model. This is an opt-in workflow and does not replace any other video provider.
+
+## Prerequisites
+
+- Python 3.10 or newer; the helper uses only the standard library.
+- An Atlas Cloud API key in `ATLASCLOUD_API_KEY`.
+- Outbound HTTPS access to `api.atlascloud.ai` and the returned output URL.
+
+Set the key in the environment. Never put it in a prompt, command argument,
+source file, or log.
+
+```bash
+export ATLASCLOUD_API_KEY="..."
+```
+
+## Safety Boundary
+
+Running a generation request may incur charges. The helper prints the exact
+request plan and exits without network access unless `--yes` is present.
+
+The generation `POST` is sent exactly once and is never retried. Only prediction
+and output `GET` requests use bounded retries for transient failures. If the
+submission result is unclear, stop and inspect the Atlas Cloud console instead
+of running the command again.
+
+## Usage
+
+Preview the request first:
+
+```bash
+python skills/atlas-video-gen/scripts/generate_video.py \
+  "A slow aerial orbit around a lighthouse at sunrise" \
+  --output lighthouse.mp4
+```
+
+After reviewing the plan, confirm one paid submission:
+
+```bash
+python skills/atlas-video-gen/scripts/generate_video.py \
+  "A slow aerial orbit around a lighthouse at sunrise" \
+  --output lighthouse.mp4 \
+  --duration 4 \
+  --ratio 16:9 \
+  --resolution 720p \
+  --yes
+```
+
+Use `--json` for a machine-readable result. The default timeout is 10 minutes,
+and `--poll-interval` controls prediction polling frequency.
+
+## Supported Inputs
+
+| Option | Values | Default |
+|---|---|---|
+| `--duration` | `4`, `6`, `8` | `8` |
+| `--ratio` | `16:9`, `9:16` | `16:9` |
+| `--resolution` | `720p`, `1080p` | `720p` |
+| `--seed` | integer; `-1` requests a random seed | `-1` |
+
+Atlas Cloud's current schema requires an 8-second duration for `1080p` output.
+The helper validates that rule before submitting.
+
+## Workflow
+
+1. Turn the request into a concise English video prompt with subject motion,
+   camera movement, setting, lighting, and audio cues when relevant.
+2. Preview the helper command without `--yes`.
+3. Obtain explicit human approval for the displayed model and parameters.
+4. Run once with `--yes`.
+5. Wait for terminal prediction status and report the saved MP4 path.
+6. On an ambiguous submission or failure, do not resubmit automatically.
+
+## Limitations
+
+- This helper supports text-to-video only. Use a separate image-to-video skill
+  when a start or end frame is required.
+- Model availability and accepted parameters can change. If Atlas Cloud rejects
+  a previously valid request, check the live model catalog and schema before
+  changing the helper.
+- Generated media remains subject to Atlas Cloud and model content policies.
+
+## Test Evidence
+
+Run the focused standard-library tests with:
+
+```bash
+python -m unittest -v skills/atlas-video-gen/scripts/test_generate_video.py
+```
+
+The tests cover schema-aligned payloads, the single-POST boundary, wrapped and
+flat API responses, preview mode, and the 1080p duration constraint.
+
+## API References
+
+- Model catalog: `https://api.atlascloud.ai/api/v1/models`
+- Submit: `POST https://api.atlascloud.ai/api/v1/model/generateVideo`
+- Poll: `GET https://api.atlascloud.ai/api/v1/model/prediction/{id}`

--- a/skills/atlas-video-gen/scripts/generate_video.py
+++ b/skills/atlas-video-gen/scripts/generate_video.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Generate one Atlas Cloud Veo video with a single, confirmed POST."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+API_BASE = "https://api.atlascloud.ai/api/v1"
+MODEL = "google/veo3.1-lite/text-to-video"
+TERMINAL_SUCCESS = {"completed", "succeeded", "success"}
+TERMINAL_FAILURE = {"failed", "canceled", "cancelled", "timeout"}
+TRANSIENT_HTTP_CODES = {408, 429, 500, 502, 503, 504}
+
+
+class AtlasVideoError(RuntimeError):
+    """Raised when an Atlas Cloud request cannot be completed safely."""
+
+
+def _unwrap(payload: dict[str, Any]) -> dict[str, Any]:
+    data = payload.get("data")
+    return data if isinstance(data, dict) else payload
+
+
+def _request_json(
+    method: str,
+    url: str,
+    api_key: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    attempts: int = 1,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "agi-super-team-atlas-video-gen/1.0",
+        },
+    )
+
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                decoded = response.read().decode("utf-8")
+                result = json.loads(decoded)
+                if not isinstance(result, dict):
+                    raise AtlasVideoError("Atlas Cloud returned a non-object response")
+                return result
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            if exc.code in TRANSIENT_HTTP_CODES and attempt + 1 < attempts:
+                sleep(2**attempt)
+                continue
+            raise AtlasVideoError(
+                f"Atlas Cloud {method} failed with HTTP {exc.code}: {detail}"
+            ) from exc
+        except (urllib.error.URLError, TimeoutError) as exc:
+            if attempt + 1 < attempts:
+                sleep(2**attempt)
+                continue
+            raise AtlasVideoError(f"Atlas Cloud {method} request failed: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise AtlasVideoError("Atlas Cloud returned invalid JSON") from exc
+
+    raise AtlasVideoError(f"Atlas Cloud {method} request exhausted its attempts")
+
+
+def submit_prediction(api_key: str, payload: dict[str, Any]) -> str:
+    # Billable generation submissions are intentionally never retried.
+    response = _request_json(
+        "POST", f"{API_BASE}/model/generateVideo", api_key, payload, attempts=1
+    )
+    data = _unwrap(response)
+    prediction_id = data.get("id") or data.get("request_id") or data.get("prediction_id")
+    if not prediction_id:
+        raise AtlasVideoError(
+            "Atlas Cloud accepted no identifiable prediction; do not resubmit automatically"
+        )
+    return str(prediction_id)
+
+
+def poll_prediction(
+    api_key: str,
+    prediction_id: str,
+    *,
+    poll_interval: float,
+    timeout: float,
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+) -> list[str]:
+    started = clock()
+    url = f"{API_BASE}/model/prediction/{prediction_id}"
+
+    while clock() - started < timeout:
+        response = _request_json("GET", url, api_key, attempts=3, sleep=sleep)
+        data = _unwrap(response)
+        status = str(data.get("status", "")).lower()
+
+        if status in TERMINAL_SUCCESS:
+            outputs = data.get("outputs") or data.get("output") or []
+            if isinstance(outputs, str):
+                outputs = [outputs]
+            urls = [item for item in outputs if isinstance(item, str) and item]
+            if not urls:
+                raise AtlasVideoError("Prediction completed without an output URL")
+            return urls
+        if status in TERMINAL_FAILURE:
+            detail = data.get("error") or data.get("message") or "unknown error"
+            raise AtlasVideoError(f"Prediction {status}: {detail}")
+
+        sleep(poll_interval)
+
+    raise AtlasVideoError(f"Timed out after {timeout:g}s waiting for prediction")
+
+
+def download_video(
+    url: str,
+    output_path: Path,
+    *,
+    attempts: int = 3,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "agi-super-team-atlas-video-gen/1.0"}
+    )
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(request, timeout=300) as response:
+                content = response.read()
+            if not content:
+                raise AtlasVideoError("Downloaded video is empty")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(content)
+            return
+        except urllib.error.HTTPError as exc:
+            if exc.code in TRANSIENT_HTTP_CODES and attempt + 1 < attempts:
+                sleep(2**attempt)
+                continue
+            raise AtlasVideoError(f"Video download failed with HTTP {exc.code}") from exc
+        except (urllib.error.URLError, TimeoutError) as exc:
+            if attempt + 1 < attempts:
+                sleep(2**attempt)
+                continue
+            raise AtlasVideoError(f"Video download failed: {exc}") from exc
+    raise AtlasVideoError("Video download exhausted its attempts")
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    if args.resolution == "1080p" and args.duration != 8:
+        raise AtlasVideoError("1080p output requires --duration 8")
+    return {
+        "model": MODEL,
+        "prompt": args.prompt,
+        "aspect_ratio": args.ratio,
+        "duration": args.duration,
+        "resolution": args.resolution,
+        "seed": args.seed,
+    }
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate one Veo 3.1 Lite video through Atlas Cloud"
+    )
+    parser.add_argument("prompt", help="Text description of the video")
+    parser.add_argument("-o", "--output", required=True, help="Output MP4 path")
+    parser.add_argument("-r", "--ratio", choices=["16:9", "9:16"], default="16:9")
+    parser.add_argument("-d", "--duration", choices=[4, 6, 8], type=int, default=8)
+    parser.add_argument("--resolution", choices=["720p", "1080p"], default="720p")
+    parser.add_argument("--seed", type=int, default=-1)
+    parser.add_argument("--poll-interval", type=float, default=10.0)
+    parser.add_argument("--timeout", type=float, default=600.0)
+    parser.add_argument("--yes", action="store_true", help="Confirm one paid POST")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    try:
+        if args.poll_interval <= 0 or args.timeout <= 0:
+            raise AtlasVideoError("poll interval and timeout must be positive")
+        payload = build_payload(args)
+        plan = {
+            "provider": "atlas-cloud",
+            "endpoint": f"{API_BASE}/model/generateVideo",
+            "payload": payload,
+            "output": str(Path(args.output)),
+            "billable_post_attempts": 1,
+        }
+
+        if not args.yes:
+            print(json.dumps(plan, ensure_ascii=False, indent=2))
+            print("Preview only. Re-run with --yes to send one paid request.", file=sys.stderr)
+            return 2
+
+        api_key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+        if not api_key:
+            raise AtlasVideoError("ATLASCLOUD_API_KEY is required")
+
+        prediction_id = submit_prediction(api_key, payload)
+        output_urls = poll_prediction(
+            api_key,
+            prediction_id,
+            poll_interval=args.poll_interval,
+            timeout=args.timeout,
+        )
+        output_path = Path(args.output).expanduser()
+        download_video(output_urls[0], output_path)
+        result = {
+            "success": True,
+            "prediction_id": prediction_id,
+            "model": MODEL,
+            "output": str(output_path),
+        }
+        if args.json_output:
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+        else:
+            print(output_path)
+        return 0
+    except AtlasVideoError as exc:
+        error = {"success": False, "error": str(exc)}
+        if getattr(args, "json_output", False):
+            print(json.dumps(error, ensure_ascii=False, indent=2))
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/atlas-video-gen/scripts/test_generate_video.py
+++ b/skills/atlas-video-gen/scripts/test_generate_video.py
@@ -1,0 +1,112 @@
+import argparse
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("generate_video.py")
+SPEC = importlib.util.spec_from_file_location("atlas_video_gen", SCRIPT)
+atlas_video_gen = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(atlas_video_gen)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class AtlasVideoGenTests(unittest.TestCase):
+    def test_payload_matches_vetted_veo_lite_schema(self):
+        args = argparse.Namespace(
+            prompt="A lighthouse at sunrise",
+            ratio="16:9",
+            duration=4,
+            resolution="720p",
+            seed=-1,
+        )
+        self.assertEqual(
+            atlas_video_gen.build_payload(args),
+            {
+                "model": "google/veo3.1-lite/text-to-video",
+                "prompt": "A lighthouse at sunrise",
+                "aspect_ratio": "16:9",
+                "duration": 4,
+                "resolution": "720p",
+                "seed": -1,
+            },
+        )
+
+    @mock.patch.object(atlas_video_gen.urllib.request, "urlopen")
+    def test_submission_posts_once_and_accepts_wrapped_response(self, urlopen):
+        urlopen.return_value = FakeResponse(
+            {"code": 200, "data": {"id": "prediction-123", "status": "created"}}
+        )
+
+        prediction_id = atlas_video_gen.submit_prediction(
+            "secret", {"model": atlas_video_gen.MODEL, "prompt": "test"}
+        )
+
+        self.assertEqual(prediction_id, "prediction-123")
+        self.assertEqual(urlopen.call_count, 1)
+        request = urlopen.call_args.args[0]
+        self.assertEqual(request.get_method(), "POST")
+        self.assertNotIn("secret", request.data.decode("utf-8"))
+
+    @mock.patch.object(atlas_video_gen, "_request_json")
+    def test_polling_accepts_flat_completed_response(self, request_json):
+        request_json.side_effect = [
+            {"status": "processing", "outputs": []},
+            {"status": "completed", "outputs": ["https://example.com/video.mp4"]},
+        ]
+        ticks = iter([0.0, 0.0, 1.0])
+
+        outputs = atlas_video_gen.poll_prediction(
+            "secret",
+            "prediction-123",
+            poll_interval=1,
+            timeout=10,
+            sleep=lambda _seconds: None,
+            clock=lambda: next(ticks),
+        )
+
+        self.assertEqual(outputs, ["https://example.com/video.mp4"])
+        self.assertEqual(request_json.call_count, 2)
+        self.assertTrue(all(call.kwargs["attempts"] == 3 for call in request_json.call_args_list))
+
+    def test_preview_does_not_read_credentials_or_use_network(self):
+        with mock.patch.dict(atlas_video_gen.os.environ, {}, clear=True), mock.patch.object(
+            atlas_video_gen, "submit_prediction"
+        ) as submit:
+            exit_code = atlas_video_gen.main(
+                ["A lighthouse at sunrise", "--output", "preview.mp4"]
+            )
+
+        self.assertEqual(exit_code, 2)
+        submit.assert_not_called()
+
+    def test_1080p_requires_eight_seconds(self):
+        args = argparse.Namespace(
+            prompt="test",
+            ratio="16:9",
+            duration=6,
+            resolution="1080p",
+            seed=-1,
+        )
+        with self.assertRaisesRegex(atlas_video_gen.AtlasVideoError, "duration 8"):
+            atlas_video_gen.build_payload(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atlas_video_gen.py
+++ b/tests/test_atlas_video_gen.py
@@ -1,0 +1,14 @@
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_TEST = (
+    Path(__file__).resolve().parents[1]
+    / "skills/atlas-video-gen/scripts/test_generate_video.py"
+)
+SPEC = importlib.util.spec_from_file_location("atlas_video_gen_tests", SCRIPT_TEST)
+atlas_video_gen_tests = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(atlas_video_gen_tests)
+
+AtlasVideoGenTests = atlas_video_gen_tests.AtlasVideoGenTests


### PR DESCRIPTION
## Summary

- add an opt-in `atlas-video-gen` Skill for Atlas Cloud's Veo 3.1 Lite text-to-video route
- require a preview and explicit `--yes` confirmation before the single billable generation POST
- bound prediction/output GET retries, package the executable helper, and add focused tests plus generated catalog updates

## Scope and risk

- Affected paths: `skills/atlas-video-gen/`, its repository test loader, package inventory, manifest count, and generated catalog files
- User-visible behavior before/after: Atlas Cloud was not available as a self-contained video Skill; users can now preview and explicitly submit one text-to-video job without changing existing provider defaults
- Security, privacy, financial, publishing, or destructive-operation risks: the API key is environment-only; preview mode performs no network access; `--yes` is required for the one potentially billable POST; generation POSTs are never retried
- Rollback or removal plan: remove `skills/atlas-video-gen/` and its test loader, remove the package entry, restore the manifest count, then rebuild the generated catalogs

## Evidence

- [x] `npm test`
- [x] `npm run validate:strict`
- [x] Examples were run in an isolated environment where safe
- [x] Skipped checks and reasons are listed below

Commands and results:

- `python -m unittest -v tests.test_atlas_video_gen`: 5 passed
- `python -m unittest -v skills/atlas-video-gen/scripts/test_generate_video.py`: 5 passed
- `npm test`: 293 repository tests passed, 1 conditionally skipped; installer and generated-artifact checks passed
- `npm run validate:strict`: 0 errors, 0 warnings
- `npm run check:architecture`: 100/100 classification contracts
- `npm pack --dry-run --json`: includes the Skill entrypoint, implementation, and focused test
- one live 4-second 720p generation smoke completed and downloaded a non-empty ISO MP4; the billable POST was sent once

Limitations: `ffprobe` was unavailable in the local environment, so the smoke artifact was verified by file type and non-empty size rather than a codec-level probe. The generated quality check also reports existing baseline observations for the current upstream stock-industry Skill; the new Atlas Skill itself has test evidence and no quality-report entry.

## Provenance

Original. The implementation was written for this change. The Atlas Cloud model catalog and the `google/veo3.1-lite/text-to-video` OpenAPI schema were retrieved on 2026-09-01 to verify the model ID, request fields, enums, and asynchronous response shape.

## Safety and review

- [x] No secrets, private data, session material, or production configuration
- [x] No unsupported catalog, compatibility, performance, profit, security, or production-readiness claims
- [x] External actions require explicit human approval
- [x] Documentation and local links were updated
